### PR TITLE
feat(gateway): alert an organization when a budget is running out

### DIFF
--- a/alembic/versions/e4c9a2f7b1d8_add_alert_rules_and_deliveries.py
+++ b/alembic/versions/e4c9a2f7b1d8_add_alert_rules_and_deliveries.py
@@ -2,29 +2,21 @@
 
 One ``alert_rules`` row is one destination an organization wants its budget
 alerts sent to, plus the thresholds that reach it. The destination is an Apprise
-URL, so Slack, Discord, PagerDuty, mail and a plain webhook are one column
-rather than one column per vendor, and it is stored encrypted because such a URL
-embeds a bot token or basic-auth credentials.
+URL, so Slack, Discord, PagerDuty and a plain webhook are one column rather than
+one per vendor, and it is stored encrypted because such a URL embeds a token.
 
 ``alert_deliveries`` is what makes the feature send each alert once. A crossed
 threshold stays crossed for the rest of the budget period and every refresher in
 ``gateway.main`` runs once per worker, so both a repeat over time and a repeat
 across workers are settled by one unique constraint that a claim inserts against
-before dispatching. ``period_start`` is part of the key, which is what re-arms an
-alert when a budget period rolls without anything having to clear the table.
+before dispatching. ``period_start`` is part of the key, which re-arms an alert
+when a period rolls without anything having to clear the table.
 
-The partial unique index alongside the constraint covers a budget with no period
-at all: PostgreSQL treats two NULL ``period_start`` values as distinct, so the
-constraint alone would let a never-rolling ceiling alert on every tick.
+The partial unique index alongside it covers a budget with no period at all:
+PostgreSQL treats two NULL ``period_start`` values as distinct.
 
-``alert_rules.organization_id`` cascades, matching the other tenant-owned
-configuration tables (``organization_guardrails``, ``workspace_mcp_servers``):
-these rows are configuration, not durable request-plane history.
 ``scoped_budget_id`` is deliberately not a foreign key, matching
 ``scoped_budgets``' own columns, which declare none.
-
-A deployment that creates no alert rules is unaffected: the evaluator returns on
-its first query when the table is empty.
 
 Revision ID: e4c9a2f7b1d8
 Revises: d5b7f9a1c3e6
@@ -45,7 +37,6 @@ _RULES_UNIQUE_NAME = "uq_alert_rules_org_name"
 _RULES_WARN_CHECK = "ck_alert_rules_warn_percent_range"
 _DELIVERIES_UNIQUE_NAME = "uq_alert_deliveries_rule_budget_period_kind"
 _DELIVERIES_NO_PERIOD_INDEX = "uq_alert_deliveries_rule_budget_kind_no_period"
-_DELIVERIES_LOOKUP_INDEX = "ix_alert_deliveries_rule_period"
 
 
 def upgrade() -> None:
@@ -108,15 +99,9 @@ def upgrade() -> None:
         sqlite_where=sa.text("period_start IS NULL"),
         postgresql_where=sa.text("period_start IS NULL"),
     )
-    op.create_index(
-        _DELIVERIES_LOOKUP_INDEX,
-        "alert_deliveries",
-        ["alert_rule_id", "period_start"],
-    )
 
 
 def downgrade() -> None:
-    op.drop_index(_DELIVERIES_LOOKUP_INDEX, table_name="alert_deliveries")
     op.drop_index(_DELIVERIES_NO_PERIOD_INDEX, table_name="alert_deliveries")
     op.drop_index(op.f("ix_alert_deliveries_alert_rule_id"), table_name="alert_deliveries")
     op.drop_table("alert_deliveries")

--- a/alembic/versions/e4c9a2f7b1d8_add_alert_rules_and_deliveries.py
+++ b/alembic/versions/e4c9a2f7b1d8_add_alert_rules_and_deliveries.py
@@ -1,0 +1,124 @@
+"""Add organization-scoped alert rules and the delivery dedupe ledger.
+
+One ``alert_rules`` row is one destination an organization wants its budget
+alerts sent to, plus the thresholds that reach it. The destination is an Apprise
+URL, so Slack, Discord, PagerDuty, mail and a plain webhook are one column
+rather than one column per vendor, and it is stored encrypted because such a URL
+embeds a bot token or basic-auth credentials.
+
+``alert_deliveries`` is what makes the feature send each alert once. A crossed
+threshold stays crossed for the rest of the budget period and every refresher in
+``gateway.main`` runs once per worker, so both a repeat over time and a repeat
+across workers are settled by one unique constraint that a claim inserts against
+before dispatching. ``period_start`` is part of the key, which is what re-arms an
+alert when a budget period rolls without anything having to clear the table.
+
+The partial unique index alongside the constraint covers a budget with no period
+at all: PostgreSQL treats two NULL ``period_start`` values as distinct, so the
+constraint alone would let a never-rolling ceiling alert on every tick.
+
+``alert_rules.organization_id`` cascades, matching the other tenant-owned
+configuration tables (``organization_guardrails``, ``workspace_mcp_servers``):
+these rows are configuration, not durable request-plane history.
+``scoped_budget_id`` is deliberately not a foreign key, matching
+``scoped_budgets``' own columns, which declare none.
+
+A deployment that creates no alert rules is unaffected: the evaluator returns on
+its first query when the table is empty.
+
+Revision ID: e4c9a2f7b1d8
+Revises: d5b7f9a1c3e6
+Create Date: 2026-09-09
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e4c9a2f7b1d8"
+down_revision: str | Sequence[str] | None = "d5b7f9a1c3e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_RULES_UNIQUE_NAME = "uq_alert_rules_org_name"
+_RULES_WARN_CHECK = "ck_alert_rules_warn_percent_range"
+_DELIVERIES_UNIQUE_NAME = "uq_alert_deliveries_rule_budget_period_kind"
+_DELIVERIES_NO_PERIOD_INDEX = "uq_alert_deliveries_rule_budget_kind_no_period"
+_DELIVERIES_LOOKUP_INDEX = "ix_alert_deliveries_rule_period"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "alert_rules",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("encrypted_destination", sa.Text(), nullable=False),
+        sa.Column("redacted_destination", sa.String(), nullable=False),
+        sa.Column("warn_at_percent", sa.Integer(), nullable=True),
+        sa.Column("notify_on_exceeded", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("organization_id", "name", name=_RULES_UNIQUE_NAME),
+        sa.CheckConstraint(
+            "warn_at_percent IS NULL OR (warn_at_percent > 0 AND warn_at_percent < 100)",
+            name=_RULES_WARN_CHECK,
+        ),
+    )
+    op.create_index(
+        op.f("ix_alert_rules_organization_id"),
+        "alert_rules",
+        ["organization_id"],
+    )
+
+    op.create_table(
+        "alert_deliveries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("alert_rule_id", sa.Uuid(), nullable=False),
+        sa.Column("scoped_budget_id", sa.String(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("period_start", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("delivered", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("detail", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["alert_rule_id"], ["alert_rules.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "alert_rule_id",
+            "scoped_budget_id",
+            "period_start",
+            "kind",
+            name=_DELIVERIES_UNIQUE_NAME,
+        ),
+    )
+    op.create_index(
+        op.f("ix_alert_deliveries_alert_rule_id"),
+        "alert_deliveries",
+        ["alert_rule_id"],
+    )
+    op.create_index(
+        _DELIVERIES_NO_PERIOD_INDEX,
+        "alert_deliveries",
+        ["alert_rule_id", "scoped_budget_id", "kind"],
+        unique=True,
+        sqlite_where=sa.text("period_start IS NULL"),
+        postgresql_where=sa.text("period_start IS NULL"),
+    )
+    op.create_index(
+        _DELIVERIES_LOOKUP_INDEX,
+        "alert_deliveries",
+        ["alert_rule_id", "period_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_DELIVERIES_LOOKUP_INDEX, table_name="alert_deliveries")
+    op.drop_index(_DELIVERIES_NO_PERIOD_INDEX, table_name="alert_deliveries")
+    op.drop_index(op.f("ix_alert_deliveries_alert_rule_id"), table_name="alert_deliveries")
+    op.drop_table("alert_deliveries")
+    op.drop_index(op.f("ix_alert_rules_organization_id"), table_name="alert_rules")
+    op.drop_table("alert_rules")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,13 +267,14 @@ govern how the deployment acts on them:
 - `alert_evaluation_interval_sec` (default `60`): how often the organization's
   budget ceilings are checked against their alert rules' thresholds. `0`
   disables alert evaluation entirely, leaving configured rules in place and
-  sending nothing. Standalone mode only.
-- `alert_allow_private_hosts` (default `false`): an SSRF gate. A
-  webhook-shaped destination (the `json`, `jsons`, `xml`, `xmls`, `form` and
-  `forms` Apprise schemas) is refused when it resolves to a private, loopback or
+  sending nothing. Not used in hybrid mode, which holds no local ceilings.
+- `alert_allow_private_hosts` (default `false`): an SSRF gate. An alert
+  destination whose URL names a host (`json`, `mailto`, `gotify`, `ntfy`,
+  `matrix`, `rocket` and the rest of that group; see the dashboard guide for the
+  full list) is refused when that host resolves to a private, loopback or
   reserved address. Enable it to alert an internal chat server or webhook
-  receiver on the deployment's own network. Vendor schemas such as `slack://`
-  post to their own endpoints and are unaffected either way. Like the other
+  receiver on the deployment's own network. Schemas such as `slack://` post to
+  endpoints compiled into Apprise and have no address to check. Like the other
   outbound network gates, this is a startup setting rather than a dashboard
   toggle.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,25 @@ and guardrail configuration. Common startup settings are:
 See [Built-in tools](tools.md), [MCP](mcp.md), and
 [Guardrails](guardrails.md) for behavior and security boundaries.
 
+## Budget alert variables
+
+Alert destinations themselves are configured per organization in the dashboard,
+not here (see [Budget alerts](dashboard.md#budget-alerts)). Two startup settings
+govern how the deployment acts on them:
+
+- `alert_evaluation_interval_sec` (default `60`): how often the organization's
+  budget ceilings are checked against their alert rules' thresholds. `0`
+  disables alert evaluation entirely, leaving configured rules in place and
+  sending nothing. Standalone mode only.
+- `alert_allow_private_hosts` (default `false`): an SSRF gate. A
+  webhook-shaped destination (the `json`, `jsons`, `xml`, `xmls`, `form` and
+  `forms` Apprise schemas) is refused when it resolves to a private, loopback or
+  reserved address. Enable it to alert an internal chat server or webhook
+  receiver on the deployment's own network. Vendor schemas such as `slack://`
+  post to their own endpoints and are unaffected either way. Like the other
+  outbound network gates, this is a startup setting rather than a dashboard
+  toggle.
+
 ## Documentation links
 
 By default the dashboard's Documentation link opens the bundled guide at

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -126,7 +126,7 @@ A destination is an [Apprise](https://github.com/caronc/apprise) URL, which is
 what makes Slack, Discord, PagerDuty, Telegram, email and a plain webhook one
 field rather than one integration each:
 
-```
+```text
 slack://token/channel
 discord://webhook_id/webhook_token
 pagerduty://integration_key@api_key
@@ -156,10 +156,11 @@ Three things are worth knowing before relying on it:
   by default; `0` turns alerting off deployment-wide while leaving the rules in
   place). An alert therefore arrives within about a minute of a crossing rather
   than instantly.
-- A webhook-shaped destination (the `json`, `xml` and `form` schemas) is
-  refused if it resolves to a private, loopback or reserved address. Set
-  `alert_allow_private_hosts` to alert an internal receiver on the deployment's
-  own network. Vendor schemas post to their own endpoints and are unaffected.
+- A webhook-shaped destination (`json`, `jsons`, `xml`, `xmls`, `form` or
+  `forms`) is refused if it resolves to a private, loopback or reserved
+  address. Set `alert_allow_private_hosts` to alert an internal receiver on the
+  deployment's own network. Vendor schemas post to their own endpoints and are
+  unaffected.
 
 Budgets with no owning organization are the deployment's own and are not covered
 by these rules.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -81,6 +81,7 @@ The organization view contains tenant-wide administration:
 - Workspaces and organization members
 - Email domains, for joining colleagues automatically
 - Spend and budgets
+- Budget alerts, for being told when a ceiling is running out
 - Organization pricing
 - Organization settings and, in hosted mode, provider keys
 
@@ -113,6 +114,55 @@ source and does not consume a budget.
 
 Use Prometheus at `/metrics` for process-level monitoring when
 `enable_metrics` is enabled.
+
+### Budget alerts
+
+Budget alerts push a message out when one of the organization's budget ceilings
+is running out, so nobody has to be watching a page. Budget alerts on the
+organization rail holds the destinations; each one covers every ceiling the
+organization owns.
+
+A destination is an [Apprise](https://github.com/caronc/apprise) URL, which is
+what makes Slack, Discord, PagerDuty, Telegram, email and a plain webhook one
+field rather than one integration each:
+
+```
+slack://token/channel
+discord://webhook_id/webhook_token
+pagerduty://integration_key@api_key
+mailto://alerts@example.com
+json://hooks.example.com/incoming
+```
+
+Each rule sends at two points, either of which can be turned off: a warning at
+a percentage of the limit (80 by default), and a message when a ceiling reaches
+its limit and starts refusing requests. The warning is the useful one; by the
+time requests are being refused, the overspend has already happened. A rule
+sends each of those once per budget period, so a ceiling that stays over its
+threshold does not repeat, and a period reset re-arms it.
+
+A ceiling is measured on whichever of its limits is closest to being reached,
+counting reservations as well as settled spend, which matches how the gateway
+decides to refuse a request in the first place.
+
+Three things are worth knowing before relying on it:
+
+- The destination is stored encrypted and never shown again, because an Apprise
+  URL carries its credentials. The page displays only the scheme and host. Use
+  **Send test** to prove a destination works while setting it up: a webhook that
+  silently accepts nothing looks exactly like a budget that never crossed a
+  threshold.
+- Ceilings are checked on a timer, `alert_evaluation_interval_sec` (60 seconds
+  by default; `0` turns alerting off deployment-wide while leaving the rules in
+  place). An alert therefore arrives within about a minute of a crossing rather
+  than instantly.
+- A webhook-shaped destination (the `json`, `xml` and `form` schemas) is
+  refused if it resolves to a private, loopback or reserved address. Set
+  `alert_allow_private_hosts` to alert an internal receiver on the deployment's
+  own network. Vendor schemas post to their own endpoints and are unaffected.
+
+Budgets with no owning organization are the deployment's own and are not covered
+by these rules.
 
 ## Organization
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -123,16 +123,32 @@ organization rail holds the destinations; each one covers every ceiling the
 organization owns.
 
 A destination is an [Apprise](https://github.com/caronc/apprise) URL, which is
-what makes Slack, Discord, PagerDuty, Telegram, email and a plain webhook one
-field rather than one integration each:
+what makes Slack, Discord, PagerDuty, email and a plain webhook one field rather
+than one integration each:
 
 ```text
 slack://token/channel
 discord://webhook_id/webhook_token
 pagerduty://integration_key@api_key
-mailto://alerts@example.com
+mailto://user:password@smtp.example.com
 json://hooks.example.com/incoming
 ```
+
+Otari accepts these schemas:
+
+| Group | Schemas |
+| --- | --- |
+| Webhooks and self-hosted services | `json`, `jsons`, `xml`, `xmls`, `form`, `forms`, `mailto`, `mailtos`, `gotify`, `gotifys`, `ntfy`, `matrix`, `matrixs`, `mmost`, `mmosts`, `rocket`, `rockets`, `ncloud`, `nclouds`, `apprise`, `apprises` |
+| Hosted services | `slack`, `discord`, `msteams`, `pagerduty`, `opsgenie`, `pover`, `pbul`, `tgram`, `twilio`, `sns`, `ses`, `signal` |
+
+Anything else is refused. Apprise supports many more, but the two groups differ
+in whether the URL names a host Otari will dial, and that decides whether the
+SSRF check below applies, so a schema has to be classified before it can be
+accepted. Ask for one and it is a one-line addition.
+
+`mailto://` carries its own SMTP credentials and does not use the deployment's
+configured mail settings, which is a separate thing entirely. If you already
+have mail set up, a webhook or a chat destination is usually less to maintain.
 
 Each rule sends at two points, either of which can be turned off: a warning at
 a percentage of the limit (80 by default), and a message when a ceiling reaches
@@ -156,11 +172,11 @@ Three things are worth knowing before relying on it:
   by default; `0` turns alerting off deployment-wide while leaving the rules in
   place). An alert therefore arrives within about a minute of a crossing rather
   than instantly.
-- A webhook-shaped destination (`json`, `jsons`, `xml`, `xmls`, `form` or
-  `forms`) is refused if it resolves to a private, loopback or reserved
-  address. Set `alert_allow_private_hosts` to alert an internal receiver on the
-  deployment's own network. Vendor schemas post to their own endpoints and are
-  unaffected.
+- A destination in the first group above names a host, and is refused if that
+  host resolves to a private, loopback or reserved address. Set
+  `alert_allow_private_hosts` to alert an internal receiver on the deployment's
+  own network. The second group posts to endpoints compiled into Apprise, so
+  there is no address to check and the setting does not apply.
 
 Budgets with no owning organization are the deployment's own and are not covered
 by these rules.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1086,7 +1086,7 @@
         },
         "properties": {
           "destination": {
-            "description": "Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Encrypted at rest and never returned",
+            "description": "Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Only the schemas Otari has classified are accepted, because whether the URL names a host decides whether the SSRF check applies; a rejection lists them. Encrypted at rest and never returned",
             "maxLength": 4096,
             "minLength": 1,
             "title": "Destination",

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1076,6 +1076,217 @@
         "title": "AgentTelemetryUsage",
         "type": "object"
       },
+      "AlertRuleCreate": {
+        "description": "Request body for a new alert rule.\n\n``destination`` is an Apprise URL. It is validated for parseability at this\nboundary rather than at send time, so an operator learns their URL is\nunusable while the form is still open instead of discovering it from an\nalert that never arrived.",
+        "example": {
+          "destination": "slack://xoxb-token/C0123456789",
+          "name": "Platform team Slack",
+          "notify_on_exceeded": true,
+          "warn_at_percent": 80
+        },
+        "properties": {
+          "destination": {
+            "description": "Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Encrypted at rest and never returned",
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Destination",
+            "type": "string"
+          },
+          "enabled": {
+            "default": true,
+            "description": "False stops this rule sending without discarding it",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "How this rule is identified in the dashboard and in the alert body, unique per organization",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "notify_on_exceeded": {
+            "default": true,
+            "description": "Send an alert when a ceiling reaches a limit and starts refusing requests",
+            "title": "Notify On Exceeded",
+            "type": "boolean"
+          },
+          "warn_at_percent": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 100.0,
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 80,
+            "description": "Send a warning once a ceiling reaches this percent of any of its limits. Null sends no warning, leaving only the exceeded alert",
+            "title": "Warn At Percent"
+          }
+        },
+        "required": [
+          "name",
+          "destination"
+        ],
+        "title": "AlertRuleCreate",
+        "type": "object"
+      },
+      "AlertRulePublic": {
+        "description": "The API-facing shape. Carries the redacted destination, never the real one.",
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "destination": {
+            "title": "Destination",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "notify_on_exceeded": {
+            "title": "Notify On Exceeded",
+            "type": "boolean"
+          },
+          "organization_id": {
+            "format": "uuid",
+            "title": "Organization Id",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "warn_at_percent": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warn At Percent"
+          }
+        },
+        "required": [
+          "id",
+          "organization_id",
+          "name",
+          "destination",
+          "warn_at_percent",
+          "notify_on_exceeded",
+          "enabled",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AlertRulePublic",
+        "type": "object"
+      },
+      "AlertRuleTestResult": {
+        "description": "The outcome of one on-demand send.\n\n``detail`` carries the dispatcher's reason on failure, which names what went\nwrong without naming the destination, since the caller already knows which\nrule they asked about.",
+        "properties": {
+          "delivered": {
+            "title": "Delivered",
+            "type": "boolean"
+          },
+          "detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          }
+        },
+        "required": [
+          "delivered"
+        ],
+        "title": "AlertRuleTestResult",
+        "type": "object"
+      },
+      "AlertRuleUpdate": {
+        "description": "Partial update. Only the fields the caller sets are applied.\n\n``destination`` has two states rather than three, unlike the credential\nfields on `organization_guardrail_service`: the column is NOT NULL, so there\nis nothing to clear it to. Omit it to keep the stored destination, send a\nvalue to replace it.\n\n``warn_at_percent`` is the opposite: an explicit ``null`` is meaningful\nthere and means \"stop warning, alert only on refusal\", so it is the one\nfield here where null is accepted as a value.",
+        "example": {
+          "enabled": false,
+          "warn_at_percent": 90
+        },
+        "properties": {
+          "destination": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Destination",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "notify_on_exceeded": {
+            "title": "Notify On Exceeded",
+            "type": "boolean"
+          },
+          "warn_at_percent": {
+            "anyOf": [
+              {
+                "exclusiveMaximum": 100.0,
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Warn At Percent"
+          }
+        },
+        "title": "AlertRuleUpdate",
+        "type": "object"
+      },
+      "AlertRulesPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AlertRulePublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "AlertRulesPublic",
+        "type": "object"
+      },
       "AliasRequest": {
         "description": "Request to create or update an alias.",
         "properties": {
@@ -18472,6 +18683,287 @@
         "summary": "Update Active Organization",
         "tags": [
           "organizations"
+        ]
+      }
+    },
+    "/v1/organizations/me/alert-rules": {
+      "get": {
+        "description": "List where the caller's organization sends its budget alerts.\n\nOrganization owners and admins only. Each rule's destination is returned\nredacted to its scheme and host: an Apprise URL carries its credentials in\nthe path, so the stored value is never echoed back.",
+        "operationId": "list_alert_rules_v1_organizations_me_alert_rules_get",
+        "parameters": [
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRulesPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Alert Rules",
+        "tags": [
+          "organization-alerts"
+        ]
+      },
+      "post": {
+        "description": "Send this organization's budget alerts somewhere. Organization owners and admins only.\n\n``destination`` is an Apprise URL, so one field covers Slack, Discord,\nPagerDuty, Telegram, mail and a plain JSON webhook. It is validated for\nparseability here, and a webhook-shaped destination is additionally checked\nagainst the same SSRF rules the MCP and web-search write paths apply.\n\n``warn_at_percent`` defaults to 80, which is the useful half of this\nfeature: a refusal is already too late to act on. Set it to null to alert\nonly when a ceiling starts refusing requests.",
+        "operationId": "create_alert_rule_v1_organizations_me_alert_rules_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRulePublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Alert Rule",
+        "tags": [
+          "organization-alerts"
+        ]
+      }
+    },
+    "/v1/organizations/me/alert-rules/{rule_id}": {
+      "delete": {
+        "description": "Discard a rule and its delivery history. Organization owners and admins only.\n\nUse ``enabled: false`` instead to stop the alerts while keeping the\ndestination. Deleting drops the record of what has already been sent, so a\nceiling that is still over its threshold alerts again once a rule is\nrecreated.",
+        "operationId": "delete_alert_rule_v1_organizations_me_alert_rules__rule_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Rule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Alert Rule",
+        "tags": [
+          "organization-alerts"
+        ]
+      },
+      "patch": {
+        "description": "Change a rule's name, destination, thresholds, or enabled flag.\n\nOrganization owners and admins only. Omitted fields are left as they are.\n``warn_at_percent`` is the one field where an explicit null is a value\nrather than an omission: it means stop warning and alert only on refusal.",
+        "operationId": "update_alert_rule_v1_organizations_me_alert_rules__rule_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Rule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlertRuleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRulePublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Alert Rule",
+        "tags": [
+          "organization-alerts"
+        ]
+      }
+    },
+    "/v1/organizations/me/alert-rules/{rule_id}/test": {
+      "post": {
+        "description": "Send a sample alert to this rule's destination now. Organization owners and admins only.\n\nThe counterpart of ``POST /v1/settings/mail/test``: a destination that\nsilently accepts nothing looks exactly like a budget that never crossed a\nthreshold, so proving the path works belongs at setup time rather than\nduring the incident it was meant to warn about.\n\nRecords nothing. A test is not an alert about a ceiling, and claiming a\ndedupe key here would suppress the real alert it is rehearsing for.",
+        "operationId": "test_alert_rule_v1_organizations_me_alert_rules__rule_id__test_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "rule_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Rule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlertRuleTestResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Test Alert Rule",
+        "tags": [
+          "organization-alerts"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2979,6 +2979,178 @@
     {
       "item": [
         {
+          "name": "List Alert Rules",
+          "request": {
+            "description": "List where the caller's organization sends its budget alerts.\n\nOrganization owners and admins only. Each rule's destination is returned\nredacted to its scheme and host: an Apprise URL carries its credentials in\nthe path, so the stored value is never echoed back.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "alert-rules"
+              ],
+              "query": [
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/alert-rules?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Alert Rule",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"destination\": \"slack://xoxb-token/C0123456789\",\n  \"name\": \"Platform team Slack\",\n  \"notify_on_exceeded\": true,\n  \"warn_at_percent\": 80\n}"
+            },
+            "description": "Send this organization's budget alerts somewhere. Organization owners and admins only.\n\n``destination`` is an Apprise URL, so one field covers Slack, Discord,\nPagerDuty, Telegram, mail and a plain JSON webhook. It is validated for\nparseability here, and a webhook-shaped destination is additionally checked\nagainst the same SSRF rules the MCP and web-search write paths apply.\n\n``warn_at_percent`` defaults to 80, which is the useful half of this\nfeature: a refusal is already too late to act on. Set it to null to alert\nonly when a ceiling starts refusing requests.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "alert-rules"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/alert-rules"
+            }
+          }
+        },
+        {
+          "name": "Update Alert Rule",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"enabled\": false,\n  \"warn_at_percent\": 90\n}"
+            },
+            "description": "Change a rule's name, destination, thresholds, or enabled flag.\n\nOrganization owners and admins only. Omitted fields are left as they are.\n``warn_at_percent`` is the one field where an explicit null is a value\nrather than an omission: it means stop warning and alert only on refusal.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "alert-rules",
+                ":rule_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/alert-rules/:rule_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "rule_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Alert Rule",
+          "request": {
+            "description": "Discard a rule and its delivery history. Organization owners and admins only.\n\nUse ``enabled: false`` instead to stop the alerts while keeping the\ndestination. Deleting drops the record of what has already been sent, so a\nceiling that is still over its threshold alerts again once a rule is\nrecreated.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "alert-rules",
+                ":rule_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/alert-rules/:rule_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "rule_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Test Alert Rule",
+          "request": {
+            "description": "Send a sample alert to this rule's destination now. Organization owners and admins only.\n\nThe counterpart of ``POST /v1/settings/mail/test``: a destination that\nsilently accepts nothing looks exactly like a budget that never crossed a\nthreshold, so proving the path works belongs at setup time rather than\nduring the incident it was meant to warn about.\n\nRecords nothing. A test is not an alert about a ceiling, and claiming a\ndedupe key here would suppress the real alert it is rehearsing for.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "alert-rules",
+                ":rule_id",
+                "test"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/alert-rules/:rule_id/test",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "rule_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "organization-alerts"
+    },
+    {
+      "item": [
+        {
           "name": "List Organization Budgets",
           "request": {
             "description": "List the budgets this organization has defined. Owners and admins only.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,17 @@ dependencies = [
     "any-llm-sdk[all]>=1.27.1",
     "alembic>=1.13.0",
     "aiosqlite>=0.19.0",
+    # Notification fan-out for budget alerts (`services/alerts/`). One library
+    # rather than an adapter per destination: an alert rule stores an Apprise
+    # URL, so Slack, Discord, PagerDuty, Telegram, a plain webhook and mail are
+    # all the same column and the same code path. Taken as a core dependency,
+    # not an extra, because an alert rule an operator configured through the
+    # dashboard must not silently deliver nothing on a deployment that resolved
+    # dependencies without it. The 100-plus transports are pure Python; the ones
+    # needing a compiled or protocol-specific package (paho-mqtt, slixmpp, PGPy,
+    # hidapi) live behind Apprise's own "all-plugins" extra, which is
+    # deliberately not taken.
+    "apprise>=1.9.0,<2.0.0",
     # OAuth protocol mechanics for dashboard sign-in: provider endpoints, the
     # code exchange, and the userinfo fetch that normalizes a provider response
     # into an identity profile. The platform moved onto it in otari-ai#1740 and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,15 +16,12 @@ dependencies = [
     "alembic>=1.13.0",
     "aiosqlite>=0.19.0",
     # Notification fan-out for budget alerts (`services/alerts/`). One library
-    # rather than an adapter per destination: an alert rule stores an Apprise
-    # URL, so Slack, Discord, PagerDuty, Telegram, a plain webhook and mail are
-    # all the same column and the same code path. Taken as a core dependency,
-    # not an extra, because an alert rule an operator configured through the
-    # dashboard must not silently deliver nothing on a deployment that resolved
-    # dependencies without it. The 100-plus transports are pure Python; the ones
-    # needing a compiled or protocol-specific package (paho-mqtt, slixmpp, PGPy,
-    # hidapi) live behind Apprise's own "all-plugins" extra, which is
-    # deliberately not taken.
+    # rather than an adapter per destination: a rule stores an Apprise URL, so
+    # Slack, Discord, PagerDuty and a plain webhook are one column and one code
+    # path. A core dependency rather than an extra, because a rule an operator
+    # configured through the dashboard must not silently deliver nothing on a
+    # deployment that resolved dependencies without it. The transports needing a
+    # compiled package sit behind Apprise's "all-plugins" extra, not taken here.
     "apprise>=1.9.0,<2.0.0",
     # OAuth protocol mechanics for dashboard sign-in: provider endpoints, the
     # code exchange, and the userinfo fetch that normalizes a provider response

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -276,6 +276,17 @@ GET /v1/organizations/me/spend-ceilings                     # dashboard-only
 POST /v1/organizations/me/spend-ceilings                    # dashboard-only
 PATCH /v1/organizations/me/spend-ceilings/{ceiling_id}      # dashboard-only
 DELETE /v1/organizations/me/spend-ceilings/{ceiling_id}     # dashboard-only
+# Budget alert rules. Dashboard-only for the reason the organization budget
+# family above is: the organization is resolved from the caller's dashboard
+# session rather than named in the request, so an SDK caller holding a workspace
+# key has no organization for these to act on. The destination is also a stored
+# credential the API never returns, which makes a rule something to configure
+# once in a browser rather than something to drive from code.
+GET /v1/organizations/me/alert-rules                        # dashboard-only
+POST /v1/organizations/me/alert-rules                       # dashboard-only
+PATCH /v1/organizations/me/alert-rules/{rule_id}            # dashboard-only
+DELETE /v1/organizations/me/alert-rules/{rule_id}           # dashboard-only
+POST /v1/organizations/me/alert-rules/{rule_id}/test        # dashboard-only
 GET /v1/organizations/me/guardrails                         # operator surface
 POST /v1/organizations/me/guardrails                        # operator surface
 PATCH /v1/organizations/me/guardrails/{guardrail_id}        # operator surface

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -30,6 +30,7 @@ from gateway.api.routes import (
     models,
     moderations,
     org_provider_keys,
+    organization_alerts,
     organization_budgets,
     organization_guardrails,
     organization_keys,
@@ -177,6 +178,7 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(organization_budgets.ceilings_router)
     app.include_router(organization_pricing.router)
     app.include_router(organization_guardrails.router)
+    app.include_router(organization_alerts.router)
     # The tenant-scoped read over the same rows ``/v1/usage`` serves to an
     # operator. Mounted with the rest of the ``/v1/organizations/me`` surface
     # rather than beside the usage routers, because what it is scoped to is what

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -83,6 +83,18 @@ STANDALONE_SURFACES: tuple[str, ...] = (
     "budgets",
     "keys",
     "models",
+    # The organization's budget alert rules
+    # (``/v1/organizations/me/alert-rules``). Its own surface rather than a
+    # reading of ``budgets``: the two are different pages with different access,
+    # and a deployment that runs the alert evaluator with
+    # ``alert_evaluation_interval_sec`` at zero still serves the router, so the
+    # page is where a tenant sees the rules it has configured either way.
+    #
+    # Inherited by ``HOSTED_SURFACES`` through the splat below, which is
+    # correct: a hosted tenant's ceilings accumulate spend from the usage its
+    # hybrid gateways report, so it has exactly the same reason to be told a cap
+    # is approaching.
+    "organization_alerts",
     "organizations",
     "pricing",
     "providers",

--- a/src/gateway/api/routes/organization_alerts.py
+++ b/src/gateway/api/routes/organization_alerts.py
@@ -1,0 +1,141 @@
+"""The caller's organization's budget alert rules (standalone mode only).
+
+Thin composition over `gateway.services.tenancy.organization_alert_service`:
+resolve the caller's identity, call the service, return its typed result. The
+role gate and the destination checks live there, and the domain errors it raises
+carry their own statuses (see `gateway.services.tenancy.errors`), so nothing
+here catches them.
+
+Scoped to ``/me`` for the reason `routes/organization_guardrails.py` and
+`routes/organization_pricing.py` are: a standalone deployment has exactly one
+organization and the caller's identity already points at it, so a request cannot
+name one.
+
+What these rules are evaluated against is the organization's own budget
+ceilings, on the timer in `gateway.services.alerts.evaluator`. Nothing on this
+router sends an alert except ``POST /{rule_id}/test``, which is explicitly a
+rehearsal.
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import CurrentIdentity, get_db, verify_master_key
+from gateway.api.routes.organizations import Message
+from gateway.services.tenancy.organization_alert_service import (
+    AlertRuleCreate,
+    AlertRulePublic,
+    AlertRulesPublic,
+    AlertRuleTestResult,
+    AlertRuleUpdate,
+    OrganizationAlertService,
+)
+
+# Master key on the router, as every standalone management router declares it.
+# The role gate is a separate question answered in the service: the credential
+# says a request is the operator's, the membership says whether that identity
+# may change where this organization's alerts are sent.
+router = APIRouter(
+    prefix="/v1/organizations/me/alert-rules",
+    tags=["organization-alerts"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+def get_organization_alert_service(db: Annotated[AsyncSession, Depends(get_db)]) -> OrganizationAlertService:
+    """Build the service on the request's session."""
+    return OrganizationAlertService(db)
+
+
+OrganizationAlertServiceDep = Annotated[OrganizationAlertService, Depends(get_organization_alert_service)]
+
+
+@router.get("")
+async def list_alert_rules(
+    service: OrganizationAlertServiceDep,
+    current_identity: CurrentIdentity,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> AlertRulesPublic:
+    """List where the caller's organization sends its budget alerts.
+
+    Organization owners and admins only. Each rule's destination is returned
+    redacted to its scheme and host: an Apprise URL carries its credentials in
+    the path, so the stored value is never echoed back.
+    """
+    return await service.list_rules(user=current_identity, skip=skip, limit=limit)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_alert_rule(
+    service: OrganizationAlertServiceDep,
+    current_identity: CurrentIdentity,
+    body: AlertRuleCreate,
+) -> AlertRulePublic:
+    """Send this organization's budget alerts somewhere. Organization owners and admins only.
+
+    ``destination`` is an Apprise URL, so one field covers Slack, Discord,
+    PagerDuty, Telegram, mail and a plain JSON webhook. It is validated for
+    parseability here, and a webhook-shaped destination is additionally checked
+    against the same SSRF rules the MCP and web-search write paths apply.
+
+    ``warn_at_percent`` defaults to 80, which is the useful half of this
+    feature: a refusal is already too late to act on. Set it to null to alert
+    only when a ceiling starts refusing requests.
+    """
+    return await service.create_rule(user=current_identity, request=body)
+
+
+@router.patch("/{rule_id}")
+async def update_alert_rule(
+    service: OrganizationAlertServiceDep,
+    current_identity: CurrentIdentity,
+    rule_id: uuid.UUID,
+    body: AlertRuleUpdate,
+) -> AlertRulePublic:
+    """Change a rule's name, destination, thresholds, or enabled flag.
+
+    Organization owners and admins only. Omitted fields are left as they are.
+    ``warn_at_percent`` is the one field where an explicit null is a value
+    rather than an omission: it means stop warning and alert only on refusal.
+    """
+    return await service.update_rule(user=current_identity, rule_id=rule_id, request=body)
+
+
+@router.delete("/{rule_id}")
+async def delete_alert_rule(
+    service: OrganizationAlertServiceDep,
+    current_identity: CurrentIdentity,
+    rule_id: uuid.UUID,
+) -> Message:
+    """Discard a rule and its delivery history. Organization owners and admins only.
+
+    Use ``enabled: false`` instead to stop the alerts while keeping the
+    destination. Deleting drops the record of what has already been sent, so a
+    ceiling that is still over its threshold alerts again once a rule is
+    recreated.
+    """
+    await service.delete_rule(user=current_identity, rule_id=rule_id)
+    return Message(message="Alert rule deleted")
+
+
+@router.post("/{rule_id}/test")
+async def test_alert_rule(
+    service: OrganizationAlertServiceDep,
+    current_identity: CurrentIdentity,
+    rule_id: uuid.UUID,
+) -> AlertRuleTestResult:
+    """Send a sample alert to this rule's destination now. Organization owners and admins only.
+
+    The counterpart of ``POST /v1/settings/mail/test``: a destination that
+    silently accepts nothing looks exactly like a budget that never crossed a
+    threshold, so proving the path works belongs at setup time rather than
+    during the incident it was meant to warn about.
+
+    Records nothing. A test is not an alert about a ceiling, and claiming a
+    dedupe key here would suppress the real alert it is rehearsing for.
+    """
+    return await service.test_rule(user=current_identity, rule_id=rule_id)

--- a/src/gateway/api/routes/organization_alerts.py
+++ b/src/gateway/api/routes/organization_alerts.py
@@ -1,4 +1,4 @@
-"""The caller's organization's budget alert rules (standalone mode only).
+"""The caller's organization's budget alert rules.
 
 Thin composition over `gateway.services.tenancy.organization_alert_service`:
 resolve the caller's identity, call the service, return its typed result. The

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -212,10 +212,10 @@ _DELIBERATELY_OMITTED: tuple[str, ...] = (
     # Not shown today, and each could be. Nothing below is a secret or an
     # unrenderable shape; no page has needed it yet.
     "activation_guide",
+    "alert_evaluation_interval_sec",
     "bootstrap",
     "budget_reservation_retention_sec",
     "budget_reservation_sweep_batch",
-    "alert_evaluation_interval_sec",
     "budget_reservation_sweep_interval_sec",
     "budget_reservation_ttl_sec",
     "capture_agent_telemetry",

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -134,6 +134,7 @@ _CONFIG_VIEW: tuple[tuple[str, tuple[str, ...]], ...] = (
             "mcp_allow_loopback",
             "mcp_allow_private_hosts",
             "provider_allow_private_hosts",
+            "alert_allow_private_hosts",
         ),
     ),
     (
@@ -214,6 +215,7 @@ _DELIBERATELY_OMITTED: tuple[str, ...] = (
     "bootstrap",
     "budget_reservation_retention_sec",
     "budget_reservation_sweep_batch",
+    "alert_evaluation_interval_sec",
     "budget_reservation_sweep_interval_sec",
     "budget_reservation_ttl_sec",
     "capture_agent_telemetry",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -111,6 +111,7 @@ ENV_BRIDGED_FIELDS = (
     "mcp_allow_loopback",
     "mcp_allow_private_hosts",
     "provider_allow_private_hosts",
+    "alert_allow_private_hosts",
 )
 
 
@@ -839,6 +840,15 @@ class GatewayConfig(BaseSettings):
             "concurrent request past a cap the in-flight one is already spending against."
         ),
     )
+    alert_evaluation_interval_sec: int = Field(
+        default=60,
+        ge=0,
+        description=(
+            "How often to check the organization budget ceilings against their alert rules' "
+            "thresholds and send what has crossed one. 0 disables alert evaluation entirely, "
+            "leaving configured rules in place and sending nothing. Standalone mode only."
+        ),
+    )
     budget_reservation_sweep_interval_sec: int = Field(
         default=300,
         ge=0,
@@ -1174,6 +1184,16 @@ class GatewayConfig(BaseSettings):
         description=(
             "SSRF gate: allow MCP server URLs that resolve to private/reserved hosts, and accept "
             "hostnames that fail to resolve at validation time. Off by default."
+        ),
+    )
+    alert_allow_private_hosts: bool = Field(
+        default=False,
+        description=(
+            "SSRF gate: allow a webhook-style alert destination (the json/jsons/xml/xmls/form/forms "
+            "Apprise schemas) that resolves to a private/loopback/reserved host. Off by default. "
+            "Enable it to alert an internal chat server or webhook receiver on the deployment's own "
+            "network. Vendor schemas with fixed endpoints (slack, discord, pagerduty and the rest) "
+            "are unaffected either way. Also settable via OTARI_ALERT_ALLOW_PRIVATE_HOSTS."
         ),
     )
     provider_allow_private_hosts: bool = Field(

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -846,7 +846,7 @@ class GatewayConfig(BaseSettings):
         description=(
             "How often to check the organization budget ceilings against their alert rules' "
             "thresholds and send what has crossed one. 0 disables alert evaluation entirely, "
-            "leaving configured rules in place and sending nothing. Standalone mode only."
+            "leaving configured rules in place and sending nothing. Not used in hybrid mode."
         ),
     )
     budget_reservation_sweep_interval_sec: int = Field(
@@ -1189,11 +1189,12 @@ class GatewayConfig(BaseSettings):
     alert_allow_private_hosts: bool = Field(
         default=False,
         description=(
-            "SSRF gate: allow a webhook-style alert destination (the json/jsons/xml/xmls/form/forms "
-            "Apprise schemas) that resolves to a private/loopback/reserved host. Off by default. "
-            "Enable it to alert an internal chat server or webhook receiver on the deployment's own "
-            "network. Vendor schemas with fixed endpoints (slack, discord, pagerduty and the rest) "
-            "are unaffected either way. Also settable via OTARI_ALERT_ALLOW_PRIVATE_HOSTS."
+            "SSRF gate: allow an alert destination whose URL names a host (json, mailto, gotify, "
+            "ntfy, matrix and the rest of that group) that resolves to a private/loopback/reserved "
+            "host. Off by default. Enable it to alert an internal chat server or webhook receiver "
+            "on the deployment's own network. Schemas with endpoints compiled into Apprise (slack, "
+            "discord, pagerduty and the rest) have no address to check and are unaffected. "
+            "Also settable via OTARI_ALERT_ALLOW_PRIVATE_HOSTS."
         ),
     )
     provider_allow_private_hosts: bool = Field(

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -22,6 +22,7 @@ from gateway.inflight import InFlightMiddleware, InFlightRegistry
 from gateway.log_config import logger
 from gateway.rate_limit import RateLimiter
 from gateway.root_page import FAVICON_SVG, ROOT_TUTORIAL_HTML
+from gateway.services.alerts import run_budget_alert_evaluator
 from gateway.services.alias_service import load_aliases_at_startup, reset_alias_cache, run_alias_refresher
 from gateway.services.bootstrap_service import bootstrap_first_api_key
 from gateway.services.budget_reservation_ledger import run_reservation_sweeper
@@ -310,6 +311,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
         discovery_refresher: asyncio.Task[None] | None = None
         catalog_refresher: asyncio.Task[None] | None = None
         reservation_sweeper: asyncio.Task[None] | None = None
+        alert_evaluator: asyncio.Task[None] | None = None
         if config.is_hybrid_mode:
             log_writer = NoopLogWriter()
         else:
@@ -424,6 +426,17 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                     )
                 )
 
+            # Budget alerts are read off the ceilings on a timer rather than
+            # fired from the reserve/settle path, which is deliberately left
+            # untouched: see `services/alerts/__init__.py`. Standalone only, for
+            # the same reason the sweeper above is, and skipped entirely when the
+            # interval is zero, which is the operator's off switch for the
+            # feature as a whole.
+            if config.alert_evaluation_interval_sec > 0:
+                alert_evaluator = asyncio.create_task(
+                    run_budget_alert_evaluator(config.alert_evaluation_interval_sec)
+                )
+
         # Start the writer inside the try so a failure here still runs the cleanup
         # below; the refresher tasks are already created and would otherwise leak.
         log_writer_started = False
@@ -443,6 +456,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 (discovery_refresher, "model discovery"),
                 (catalog_refresher, "models.dev catalog"),
                 (reservation_sweeper, "budget reservation sweep"),
+                (alert_evaluator, "budget alert evaluation"),
             ]
             await _stop_refreshers([(task, name) for task, name in refreshers if task is not None])
             if alias_refresher is not None:

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -428,10 +428,9 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
 
             # Budget alerts are read off the ceilings on a timer rather than
             # fired from the reserve/settle path, which is deliberately left
-            # untouched: see `services/alerts/__init__.py`. Standalone only, for
-            # the same reason the sweeper above is, and skipped entirely when the
-            # interval is zero, which is the operator's off switch for the
-            # feature as a whole.
+            # untouched: see `services/alerts/__init__.py`. Wherever local
+            # ceilings exist, so standalone and hosted but not hybrid, and
+            # skipped when the interval is zero, which is the off switch.
             if config.alert_evaluation_interval_sec > 0:
                 alert_evaluator = asyncio.create_task(
                     run_budget_alert_evaluator(config.alert_evaluation_interval_sec)

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -94,6 +94,18 @@ AUTH_FAILURES = Counter(
     registry=REGISTRY,
 )
 
+# Labeled by outcome as well as kind, because "the alert fired" and "the alert
+# arrived" are the two different things an operator needs to tell apart: a
+# destination that has quietly stopped accepting deliveries looks identical to a
+# budget that never crossed a threshold unless the failures are counted
+# separately.
+ALERT_DELIVERIES = Counter(
+    "gateway_alert_deliveries",
+    "Total number of budget alerts dispatched, by kind and outcome",
+    ["kind", "outcome"],
+    registry=REGISTRY,
+)
+
 LOG_WRITER_QUEUE_DEPTH = Gauge(
     "gateway_usage_log_queue_depth",
     "Number of usage log entries waiting to be written",
@@ -230,6 +242,11 @@ def record_budget_exceeded() -> None:
 def record_auth_failure(reason: str) -> None:
     """Record an authentication failure."""
     AUTH_FAILURES.labels(reason=reason).inc()
+
+
+def record_alert_delivery(*, kind: str, delivered: bool) -> None:
+    """Record one dispatched budget alert and whether it reached its destination."""
+    ALERT_DELIVERIES.labels(kind=kind, outcome="delivered" if delivered else "failed").inc()
 
 
 log_writer_queue_depth = LOG_WRITER_QUEUE_DEPTH

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1910,7 +1910,16 @@ class AlertRule(Base):
     # Percent of the cap at which a warning fires, or NULL for no warning. The
     # useful half of this feature: a refusal is already too late to act on,
     # where 80 percent is a number somebody can still do something about.
-    warn_at_percent: Mapped[int | None] = mapped_column(default=80)
+    #
+    # **No column default, deliberately.** A scalar ``default=80`` here fires
+    # whenever the attribute is None at INSERT, and SQLAlchemy cannot tell an
+    # explicit ``None`` from an omission, so it silently overwrote the one value
+    # a caller most needs to be able to send: ``warn_at_percent: null`` means
+    # "no early warning, alert only on refusal", and it was being stored as 80,
+    # handing an operator the warnings they had just declined. The default
+    # belongs to the request schema (``AlertRuleCreate``), which is the layer
+    # that can distinguish "not sent" from "sent as null".
+    warn_at_percent: Mapped[int | None] = mapped_column(default=None)
     # Whether reaching the cap itself fires. Separable from the warning because
     # a deployment that routes refusals through its own error monitoring wants
     # the warning and not the duplicate.

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1858,6 +1858,148 @@ class WorkspaceWebSearchConfig(Base):
     )
 
 
+class AlertRule(Base):
+    """Where an organization wants to be told about its budgets, and when.
+
+    One row is one destination plus the thresholds that reach it. The
+    destination is an `Apprise <https://github.com/caronc/apprise>`_ URL, which
+    is what keeps this table one column wide instead of one column per vendor:
+    ``slack://``, ``discord://``, ``pagerduty://``, ``mailto://`` and a plain
+    ``json://`` webhook are all the same string, and adding a destination Otari
+    has never heard of needs no migration and no code.
+
+    **Organization-scoped, so a tenant is told about its own budgets.** The
+    ceilings a rule watches are the ``scoped_budgets`` rows whose ``budgets``
+    row carries this ``organization_id``. A budget with a NULL
+    ``organization_id`` is therefore never alerted on, which is not an
+    oversight: ``entities.Budget`` records that NULL means the deployment's own
+    and that the organization-scoped surface never lists, offers or repoints
+    one, so from a tenant's side it does not exist. Deployment-wide rules for
+    those are the operator's plane and are deliberately not in this table yet;
+    ``alert_deliveries`` keys on ``alert_rule_id``, so adding them later needs
+    no change to the dedupe shape.
+
+    The URL is a credential. A ``slack://`` URL embeds a bot token and a
+    ``json://`` one can embed basic-auth, so it is encrypted at rest with
+    ``OTARI_SECRET_KEY`` and never returned over the API, the same convention
+    ``ProviderCredential`` and ``OrganizationGuardrail`` use. The API returns
+    ``redact_url_secrets`` output instead, which keeps the scheme and host a
+    reader needs to recognize the row without echoing the secret in it.
+    """
+
+    __tablename__ = "alert_rules"
+    __table_args__ = (
+        UniqueConstraint("organization_id", "name", name="uq_alert_rules_org_name"),
+        CheckConstraint(
+            "warn_at_percent IS NULL OR (warn_at_percent > 0 AND warn_at_percent < 100)",
+            name="ck_alert_rules_warn_percent_range",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("organization.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(nullable=False)
+    encrypted_destination: Mapped[str] = mapped_column(Text, nullable=False)
+    # Kept in the clear beside the ciphertext so the list endpoint and the
+    # evaluator's log lines can name the destination without holding the secret
+    # key. `redact_url_secrets` output, so it carries scheme and host and no
+    # userinfo, token or query string.
+    redacted_destination: Mapped[str] = mapped_column(nullable=False)
+    # Percent of the cap at which a warning fires, or NULL for no warning. The
+    # useful half of this feature: a refusal is already too late to act on,
+    # where 80 percent is a number somebody can still do something about.
+    warn_at_percent: Mapped[int | None] = mapped_column(default=80)
+    # Whether reaching the cap itself fires. Separable from the warning because
+    # a deployment that routes refusals through its own error monitoring wants
+    # the warning and not the duplicate.
+    notify_on_exceeded: Mapped[bool] = mapped_column(default=True, nullable=False)
+    # The organization's kill switch, matching `OrganizationGuardrail.enabled`:
+    # stop the alerts without losing the destination it took to set up.
+    enabled: Mapped[bool] = mapped_column(default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcDateTime(),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+
+class AlertDelivery(Base):
+    """One alert that has already been sent, so it is not sent again.
+
+    **This table is the load-bearing part of the feature, and the unique
+    constraint is the mechanism.** Two separate duplicate sources collapse into
+    one answer here. A threshold stays crossed for the rest of the budget
+    period, so an evaluator that only compared spend against the cap would
+    re-alert on every tick; and every refresher in ``gateway.main`` runs once
+    per worker, so N workers would each send the same alert at the same time.
+    Both are settled by inserting this row *before* dispatching and treating an
+    ``IntegrityError`` as "somebody already did it": the database is the only
+    thing all the workers agree on. No advisory lock and no leader election,
+    matching ``services/budget_reservation_ledger.py``'s no-row-locks stance.
+
+    ``period_start`` is copied off the ``scoped_budgets`` row rather than
+    referenced, which is what re-arms an alert after a budget resets: a new
+    period is a different key, so the next crossing inserts rather than
+    colliding, and nothing has to go back and clear this table. It also means a
+    row here outlives the period it describes, which is why
+    ``purge_delivered_before`` exists.
+
+    Nullable ``period_start`` is a budget with no period at all (neither
+    ``budget_duration_sec`` nor ``reset_alignment``), whose ceiling never rolls.
+    NULL in a unique constraint does not collide on PostgreSQL, so those rows
+    are deduped by the partial index below instead of by the constraint.
+    """
+
+    __tablename__ = "alert_deliveries"
+    __table_args__ = (
+        UniqueConstraint(
+            "alert_rule_id",
+            "scoped_budget_id",
+            "period_start",
+            "kind",
+            name="uq_alert_deliveries_rule_budget_period_kind",
+        ),
+        # The periodless case the class docstring describes. PostgreSQL treats
+        # two NULL ``period_start`` values as distinct, so the constraint above
+        # would let a never-rolling ceiling alert once per tick forever.
+        Index(
+            "uq_alert_deliveries_rule_budget_kind_no_period",
+            "alert_rule_id",
+            "scoped_budget_id",
+            "kind",
+            unique=True,
+            sqlite_where=text("period_start IS NULL"),
+            postgresql_where=text("period_start IS NULL"),
+        ),
+        # The evaluator asks "which of these ceilings have I already alerted
+        # on", so the lookup is by rule and period, not by id.
+        Index("ix_alert_deliveries_rule_period", "alert_rule_id", "period_start"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    alert_rule_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("alert_rules.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Not a foreign key, matching ``scoped_budgets``' own columns: that table
+    # declares none because the rows its scopes name live in four tables and a
+    # provider instance may be configured in ``config.yml`` with no row at all.
+    # A ceiling that is deleted leaves its delivery rows to ``purge_delivered_before``.
+    scoped_budget_id: Mapped[str] = mapped_column(nullable=False)
+    # ``warning`` or ``exceeded``. A plain string rather than a database enum,
+    # for the reason ``ScopedBudget.scope_type`` is one: a third kind should not
+    # need an enum migration.
+    kind: Mapped[str] = mapped_column(nullable=False)
+    period_start: Mapped[datetime | None] = mapped_column(UtcDateTime(), default=None)
+    # Whether the send itself succeeded. The row is claimed before dispatch, so
+    # a false here is an alert that was suppressed and never arrived, which is
+    # the state an operator debugging a silent destination needs to see.
+    delivered: Mapped[bool] = mapped_column(default=False, nullable=False)
+    detail: Mapped[str | None] = mapped_column(Text, default=None)
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
+
 class OrganizationGuardrail(Base):
     """A guardrail an organization runs over the requests of its workspaces.
 

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1864,27 +1864,22 @@ class AlertRule(Base):
     One row is one destination plus the thresholds that reach it. The
     destination is an `Apprise <https://github.com/caronc/apprise>`_ URL, which
     is what keeps this table one column wide instead of one column per vendor:
-    ``slack://``, ``discord://``, ``pagerduty://``, ``mailto://`` and a plain
-    ``json://`` webhook are all the same string, and adding a destination Otari
-    has never heard of needs no migration and no code.
+    ``slack://``, ``discord://``, ``pagerduty://`` and a plain ``json://``
+    webhook are all the same string.
 
-    **Organization-scoped, so a tenant is told about its own budgets.** The
-    ceilings a rule watches are the ``scoped_budgets`` rows whose ``budgets``
-    row carries this ``organization_id``. A budget with a NULL
-    ``organization_id`` is therefore never alerted on, which is not an
-    oversight: ``entities.Budget`` records that NULL means the deployment's own
-    and that the organization-scoped surface never lists, offers or repoints
-    one, so from a tenant's side it does not exist. Deployment-wide rules for
-    those are the operator's plane and are deliberately not in this table yet;
-    ``alert_deliveries`` keys on ``alert_rule_id``, so adding them later needs
-    no change to the dedupe shape.
+    **Organization-scoped, so a tenant is told about its own budgets.** A rule
+    watches the ``scoped_budgets`` rows whose ``budgets`` row carries this
+    ``organization_id``. A budget with a NULL one is therefore never alerted on,
+    which is not an oversight: ``entities.Budget`` records that NULL means the
+    deployment's own and that the organization-scoped surface never lists,
+    offers or repoints one. Deployment-wide rules are the operator's plane and
+    would need a column here saying what a rule watches.
 
-    The URL is a credential. A ``slack://`` URL embeds a bot token and a
-    ``json://`` one can embed basic-auth, so it is encrypted at rest with
-    ``OTARI_SECRET_KEY`` and never returned over the API, the same convention
-    ``ProviderCredential`` and ``OrganizationGuardrail`` use. The API returns
-    ``redact_url_secrets`` output instead, which keeps the scheme and host a
-    reader needs to recognize the row without echoing the secret in it.
+    The URL is a credential, so it is encrypted at rest with
+    ``OTARI_SECRET_KEY`` and never returned, the same convention
+    ``ProviderCredential`` uses. The API returns ``redact_alert_destination``
+    output instead, which masks path segments as well as userinfo because
+    Apprise puts its tokens in the path.
     """
 
     __tablename__ = "alert_rules"
@@ -1903,13 +1898,10 @@ class AlertRule(Base):
     name: Mapped[str] = mapped_column(nullable=False)
     encrypted_destination: Mapped[str] = mapped_column(Text, nullable=False)
     # Kept in the clear beside the ciphertext so the list endpoint and the
-    # evaluator's log lines can name the destination without holding the secret
-    # key. `redact_url_secrets` output, so it carries scheme and host and no
-    # userinfo, token or query string.
+    # evaluator's log lines can name the destination without the secret key.
     redacted_destination: Mapped[str] = mapped_column(nullable=False)
     # Percent of the cap at which a warning fires, or NULL for no warning. The
-    # useful half of this feature: a refusal is already too late to act on,
-    # where 80 percent is a number somebody can still do something about.
+    # useful half of this feature: a refusal is already too late to act on.
     #
     # **No column default, deliberately.** A scalar ``default=80`` here fires
     # whenever the attribute is None at INSERT, and SQLAlchemy cannot tell an
@@ -1920,12 +1912,11 @@ class AlertRule(Base):
     # belongs to the request schema (``AlertRuleCreate``), which is the layer
     # that can distinguish "not sent" from "sent as null".
     warn_at_percent: Mapped[int | None] = mapped_column(default=None)
-    # Whether reaching the cap itself fires. Separable from the warning because
-    # a deployment that routes refusals through its own error monitoring wants
-    # the warning and not the duplicate.
+    # Whether reaching the cap itself fires. Separable because a deployment that
+    # routes refusals through its own error monitoring wants only the warning.
     notify_on_exceeded: Mapped[bool] = mapped_column(default=True, nullable=False)
-    # The organization's kill switch, matching `OrganizationGuardrail.enabled`:
-    # stop the alerts without losing the destination it took to set up.
+    # Kill switch, matching `OrganizationGuardrail.enabled`: stop the alerts
+    # without losing the destination it took to set up.
     enabled: Mapped[bool] = mapped_column(default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
@@ -1939,27 +1930,23 @@ class AlertDelivery(Base):
     """One alert that has already been sent, so it is not sent again.
 
     **This table is the load-bearing part of the feature, and the unique
-    constraint is the mechanism.** Two separate duplicate sources collapse into
-    one answer here. A threshold stays crossed for the rest of the budget
-    period, so an evaluator that only compared spend against the cap would
-    re-alert on every tick; and every refresher in ``gateway.main`` runs once
-    per worker, so N workers would each send the same alert at the same time.
-    Both are settled by inserting this row *before* dispatching and treating an
-    ``IntegrityError`` as "somebody already did it": the database is the only
-    thing all the workers agree on. No advisory lock and no leader election,
-    matching ``services/budget_reservation_ledger.py``'s no-row-locks stance.
+    constraint is the mechanism.** Two duplicate sources collapse into it. A
+    threshold stays crossed for the rest of the budget period, so comparing
+    spend against the cap alone would re-alert every tick; and every refresher
+    in ``gateway.main`` runs once per worker, so N workers would each send the
+    same alert at once. Both are settled by inserting this row *before*
+    dispatching and treating an ``IntegrityError`` as "somebody already did it".
+    No advisory lock and no leader election, matching
+    ``services/budget_reservation_ledger.py``.
 
     ``period_start`` is copied off the ``scoped_budgets`` row rather than
     referenced, which is what re-arms an alert after a budget resets: a new
-    period is a different key, so the next crossing inserts rather than
-    colliding, and nothing has to go back and clear this table. It also means a
-    row here outlives the period it describes, which is why
-    ``purge_delivered_before`` exists.
+    period is a different key. It also means a row outlives the period it
+    describes, which is why ``purge_delivered_before`` exists.
 
-    Nullable ``period_start`` is a budget with no period at all (neither
-    ``budget_duration_sec`` nor ``reset_alignment``), whose ceiling never rolls.
-    NULL in a unique constraint does not collide on PostgreSQL, so those rows
-    are deduped by the partial index below instead of by the constraint.
+    A NULL ``period_start`` is a budget with no period at all. NULLs do not
+    collide in a unique constraint on PostgreSQL, so those rows are deduped by
+    the partial index below instead.
     """
 
     __tablename__ = "alert_deliveries"
@@ -1983,31 +1970,26 @@ class AlertDelivery(Base):
             sqlite_where=text("period_start IS NULL"),
             postgresql_where=text("period_start IS NULL"),
         ),
-        # The evaluator asks "which of these ceilings have I already alerted
-        # on", so the lookup is by rule and period, not by id.
-        Index("ix_alert_deliveries_rule_period", "alert_rule_id", "period_start"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
     alert_rule_id: Mapped[uuid.UUID] = mapped_column(
         Uuid, ForeignKey("alert_rules.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # Not a foreign key, matching ``scoped_budgets``' own columns: that table
-    # declares none because the rows its scopes name live in four tables and a
-    # provider instance may be configured in ``config.yml`` with no row at all.
-    # A ceiling that is deleted leaves its delivery rows to ``purge_delivered_before``.
+    # Not a foreign key, matching ``scoped_budgets``' own columns, which declare
+    # none. A deleted ceiling leaves its rows to ``purge_delivered_before``.
     scoped_budget_id: Mapped[str] = mapped_column(nullable=False)
     # ``warning`` or ``exceeded``. A plain string rather than a database enum,
     # for the reason ``ScopedBudget.scope_type`` is one: a third kind should not
     # need an enum migration.
     kind: Mapped[str] = mapped_column(nullable=False)
     period_start: Mapped[datetime | None] = mapped_column(UtcDateTime(), default=None)
-    # Whether the send itself succeeded. The row is claimed before dispatch, so
-    # a false here is an alert that was suppressed and never arrived, which is
-    # the state an operator debugging a silent destination needs to see.
+    # The row is claimed before dispatch, so a false here is an alert that was
+    # suppressed and never arrived: what an operator debugging silence needs.
     delivered: Mapped[bool] = mapped_column(default=False, nullable=False)
     detail: Mapped[str | None] = mapped_column(Text, default=None)
     created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
+
 
 class OrganizationGuardrail(Base):
     """A guardrail an organization runs over the requests of its workspaces.

--- a/src/gateway/services/alerts/__init__.py
+++ b/src/gateway/services/alerts/__init__.py
@@ -5,22 +5,20 @@ Three modules, split by what they each know:
 - :mod:`gateway.services.alerts.dispatcher` knows how to deliver a message to an
   Apprise URL, and nothing about budgets.
 - :mod:`gateway.services.alerts.evaluator` knows which ceilings have crossed a
-  threshold, claims the right to alert on each one, and asks the dispatcher to
-  send. It is the periodic worker ``gateway.main`` starts.
+  threshold, claims the right to alert on each, and asks the dispatcher to send.
+  It is the periodic worker ``gateway.main`` starts.
 - ``gateway.services.tenancy.organization_alert_service`` is the CRUD surface a
   tenant configures rules through, and lives with the other tenancy services
   because it shares their role gate and their error family.
 
 **Why a periodic evaluator rather than a hook on the request path.** The
-budget-refusal sites in ``services/budget_service.py`` are inside the
-reserve/settle lifecycle, which ``AGENTS.md`` and the backend standards both
-single out as load-bearing: a reservation that never settles leaks and
-permanently shrinks a user's budget. Alerting from there would add a query and a
-fan-out to the one path in the codebase least able to absorb either, to buy
-latency that a budget warning does not need. Reading the state on a timer costs
-the request path nothing, treats "warning" and "exceeded" as the same
-computation, and additionally catches a ceiling that crossed while the
-destination was misconfigured, which an event hook fires once and loses.
+budget-refusal sites in ``services/budget_service.py`` sit inside the
+reserve/settle lifecycle, which ``AGENTS.md`` singles out as load-bearing.
+Alerting from there would add a query and a fan-out to the path least able to
+absorb either, to buy latency a budget warning does not need. Reading state on a
+timer costs the request path nothing, makes "warning" and "exceeded" the same
+computation, and catches a ceiling that crossed while its destination was
+misconfigured.
 """
 
 from gateway.services.alerts.dispatcher import (

--- a/src/gateway/services/alerts/__init__.py
+++ b/src/gateway/services/alerts/__init__.py
@@ -1,0 +1,46 @@
+"""Outbound alerts: what an organization is told about its budgets, and where.
+
+Three modules, split by what they each know:
+
+- :mod:`gateway.services.alerts.dispatcher` knows how to deliver a message to an
+  Apprise URL, and nothing about budgets.
+- :mod:`gateway.services.alerts.evaluator` knows which ceilings have crossed a
+  threshold, claims the right to alert on each one, and asks the dispatcher to
+  send. It is the periodic worker ``gateway.main`` starts.
+- ``gateway.services.tenancy.organization_alert_service`` is the CRUD surface a
+  tenant configures rules through, and lives with the other tenancy services
+  because it shares their role gate and their error family.
+
+**Why a periodic evaluator rather than a hook on the request path.** The
+budget-refusal sites in ``services/budget_service.py`` are inside the
+reserve/settle lifecycle, which ``AGENTS.md`` and the backend standards both
+single out as load-bearing: a reservation that never settles leaks and
+permanently shrinks a user's budget. Alerting from there would add a query and a
+fan-out to the one path in the codebase least able to absorb either, to buy
+latency that a budget warning does not need. Reading the state on a timer costs
+the request path nothing, treats "warning" and "exceeded" as the same
+computation, and additionally catches a ceiling that crossed while the
+destination was misconfigured, which an event hook fires once and loses.
+"""
+
+from gateway.services.alerts.dispatcher import (
+    AlertDispatchResult,
+    UnsupportedAlertDestinationError,
+    parse_destination,
+    send_alert,
+)
+from gateway.services.alerts.evaluator import (
+    ALERT_EVALUATION_INTERVAL_SECONDS,
+    evaluate_budget_alerts,
+    run_budget_alert_evaluator,
+)
+
+__all__ = [
+    "ALERT_EVALUATION_INTERVAL_SECONDS",
+    "AlertDispatchResult",
+    "UnsupportedAlertDestinationError",
+    "evaluate_budget_alerts",
+    "parse_destination",
+    "run_budget_alert_evaluator",
+    "send_alert",
+]

--- a/src/gateway/services/alerts/dispatcher.py
+++ b/src/gateway/services/alerts/dispatcher.py
@@ -37,10 +37,23 @@ import apprise
 
 from gateway.log_config import logger
 
-# One send's ceiling, covering Apprise's own connect, read and internal retry.
-# A destination that has gone away must not hold an executor thread for the
-# length of a TCP timeout on every tick.
+# How long this coroutine waits for a send before giving up on it.
 SEND_TIMEOUT_SECONDS: Final = 15.0
+
+# The socket bounds that make the number above mean something.
+#
+# ``asyncio.wait_for`` cancels the *await*, not the work: ``async_notify`` runs
+# each plugin's blocking ``requests`` call through ``run_in_executor``, and a
+# thread already inside a socket read cannot be cancelled. So the timeout alone
+# stops this coroutine waiting while leaving the thread occupied, and the thing
+# that actually bounds the thread is the socket timeout the plugin uses.
+#
+# Apprise defaults both to 4 seconds, but they are per-plugin values an operator
+# can raise from the destination URL itself (``?cto=600&rto=600``), which would
+# park a shared executor thread for ten minutes per tick. :func:`_bound_sockets`
+# clamps them instead of trusting the URL.
+SOCKET_CONNECT_TIMEOUT_SECONDS: Final = 5.0
+SOCKET_READ_TIMEOUT_SECONDS: Final = 10.0
 
 # Explicit rather than inherited: see the module docstring. ``secure_logging``
 # is what keeps a bot token out of Apprise's own log records.
@@ -95,6 +108,40 @@ def parse_destination(destination: str) -> str:
     return str(service_name) if service_name else "Unknown"
 
 
+def _bound_sockets(client: apprise.Apprise) -> None:
+    """Clamp every loaded plugin's socket timeouts to this module's ceilings.
+
+    Set on the plugin objects rather than appended to the URL as ``?cto=&rto=``,
+    which is what an Apprise reader would reach for first: a destination can
+    already carry a query string and a fragment (``slack://tok/#channel``), so
+    concatenating parameters onto an operator's URL risks corrupting a
+    destination that worked. The attributes are ``URLBase``'s own and are what
+    ``cto``/``rto`` set anyway.
+
+    Clamped, not overwritten, so an operator who asked for a *shorter* timeout
+    keeps it and only an unreasonably long one is brought down.
+
+    The bound is per socket operation rather than per send: Apprise may retry a
+    plugin, so the guarantee here is that no single operation parks a thread
+    indefinitely, not that a send finishes within
+    :data:`SEND_TIMEOUT_SECONDS`. Closing the remaining gap would mean owning
+    Apprise's retry loop, which is not worth the coupling.
+
+    Defensive about the attributes existing: they come from ``URLBase``, so
+    every built-in plugin has them, but an entry loaded from a custom plugin
+    path need not, and a missing one must not turn one bad rule into a failed
+    pass.
+    """
+    for server in client:
+        for attribute, ceiling in (
+            ("socket_connect_timeout", SOCKET_CONNECT_TIMEOUT_SECONDS),
+            ("socket_read_timeout", SOCKET_READ_TIMEOUT_SECONDS),
+        ):
+            current = getattr(server, attribute, None)
+            if isinstance(current, int | float) and current > ceiling:
+                setattr(server, attribute, ceiling)
+
+
 async def send_alert(destination: str, *, title: str, body: str) -> AlertDispatchResult:
     """Deliver one alert, reporting failure rather than raising it.
 
@@ -110,6 +157,7 @@ async def send_alert(destination: str, *, title: str, body: str) -> AlertDispatc
         client = apprise.Apprise(asset=_ASSET)
         if not client.add(destination):
             return AlertDispatchResult(delivered=False, detail="Apprise rejected the destination URL")
+        _bound_sockets(client)
         sent = await asyncio.wait_for(
             client.async_notify(body=body, title=title),
             timeout=SEND_TIMEOUT_SECONDS,

--- a/src/gateway/services/alerts/dispatcher.py
+++ b/src/gateway/services/alerts/dispatcher.py
@@ -3,30 +3,22 @@
 This module knows nothing about budgets. It takes a destination URL, a title and
 a body, and reports whether the send worked.
 
-**Why Apprise.** An alert destination is the kind of thing every operator wants
-spelled differently: Slack here, PagerDuty there, a plain webhook into somebody
-else's internal tooling. Apprise turns that into one string, so the schema is one
-column, and a destination this codebase has never heard of needs no adapter and
-no migration. That is also why there is no port here, unlike
-``ports/growth_signal_port.py``: a port exists to keep a *vendor* choice out of
-the core, and Apprise is itself the vendor-neutral layer, so wrapping it in one
-would be a seam with a single possible implementation on either side.
+**Why Apprise.** One string covers Slack, PagerDuty, mail and a plain webhook,
+so the schema is one column rather than one per vendor. There is no port over it
+because Apprise is itself the vendor-neutral layer, so a port would be a seam
+with one possible implementation on either side.
 
-**Threads, not the event loop.** ``Apprise.async_notify`` is a real coroutine but
-its plugins are synchronous ``requests`` calls that it offloads with
-``run_in_executor(None, ...)`` (Apprise's ``plugins/base.py``). So a send never
-blocks the loop, but it does occupy a default-executor thread for the length of
-an HTTP round trip. Bounded by :data:`SEND_TIMEOUT_SECONDS` and by the evaluator
-never fanning out more than one send per rule per tick, which is what keeps a
-slow destination from starving the executor the rest of the process shares.
+**Threads, not the event loop.** ``Apprise.async_notify`` is a coroutine but its
+plugins are synchronous ``requests`` calls it offloads with
+``run_in_executor(None, ...)``. A send never blocks the loop; it does hold a
+default-executor thread for an HTTP round trip, which is what
+:data:`SEND_TIMEOUT_SECONDS` and :func:`_bound_sockets` between them bound.
 
-**Logging.** The destination is a credential: a ``slack://`` URL embeds a bot
-token and a ``json://`` one can embed basic-auth. Nothing here passes a URL to
-the gateway logger; callers log the stored redaction instead. Apprise's own
-logger redacts credentials (its ``AppriseAsset.secure_logging`` defaults true and
-its CWE-312 handling routes failures through ``cwe312_url``), and
-:data:`_ASSET` sets that flag explicitly rather than inheriting it, so the
-guarantee survives a change to Apprise's defaults.
+**Logging.** The destination is a credential: ``slack://`` embeds a bot token,
+``json://`` can embed basic-auth. Nothing here passes a URL to the gateway
+logger; callers log the stored redaction. :data:`_ASSET` sets
+``secure_logging`` explicitly so Apprise's own redaction survives a change to
+its defaults.
 """
 
 import asyncio
@@ -40,33 +32,38 @@ from gateway.log_config import logger
 # How long this coroutine waits for a send before giving up on it.
 SEND_TIMEOUT_SECONDS: Final = 15.0
 
-# The socket bounds that make the number above mean something.
-#
-# ``asyncio.wait_for`` cancels the *await*, not the work: ``async_notify`` runs
-# each plugin's blocking ``requests`` call through ``run_in_executor``, and a
-# thread already inside a socket read cannot be cancelled. So the timeout alone
-# stops this coroutine waiting while leaving the thread occupied, and the thing
-# that actually bounds the thread is the socket timeout the plugin uses.
-#
-# Apprise defaults both to 4 seconds, but they are per-plugin values an operator
-# can raise from the destination URL itself (``?cto=600&rto=600``), which would
-# park a shared executor thread for ten minutes per tick. :func:`_bound_sockets`
-# clamps them instead of trusting the URL.
+# ``asyncio.wait_for`` cancels the await, not the work: a thread already inside
+# a socket read cannot be cancelled. Apprise defaults both timeouts to 4s but
+# lets the destination URL raise them (``?cto=600``), which would park a shared
+# executor thread for ten minutes a tick, so :func:`_bound_sockets` clamps them.
 SOCKET_CONNECT_TIMEOUT_SECONDS: Final = 5.0
 SOCKET_READ_TIMEOUT_SECONDS: Final = 10.0
 
-# Explicit rather than inherited: see the module docstring. ``secure_logging``
-# is what keeps a bot token out of Apprise's own log records.
+# ``secure_logging`` keeps a bot token out of Apprise's own log records.
 _ASSET: Final = apprise.AppriseAsset(secure_logging=True)
 
 
 class UnsupportedAlertDestinationError(ValueError):
-    """Apprise cannot parse the destination, or its schema is not built in.
+    """Apprise cannot parse the destination, or Otari does not accept its schema.
 
-    Raised by :func:`parse_destination` at rule-write time, so an operator
-    learns their URL is unusable while they are looking at the form rather than
-    when a budget crosses a threshold three weeks later.
+    Raised at rule-write time, so an operator learns their URL is unusable while
+    the form is open rather than when a budget crosses a threshold weeks later.
     """
+
+
+@dataclass(frozen=True)
+class ParsedDestination:
+    """What a destination URL turned out to be, before any policy is applied.
+
+    ``host`` is the address the plugin will actually connect to, or None when
+    the plugin has none because its endpoint is compiled in. It is the value the
+    SSRF gate checks; deciding *whether* to check it is the caller's job, since
+    the netloc of a vendor schema is a token rather than a host.
+    """
+
+    scheme: str
+    service_name: str
+    host: str | None
 
 
 @dataclass(frozen=True)
@@ -74,24 +71,23 @@ class AlertDispatchResult:
     """Whether one send succeeded, and a short reason when it did not.
 
     ``detail`` is stored on the delivery row and shown to the operator, so it
-    says what happened without naming the destination: the row already carries
-    the redaction, and the reason is the part that is missing.
+    says what happened without naming the destination.
     """
 
     delivered: bool
     detail: str | None = None
 
 
-def parse_destination(destination: str) -> str:
-    """Check a destination is one Apprise can deliver to, and name its schema.
-
-    Returns the plugin's service name, which the create path stores nothing of
-    but the API echoes back so a form can confirm it understood ``slack://`` as
-    Slack.
+def parse_destination(destination: str) -> ParsedDestination:
+    """Check a destination is one Apprise can deliver to, and report what it is.
 
     ``suppress_exceptions`` keeps a malformed URL from surfacing as whatever the
     plugin's constructor happened to raise, so every rejection reaches the caller
     as one domain error.
+
+    ``smtp_host`` before ``host`` because Apprise's mail plugin maps a well-known
+    domain onto its provider's server (``mailto://u:p@gmail.com`` sends to
+    ``smtp.gmail.com``), and the gate has to check the address that is dialed.
     """
     stripped = destination.strip()
     if not stripped:
@@ -104,33 +100,25 @@ def parse_destination(destination: str) -> str:
             "Apprise does not recognize this destination. Expected a URL such as "
             "slack://token/channel, discord://webhook_id/webhook_token, or json://host/path"
         )
+    host = getattr(plugin, "smtp_host", None) or getattr(plugin, "host", None)
     service_name = getattr(plugin, "service_name", None)
-    return str(service_name) if service_name else "Unknown"
-
+    return ParsedDestination(
+        scheme=stripped.split(":", 1)[0].lower(),
+        service_name=str(service_name) if service_name else "Unknown",
+        host=str(host) if host else None,
+    )
 
 def _bound_sockets(client: apprise.Apprise) -> None:
     """Clamp every loaded plugin's socket timeouts to this module's ceilings.
 
-    Set on the plugin objects rather than appended to the URL as ``?cto=&rto=``,
-    which is what an Apprise reader would reach for first: a destination can
-    already carry a query string and a fragment (``slack://tok/#channel``), so
-    concatenating parameters onto an operator's URL risks corrupting a
-    destination that worked. The attributes are ``URLBase``'s own and are what
-    ``cto``/``rto`` set anyway.
+    Set on the plugin objects rather than appended to the URL as ``?cto=&rto=``:
+    a destination can already carry a query string and a fragment
+    (``slack://tok/#channel``), so concatenating onto an operator's URL risks
+    corrupting one that worked. Clamped rather than overwritten, so a shorter
+    timeout survives.
 
-    Clamped, not overwritten, so an operator who asked for a *shorter* timeout
-    keeps it and only an unreasonably long one is brought down.
-
-    The bound is per socket operation rather than per send: Apprise may retry a
-    plugin, so the guarantee here is that no single operation parks a thread
-    indefinitely, not that a send finishes within
-    :data:`SEND_TIMEOUT_SECONDS`. Closing the remaining gap would mean owning
-    Apprise's retry loop, which is not worth the coupling.
-
-    Defensive about the attributes existing: they come from ``URLBase``, so
-    every built-in plugin has them, but an entry loaded from a custom plugin
-    path need not, and a missing one must not turn one bad rule into a failed
-    pass.
+    The bound is per socket operation, not per send, because Apprise may retry a
+    plugin. Closing that gap would mean owning Apprise's retry loop.
     """
     for server in client:
         for attribute, ceiling in (

--- a/src/gateway/services/alerts/dispatcher.py
+++ b/src/gateway/services/alerts/dispatcher.py
@@ -1,0 +1,135 @@
+"""Delivering one alert to one Apprise URL, without ever failing a caller.
+
+This module knows nothing about budgets. It takes a destination URL, a title and
+a body, and reports whether the send worked.
+
+**Why Apprise.** An alert destination is the kind of thing every operator wants
+spelled differently: Slack here, PagerDuty there, a plain webhook into somebody
+else's internal tooling. Apprise turns that into one string, so the schema is one
+column, and a destination this codebase has never heard of needs no adapter and
+no migration. That is also why there is no port here, unlike
+``ports/growth_signal_port.py``: a port exists to keep a *vendor* choice out of
+the core, and Apprise is itself the vendor-neutral layer, so wrapping it in one
+would be a seam with a single possible implementation on either side.
+
+**Threads, not the event loop.** ``Apprise.async_notify`` is a real coroutine but
+its plugins are synchronous ``requests`` calls that it offloads with
+``run_in_executor(None, ...)`` (Apprise's ``plugins/base.py``). So a send never
+blocks the loop, but it does occupy a default-executor thread for the length of
+an HTTP round trip. Bounded by :data:`SEND_TIMEOUT_SECONDS` and by the evaluator
+never fanning out more than one send per rule per tick, which is what keeps a
+slow destination from starving the executor the rest of the process shares.
+
+**Logging.** The destination is a credential: a ``slack://`` URL embeds a bot
+token and a ``json://`` one can embed basic-auth. Nothing here passes a URL to
+the gateway logger; callers log the stored redaction instead. Apprise's own
+logger redacts credentials (its ``AppriseAsset.secure_logging`` defaults true and
+its CWE-312 handling routes failures through ``cwe312_url``), and
+:data:`_ASSET` sets that flag explicitly rather than inheriting it, so the
+guarantee survives a change to Apprise's defaults.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Final
+
+import apprise
+
+from gateway.log_config import logger
+
+# One send's ceiling, covering Apprise's own connect, read and internal retry.
+# A destination that has gone away must not hold an executor thread for the
+# length of a TCP timeout on every tick.
+SEND_TIMEOUT_SECONDS: Final = 15.0
+
+# Explicit rather than inherited: see the module docstring. ``secure_logging``
+# is what keeps a bot token out of Apprise's own log records.
+_ASSET: Final = apprise.AppriseAsset(secure_logging=True)
+
+
+class UnsupportedAlertDestinationError(ValueError):
+    """Apprise cannot parse the destination, or its schema is not built in.
+
+    Raised by :func:`parse_destination` at rule-write time, so an operator
+    learns their URL is unusable while they are looking at the form rather than
+    when a budget crosses a threshold three weeks later.
+    """
+
+
+@dataclass(frozen=True)
+class AlertDispatchResult:
+    """Whether one send succeeded, and a short reason when it did not.
+
+    ``detail`` is stored on the delivery row and shown to the operator, so it
+    says what happened without naming the destination: the row already carries
+    the redaction, and the reason is the part that is missing.
+    """
+
+    delivered: bool
+    detail: str | None = None
+
+
+def parse_destination(destination: str) -> str:
+    """Check a destination is one Apprise can deliver to, and name its schema.
+
+    Returns the plugin's service name, which the create path stores nothing of
+    but the API echoes back so a form can confirm it understood ``slack://`` as
+    Slack.
+
+    ``suppress_exceptions`` keeps a malformed URL from surfacing as whatever the
+    plugin's constructor happened to raise, so every rejection reaches the caller
+    as one domain error.
+    """
+    stripped = destination.strip()
+    if not stripped:
+        raise UnsupportedAlertDestinationError("An alert destination cannot be empty")
+    plugin = apprise.Apprise.instantiate(stripped, asset=_ASSET, suppress_exceptions=True)
+    if plugin is None:
+        # Deliberately not echoing the URL back: an invalid one is still a
+        # string the operator may have pasted a real token into.
+        raise UnsupportedAlertDestinationError(
+            "Apprise does not recognize this destination. Expected a URL such as "
+            "slack://token/channel, discord://webhook_id/webhook_token, or json://host/path"
+        )
+    service_name = getattr(plugin, "service_name", None)
+    return str(service_name) if service_name else "Unknown"
+
+
+async def send_alert(destination: str, *, title: str, body: str) -> AlertDispatchResult:
+    """Deliver one alert, reporting failure rather than raising it.
+
+    Never raises for a delivery problem, which is the contract every caller
+    depends on: the evaluator runs inside a periodic task that must survive a
+    destination outage, and a rule pointed at a decommissioned webhook must not
+    stop the rules after it in the same tick from being evaluated.
+
+    ``asyncio.CancelledError`` is re-raised rather than swallowed, so shutdown
+    still cancels a send in flight. Everything else is reported.
+    """
+    try:
+        client = apprise.Apprise(asset=_ASSET)
+        if not client.add(destination):
+            return AlertDispatchResult(delivered=False, detail="Apprise rejected the destination URL")
+        sent = await asyncio.wait_for(
+            client.async_notify(body=body, title=title),
+            timeout=SEND_TIMEOUT_SECONDS,
+        )
+    except asyncio.CancelledError:
+        raise
+    except TimeoutError:
+        logger.warning("Alert delivery timed out after %ss", SEND_TIMEOUT_SECONDS)
+        return AlertDispatchResult(delivered=False, detail=f"Timed out after {SEND_TIMEOUT_SECONDS:.0f}s")
+    except Exception as exc:
+        # Apprise surfaces a plugin's own exceptions, so the type is whatever
+        # the transport raised. The class name is logged and the message is not:
+        # a plugin that echoes its URL into the message would otherwise put the
+        # token in our log.
+        logger.warning("Alert delivery failed: %s", type(exc).__name__)
+        return AlertDispatchResult(delivered=False, detail=f"Delivery failed ({type(exc).__name__})")
+
+    # ``async_notify`` returns None when no server matched the notification (an
+    # empty client, or every server filtered out by tag), which is a
+    # configuration problem rather than a transport one and reads as falsy.
+    if not sent:
+        return AlertDispatchResult(delivered=False, detail="The destination rejected the notification")
+    return AlertDispatchResult(delivered=True)

--- a/src/gateway/services/alerts/evaluator.py
+++ b/src/gateway/services/alerts/evaluator.py
@@ -1,0 +1,492 @@
+"""Finding the ceilings that have crossed a threshold, and alerting once each.
+
+The periodic half of the feature. One pass does four things: read the enabled
+rules, read the ceilings their organizations own, claim the right to alert on
+each crossing, and dispatch. ``gateway.main`` starts
+:func:`run_budget_alert_evaluator` alongside the other lifespan refreshers, in
+standalone mode only, because a hybrid gateway reserves nothing locally and a
+hosted one mounts no inference routers, so neither has local ceilings to watch.
+
+**State, not events.** A pass asks "which ceilings are over a threshold now",
+not "which ceilings crossed one since last time". That is what lets the same
+code answer the warning and the refusal, and it is why a ceiling that crossed
+while its destination was misconfigured still alerts once the destination is
+fixed. The cost is that a crossing is reported within
+:data:`ALERT_EVALUATION_INTERVAL_SECONDS` rather than instantly, which is the
+right trade for a signal whose whole point is to arrive before a cap is reached.
+
+**Utilization counts holds.** Every axis is measured as
+``(current + reserved) / cap``, matching the gate in
+``services/scoped_budget_service.reserve``, which admits on
+``committed + held <= cap``. Measuring committed spend alone would report 90
+percent on a ceiling that is already refusing requests.
+
+**Claim before send.** :func:`_claim` inserts the ``alert_deliveries`` row and
+commits it *before* the dispatcher is called, so the row is visible to sibling
+workers for the whole length of a slow HTTP send. Doing it the other way round
+would let N workers all find the row absent, all send, and all insert. The
+insert is therefore the lock, and an ``IntegrityError`` on it is the ordinary
+outcome on N-1 of N workers rather than an error worth logging loudly.
+"""
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Final
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.core.database import create_session
+from gateway.log_config import logger
+from gateway.metrics import record_alert_delivery
+from gateway.models.entities import AlertDelivery, AlertRule, Budget, ScopedBudget
+from gateway.services.alerts.dispatcher import send_alert
+from gateway.services.secret_box import SecretDecryptionError, decrypt_secret
+
+# Matches the cadence of the other lifespan refreshers (`alias_service`,
+# `pricing_refresh_service`). A budget warning is not a page: a minute of
+# latency on a signal about a cap that took hours to approach is invisible, and
+# a shorter interval would only multiply the scan below.
+ALERT_EVALUATION_INTERVAL_SECONDS: Final = 60.0
+
+# Kinds of alert, and the dedupe key's ``kind`` column. Strings rather than an
+# enum column, per `entities.AlertDelivery`.
+KIND_WARNING: Final = "warning"
+KIND_EXCEEDED: Final = "exceeded"
+
+# Bounds on one pass, so a deployment with a very large number of rules or
+# ceilings cannot turn a background tick into an unbounded scan. Both are far
+# above any plausible configuration.
+#
+# Read the truncation honestly: both queries are ordered deterministically, so a
+# deployment that genuinely exceeds one of these evaluates the *same* prefix on
+# every tick and never reaches the rest. That is a starvation bound, not a
+# fairness one, which is why hitting either logs a warning rather than being
+# absorbed silently. Raising the limit is the answer if a real deployment ever
+# gets there; paging across ticks would need a cursor that survives a restart,
+# and inventing one for a case nobody has hit would be speculative.
+MAX_RULES_PER_PASS: Final = 500
+MAX_CEILINGS_PER_PASS: Final = 5000
+
+# How long a delivery row is kept after its period ended. Long enough that an
+# operator can still see why an alert did or did not arrive, short enough that
+# the ledger does not grow without bound on a deployment with monthly periods.
+DELIVERY_RETENTION_DAYS: Final = 90
+
+# How often the retention purge runs, rather than on every tick. The delete
+# filters on ``created_at``, which carries no index, so running it each minute
+# would scan the table 60 times an hour to remove rows that only age out once a
+# day. Hourly keeps the ledger bounded at a cost nobody can measure.
+PURGE_INTERVAL_SECONDS: Final = 3600.0
+
+
+@dataclass(frozen=True)
+class _Crossing:
+    """One ceiling that is over a threshold, and enough of it to write a message."""
+
+    scoped_budget_id: str
+    scope_type: str
+    budget_name: str | None
+    period_start: datetime | None
+    axis: str
+    used: str
+    cap: str
+    percent: int
+
+
+def _percent(used: Decimal, cap: Decimal) -> int:
+    """Utilization as a whole percent, rounded down, saturating at 999.
+
+    Floored so a ceiling at 79.9 percent does not fire an 80 percent warning,
+    and clamped because a cap lowered under an already-spent ceiling can produce
+    an arbitrarily large ratio that has no business being formatted into a
+    message.
+    """
+    if cap <= 0:
+        return 0
+    return min(int(used * 100 // cap), 999)
+
+
+def _worst_axis(ceiling: ScopedBudget, budget: Budget) -> tuple[str, Decimal, Decimal, int] | None:
+    """The most-consumed capped axis of one ceiling, or None if nothing is capped.
+
+    A budget may cap dollars, tokens, requests, or any combination, and a
+    request has to pass every one of them. The alert therefore reports whichever
+    axis is closest to refusing requests, since that is the one an operator has
+    to act on; the others are visible in the dashboard.
+    """
+    axes: list[tuple[str, Decimal, Decimal | None]] = [
+        (
+            "spend",
+            Decimal(ceiling.current_spend) + Decimal(ceiling.reserved_spend),
+            Decimal(budget.max_budget) if budget.max_budget is not None else None,
+        ),
+        (
+            "tokens",
+            Decimal(ceiling.current_tokens + ceiling.reserved_tokens),
+            Decimal(budget.token_limit) if budget.token_limit is not None else None,
+        ),
+        (
+            "requests",
+            Decimal(ceiling.current_requests + ceiling.reserved_requests),
+            Decimal(budget.request_limit) if budget.request_limit is not None else None,
+        ),
+    ]
+    scored = [(axis, used, cap, _percent(used, cap)) for axis, used, cap in axes if cap is not None and cap > 0]
+    if not scored:
+        return None
+    return max(scored, key=lambda item: item[3])
+
+
+def _format_amount(axis: str, value: Decimal) -> str:
+    """Render one axis' figure the way its unit reads.
+
+    Dollars keep two decimal places; tokens and requests are whole counts, and
+    a Decimal would otherwise render ``1000`` as ``1000.000000``.
+    """
+    if axis == "spend":
+        return f"${value:.2f}"
+    return f"{int(value):,}"
+
+
+def _message(rule_name: str, crossing: _Crossing, kind: str) -> tuple[str, str]:
+    """The title and body of one alert.
+
+    Deliberately plain text with no markup: the same body goes to Slack, to a
+    pager and to a JSON webhook, and Apprise does not translate one vendor's
+    markup into another's.
+    """
+    subject = crossing.budget_name or f"{crossing.scope_type} ceiling {crossing.scoped_budget_id}"
+    if kind == KIND_EXCEEDED:
+        title = f"Budget exceeded: {subject}"
+        opening = f"'{subject}' has reached its {crossing.axis} limit and is now refusing requests."
+    else:
+        title = f"Budget warning: {subject} at {crossing.percent}%"
+        opening = f"'{subject}' has used {crossing.percent}% of its {crossing.axis} limit."
+    period = (
+        f"Current period started {crossing.period_start.isoformat()}."
+        if crossing.period_start is not None
+        else "This ceiling has no period and does not reset on its own."
+    )
+    body = (
+        f"{opening}\n\n"
+        f"Used: {crossing.used} of {crossing.cap} ({crossing.axis})\n"
+        f"Scope: {crossing.scope_type}\n"
+        f"{period}\n\n"
+        f"Alert rule: {rule_name}"
+    )
+    return title, body
+
+
+async def _load_rules(db: AsyncSession) -> list[AlertRule]:
+    """Every enabled rule, across organizations, newest last.
+
+    One query for the whole deployment rather than one per organization: the
+    common case is a handful of rows, and a deployment with none returns here
+    having done exactly one cheap indexed read per tick, which is what makes
+    this worker free for everybody who has not configured an alert.
+    """
+    rows = (
+        await db.execute(
+            select(AlertRule)
+            .where(AlertRule.enabled.is_(True))
+            .order_by(AlertRule.created_at)
+            .limit(MAX_RULES_PER_PASS)
+        )
+    ).scalars()
+    return list(rows)
+
+
+async def _load_ceilings(db: AsyncSession, organization_ids: set[uuid.UUID]) -> list[tuple[ScopedBudget, Budget]]:
+    """The ceilings owned by these organizations, with the budget each names.
+
+    The join is what makes a rule organization-scoped: a ``scoped_budgets`` row
+    carries no tenant of its own, so its owner is the ``organization_id`` on the
+    ``budgets`` row it names. A budget with a NULL ``organization_id`` is the
+    deployment's own and is excluded by the ``IN`` rather than by a separate
+    clause (see `entities.AlertRule`).
+
+    Only ceilings that cap something are returned. A ceiling whose budget caps
+    no axis can never cross a threshold, so filtering here keeps them out of the
+    Python loop and out of the row limit.
+    """
+    if not organization_ids:
+        return []
+    stmt = (
+        select(ScopedBudget, Budget)
+        .join(Budget, Budget.budget_id == ScopedBudget.budget_id)
+        .where(
+            Budget.organization_id.in_(organization_ids),
+            (Budget.max_budget.is_not(None) | Budget.token_limit.is_not(None) | Budget.request_limit.is_not(None)),
+        )
+        .order_by(ScopedBudget.id)
+        .limit(MAX_CEILINGS_PER_PASS)
+    )
+    rows = [(ceiling, budget) for ceiling, budget in (await db.execute(stmt)).all()]
+    if len(rows) == MAX_CEILINGS_PER_PASS:
+        logger.warning(
+            "Budget alert pass hit the %s-ceiling limit; some ceilings were not evaluated this tick",
+            MAX_CEILINGS_PER_PASS,
+        )
+    return rows
+
+
+async def _already_delivered(
+    db: AsyncSession, rule_ids: set[uuid.UUID], scoped_budget_ids: set[str]
+) -> set[tuple[uuid.UUID, str, datetime | None, str]]:
+    """The dedupe keys already claimed for these rules and these ceilings.
+
+    A pre-filter, not the guarantee: :func:`_claim`'s unique constraint is what
+    actually prevents a duplicate, and this only keeps a steady state from
+    attempting an insert per crossed ceiling on every tick forever.
+
+    Narrowed to the ceilings that have *actually* crossed, which is the
+    difference between a read proportional to the work and one proportional to
+    retained history. Filtering on ``alert_rule_id`` alone would load every row
+    the retention window still holds: on daily periods that is one row per
+    ceiling per kind per day, so a deployment with a few thousand ceilings would
+    pull hundreds of thousands of rows into memory on a tick that had one alert
+    to send. Both columns are covered by ``ix_alert_deliveries_alert_rule_id``
+    and the unique constraint's leading columns.
+    """
+    if not rule_ids or not scoped_budget_ids:
+        return set()
+    rows = (
+        await db.execute(
+            select(
+                AlertDelivery.alert_rule_id,
+                AlertDelivery.scoped_budget_id,
+                AlertDelivery.period_start,
+                AlertDelivery.kind,
+            ).where(
+                AlertDelivery.alert_rule_id.in_(rule_ids),
+                AlertDelivery.scoped_budget_id.in_(scoped_budget_ids),
+            )
+        )
+    ).all()
+    return {(rule_id, budget_id, _as_utc(period), kind) for rule_id, budget_id, period, kind in rows}
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Stamp a naive timestamp UTC, so a stored key compares equal to a read one.
+
+    ``UtcDateTime`` normalizes on the way in and out, but a value that reached
+    the set from one engine and is compared against one built in Python must
+    agree on awareness or every key would miss and every tick would re-attempt
+    the insert.
+    """
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def _claim(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind: str) -> AlertDelivery | None:
+    """Take the right to send this alert, or return None if somebody else has it.
+
+    Committed before the caller dispatches, which is the whole point: the row
+    has to be visible to the other workers while the send is in flight. An
+    ``IntegrityError`` is the expected result on every worker but one and is not
+    logged as a problem.
+    """
+    delivery = AlertDelivery(
+        alert_rule_id=rule.id,
+        scoped_budget_id=crossing.scoped_budget_id,
+        kind=kind,
+        period_start=crossing.period_start,
+    )
+    db.add(delivery)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        return None
+    return delivery
+
+
+async def _record_outcome(db: AsyncSession, delivery: AlertDelivery, *, delivered: bool, detail: str | None) -> None:
+    """Write back whether the send worked, best-effort.
+
+    A failure here loses the outcome, not the dedupe: the claim is already
+    committed, so the alert is still not sent twice. Logged and swallowed
+    because the caller is a periodic task that must reach the next rule.
+    """
+    delivery.delivered = delivered
+    delivery.detail = detail
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        logger.warning("Could not record the outcome of an alert delivery", exc_info=True)
+
+
+def _kind_for(rule: AlertRule, percent: int) -> str | None:
+    """Which alert, if any, this utilization earns from this rule.
+
+    Exceeded wins over the warning when both apply, and the warning is not also
+    sent for the same pass: they are separate dedupe keys, so a ceiling that
+    passes 80 and then 100 between two ticks sends only the refusal, which is
+    the more urgent and strictly more informative of the two.
+    """
+    if percent >= 100:
+        return KIND_EXCEEDED if rule.notify_on_exceeded else None
+    if rule.warn_at_percent is not None and percent >= rule.warn_at_percent:
+        return KIND_WARNING
+    return None
+
+
+async def evaluate_budget_alerts(db: AsyncSession) -> int:
+    """Run one pass, returning how many alerts were dispatched.
+
+    The return value is for the tests and the log line; nothing branches on it.
+    """
+    rules = await _load_rules(db)
+    if not rules:
+        return 0
+    if len(rules) == MAX_RULES_PER_PASS:
+        logger.warning("Budget alert pass hit the %s-rule limit; some rules were skipped", MAX_RULES_PER_PASS)
+
+    by_organization: dict[uuid.UUID, list[AlertRule]] = {}
+    for rule in rules:
+        by_organization.setdefault(rule.organization_id, []).append(rule)
+
+    ceilings = await _load_ceilings(db, set(by_organization))
+    if not ceilings:
+        return 0
+
+    # Everything that has crossed something, worked out before a single delivery
+    # row is read. Doing it in this order is what lets the dedupe read below be
+    # narrowed to the ceilings actually in play, and it means a tick with
+    # nothing over a threshold (the overwhelmingly common case) touches the
+    # ``alert_deliveries`` table not at all.
+    candidates: list[tuple[AlertRule, _Crossing, str]] = []
+    for ceiling, budget in ceilings:
+        organization_id = budget.organization_id
+        if organization_id is None:
+            continue
+        scored = _worst_axis(ceiling, budget)
+        if scored is None:
+            continue
+        axis, used, cap, percent = scored
+        crossing = _Crossing(
+            scoped_budget_id=ceiling.id,
+            scope_type=ceiling.scope_type,
+            budget_name=budget.name or ceiling.name,
+            period_start=_as_utc(ceiling.period_start),
+            axis=axis,
+            used=_format_amount(axis, used),
+            cap=_format_amount(axis, cap),
+            percent=percent,
+        )
+        for rule in by_organization[organization_id]:
+            kind = _kind_for(rule, percent)
+            if kind is not None:
+                candidates.append((rule, crossing, kind))
+
+    if not candidates:
+        return 0
+
+    claimed = await _already_delivered(
+        db,
+        {rule.id for rule, _, _ in candidates},
+        {crossing.scoped_budget_id for _, crossing, _ in candidates},
+    )
+
+    sent = 0
+    for rule, crossing, kind in candidates:
+        if (rule.id, crossing.scoped_budget_id, crossing.period_start, kind) in claimed:
+            continue
+        if await _dispatch(db, rule, crossing, kind):
+            sent += 1
+    return sent
+
+
+async def _dispatch(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind: str) -> bool:
+    """Claim, decrypt, send, and record one alert. True when it went out.
+
+    The decryption happens after the claim rather than before, so a rule whose
+    destination cannot be decrypted still consumes its dedupe key and reports
+    the reason on the row instead of retrying the same broken decrypt on every
+    tick for the rest of the period.
+    """
+    delivery = await _claim(db, rule, crossing, kind)
+    if delivery is None:
+        return False
+
+    try:
+        destination = decrypt_secret(rule.encrypted_destination)
+    except SecretDecryptionError:
+        logger.warning("Alert rule %s has a destination that will not decrypt", rule.id)
+        await _record_outcome(db, delivery, delivered=False, detail="The stored destination could not be decrypted")
+        record_alert_delivery(kind=kind, delivered=False)
+        return False
+
+    title, body = _message(rule.name, crossing, kind)
+    result = await send_alert(destination, title=title, body=body)
+    await _record_outcome(db, delivery, delivered=result.delivered, detail=result.detail)
+    record_alert_delivery(kind=kind, delivered=result.delivered)
+    if not result.delivered:
+        # The redaction, never the destination: see `dispatcher`'s docstring.
+        logger.warning(
+            "Alert rule %s could not deliver to %s: %s",
+            rule.id,
+            rule.redacted_destination,
+            result.detail,
+        )
+    return result.delivered
+
+
+async def purge_delivered_before(db: AsyncSession, *, older_than: datetime) -> int:
+    """Drop delivery rows created before ``older_than``, returning the count.
+
+    The ledger's rows outlive the periods they describe, and a ceiling that is
+    deleted leaves its rows behind (``scoped_budget_id`` is deliberately not a
+    foreign key, matching ``scoped_budgets``' own columns). Retention rather
+    than cascade is what keeps the table bounded.
+
+    Safe to run while a pass is in flight: a row old enough to be purged
+    belongs to a period that has long since rolled, so its dedupe key is no
+    longer one any live ceiling would produce.
+    """
+    result = await db.execute(delete(AlertDelivery).where(AlertDelivery.created_at < older_than))
+    await db.commit()
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
+async def run_budget_alert_evaluator(interval: float = ALERT_EVALUATION_INTERVAL_SECONDS) -> None:
+    """Evaluate budget alerts forever. Cancelled at shutdown.
+
+    Every error is swallowed and retried on the next tick, matching
+    ``run_alias_refresher``: a database blip must not kill the worker, because
+    nothing would restart it and the deployment would then stop alerting
+    silently, which is the exact failure this feature exists to prevent.
+
+    The retention purge rides on this loop rather than a second task, since the
+    loop is already awake, but on its own much slower schedule: see
+    :data:`PURGE_INTERVAL_SECONDS`.
+    """
+    last_purge = 0.0
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with create_session() as db:
+                sent = await evaluate_budget_alerts(db)
+                if sent:
+                    logger.info("Budget alerts dispatched: %s", sent)
+                # Monotonic rather than wall clock: a clock adjustment must not
+                # make the next purge either immediate or an hour late.
+                now = asyncio.get_running_loop().time()
+                if now - last_purge >= PURGE_INTERVAL_SECONDS:
+                    last_purge = now
+                    purged = await purge_delivered_before(
+                        db, older_than=datetime.now(UTC) - timedelta(days=DELIVERY_RETENTION_DAYS)
+                    )
+                    if purged:
+                        logger.info("Purged %s expired alert delivery rows", purged)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Budget alert evaluation failed; retrying in %ss", interval, exc_info=True)

--- a/src/gateway/services/alerts/evaluator.py
+++ b/src/gateway/services/alerts/evaluator.py
@@ -411,6 +411,15 @@ async def _dispatch(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind
     destination cannot be decrypted still consumes its dedupe key and reports
     the reason on the row instead of retrying the same broken decrypt on every
     tick for the rest of the period.
+
+    **Claiming first also keeps a pooled connection out of the send.**
+    ``create_session`` yields a commit-as-you-go session with no surrounding
+    transaction, so :func:`_claim`'s commit returns its connection to the pool
+    before ``send_alert`` runs, and :func:`_record_outcome` takes a fresh one
+    afterwards. That is what stops a destination sitting on its
+    ``SEND_TIMEOUT_SECONDS`` from holding a connection for the length of every
+    alert, which is the rule ``release_session`` enforces on the request path.
+    Wrapping a pass in ``async with db.begin()`` would silently give that up.
     """
     delivery = await _claim(db, rule, crossing, kind)
     if delivery is None:

--- a/src/gateway/services/alerts/evaluator.py
+++ b/src/gateway/services/alerts/evaluator.py
@@ -1,32 +1,27 @@
 """Finding the ceilings that have crossed a threshold, and alerting once each.
 
-The periodic half of the feature. One pass does four things: read the enabled
-rules, read the ceilings their organizations own, claim the right to alert on
-each crossing, and dispatch. ``gateway.main`` starts
-:func:`run_budget_alert_evaluator` alongside the other lifespan refreshers, in
-standalone mode only, because a hybrid gateway reserves nothing locally and a
-hosted one mounts no inference routers, so neither has local ceilings to watch.
+The periodic half of the feature. One pass reads the enabled rules, reads the
+ceilings their organizations own, claims the right to alert on each crossing,
+and dispatches. ``gateway.main`` starts :func:`run_budget_alert_evaluator`
+alongside the other lifespan refreshers, wherever local ceilings exist
+(standalone and hosted; a hybrid gateway reserves nothing locally).
 
 **State, not events.** A pass asks "which ceilings are over a threshold now",
-not "which ceilings crossed one since last time". That is what lets the same
-code answer the warning and the refusal, and it is why a ceiling that crossed
-while its destination was misconfigured still alerts once the destination is
-fixed. The cost is that a crossing is reported within
-:data:`ALERT_EVALUATION_INTERVAL_SECONDS` rather than instantly, which is the
-right trade for a signal whose whole point is to arrive before a cap is reached.
+not "which crossed since last time". That is what lets the same code answer the
+warning and the refusal, and it is why a ceiling that crossed while its
+destination was misconfigured still alerts once the destination is fixed. The
+cost is a crossing reported within one interval rather than instantly.
 
-**Utilization counts holds.** Every axis is measured as
-``(current + reserved) / cap``, matching the gate in
-``services/scoped_budget_service.reserve``, which admits on
-``committed + held <= cap``. Measuring committed spend alone would report 90
-percent on a ceiling that is already refusing requests.
+**Utilization counts holds.** Every axis is ``(current + reserved) / cap``,
+matching the gate in ``services/scoped_budget_service.reserve``. Measuring
+committed spend alone would report 90 percent on a ceiling that is already
+refusing requests.
 
 **Claim before send.** :func:`_claim` inserts the ``alert_deliveries`` row and
-commits it *before* the dispatcher is called, so the row is visible to sibling
-workers for the whole length of a slow HTTP send. Doing it the other way round
-would let N workers all find the row absent, all send, and all insert. The
-insert is therefore the lock, and an ``IntegrityError`` on it is the ordinary
-outcome on N-1 of N workers rather than an error worth logging loudly.
+commits it *before* dispatching, so the row is visible to sibling workers for
+the whole length of a slow HTTP send. The insert is the lock, and an
+``IntegrityError`` on it is the ordinary outcome on N-1 of N workers rather than
+an error worth logging.
 """
 
 import asyncio
@@ -47,10 +42,9 @@ from gateway.models.entities import AlertDelivery, AlertRule, Budget, ScopedBudg
 from gateway.services.alerts.dispatcher import send_alert
 from gateway.services.secret_box import SecretDecryptionError, decrypt_secret
 
-# Matches the cadence of the other lifespan refreshers (`alias_service`,
-# `pricing_refresh_service`). A budget warning is not a page: a minute of
-# latency on a signal about a cap that took hours to approach is invisible, and
-# a shorter interval would only multiply the scan below.
+# Matches the cadence of the other lifespan refreshers. A budget warning is not
+# a page: a minute of latency on a signal about a cap that took hours to
+# approach is invisible.
 ALERT_EVALUATION_INTERVAL_SECONDS: Final = 60.0
 
 # Kinds of alert, and the dedupe key's ``kind`` column. Strings rather than an
@@ -58,29 +52,13 @@ ALERT_EVALUATION_INTERVAL_SECONDS: Final = 60.0
 KIND_WARNING: Final = "warning"
 KIND_EXCEEDED: Final = "exceeded"
 
-# Bounds on one pass, so a deployment with a very large number of rules or
-# ceilings cannot turn a background tick into an unbounded scan. Both are far
-# above any plausible configuration.
-#
-# Read the truncation honestly: both queries are ordered deterministically, so a
-# deployment that genuinely exceeds one of these evaluates the *same* prefix on
-# every tick and never reaches the rest. That is a starvation bound, not a
-# fairness one, which is why hitting either logs a warning rather than being
-# absorbed silently. Raising the limit is the answer if a real deployment ever
-# gets there; paging across ticks would need a cursor that survives a restart,
-# and inventing one for a case nobody has hit would be speculative.
-MAX_RULES_PER_PASS: Final = 500
-MAX_CEILINGS_PER_PASS: Final = 5000
-
-# How long a delivery row is kept after its period ended. Long enough that an
+# How long a delivery row is kept after it is written. Long enough that an
 # operator can still see why an alert did or did not arrive, short enough that
 # the ledger does not grow without bound on a deployment with monthly periods.
 DELIVERY_RETENTION_DAYS: Final = 90
 
-# How often the retention purge runs, rather than on every tick. The delete
-# filters on ``created_at``, which carries no index, so running it each minute
-# would scan the table 60 times an hour to remove rows that only age out once a
-# day. Hourly keeps the ledger bounded at a cost nobody can measure.
+# The purge filters on an unindexed ``created_at``, so it rides the loop on a
+# much slower schedule than the evaluation itself.
 PURGE_INTERVAL_SECONDS: Final = 3600.0
 
 
@@ -99,12 +77,10 @@ class _Crossing:
 
 
 def _percent(used: Decimal, cap: Decimal) -> int:
-    """Utilization as a whole percent, rounded down, saturating at 999.
+    """Utilization as a whole percent, floored, saturating at 999.
 
-    Floored so a ceiling at 79.9 percent does not fire an 80 percent warning,
-    and clamped because a cap lowered under an already-spent ceiling can produce
-    an arbitrarily large ratio that has no business being formatted into a
-    message.
+    Floored so 79.9 percent does not fire an 80 percent warning; clamped because
+    a cap lowered under an already-spent ceiling gives an arbitrary ratio.
     """
     if cap <= 0:
         return 0
@@ -114,10 +90,8 @@ def _percent(used: Decimal, cap: Decimal) -> int:
 def _worst_axis(ceiling: ScopedBudget, budget: Budget) -> tuple[str, Decimal, Decimal, int] | None:
     """The most-consumed capped axis of one ceiling, or None if nothing is capped.
 
-    A budget may cap dollars, tokens, requests, or any combination, and a
-    request has to pass every one of them. The alert therefore reports whichever
-    axis is closest to refusing requests, since that is the one an operator has
-    to act on; the others are visible in the dashboard.
+    A request has to pass every cap, so the alert reports whichever axis is
+    closest to refusing one. The others are visible in the dashboard.
     """
     axes: list[tuple[str, Decimal, Decimal | None]] = [
         (
@@ -145,8 +119,7 @@ def _worst_axis(ceiling: ScopedBudget, budget: Budget) -> tuple[str, Decimal, De
 def _format_amount(axis: str, value: Decimal) -> str:
     """Render one axis' figure the way its unit reads.
 
-    Dollars keep two decimal places; tokens and requests are whole counts, and
-    a Decimal would otherwise render ``1000`` as ``1000.000000``.
+    A Decimal would otherwise render a token count of ``1000`` as ``1000.000000``.
     """
     if axis == "spend":
         return f"${value:.2f}"
@@ -156,9 +129,8 @@ def _format_amount(axis: str, value: Decimal) -> str:
 def _message(rule_name: str, crossing: _Crossing, kind: str) -> tuple[str, str]:
     """The title and body of one alert.
 
-    Deliberately plain text with no markup: the same body goes to Slack, to a
-    pager and to a JSON webhook, and Apprise does not translate one vendor's
-    markup into another's.
+    Plain text with no markup: the same body goes to Slack, a pager and a JSON
+    webhook, and Apprise does not translate one vendor's markup into another's.
     """
     subject = crossing.budget_name or f"{crossing.scope_type} ceiling {crossing.scoped_budget_id}"
     if kind == KIND_EXCEEDED:
@@ -183,21 +155,14 @@ def _message(rule_name: str, crossing: _Crossing, kind: str) -> tuple[str, str]:
 
 
 async def _load_rules(db: AsyncSession) -> list[AlertRule]:
-    """Every enabled rule, across organizations, newest last.
+    """Every enabled rule, across organizations.
 
     One query for the whole deployment rather than one per organization: the
-    common case is a handful of rows, and a deployment with none returns here
-    having done exactly one cheap indexed read per tick, which is what makes
-    this worker free for everybody who has not configured an alert.
+    common case is a handful of rows, and a deployment with none returns after
+    exactly one cheap indexed read per tick, which is what makes this worker
+    free for everybody who has not configured an alert.
     """
-    rows = (
-        await db.execute(
-            select(AlertRule)
-            .where(AlertRule.enabled.is_(True))
-            .order_by(AlertRule.created_at)
-            .limit(MAX_RULES_PER_PASS)
-        )
-    ).scalars()
+    rows = (await db.execute(select(AlertRule).where(AlertRule.enabled.is_(True)))).scalars()
     return list(rows)
 
 
@@ -206,13 +171,11 @@ async def _load_ceilings(db: AsyncSession, organization_ids: set[uuid.UUID]) -> 
 
     The join is what makes a rule organization-scoped: a ``scoped_budgets`` row
     carries no tenant of its own, so its owner is the ``organization_id`` on the
-    ``budgets`` row it names. A budget with a NULL ``organization_id`` is the
-    deployment's own and is excluded by the ``IN`` rather than by a separate
-    clause (see `entities.AlertRule`).
+    ``budgets`` row it names. A NULL one is the deployment's own and is excluded
+    by the ``IN`` (see `entities.AlertRule`).
 
-    Only ceilings that cap something are returned. A ceiling whose budget caps
-    no axis can never cross a threshold, so filtering here keeps them out of the
-    Python loop and out of the row limit.
+    Only ceilings that cap something are returned: one that caps no axis can
+    never cross a threshold.
     """
     if not organization_ids:
         return []
@@ -223,62 +186,12 @@ async def _load_ceilings(db: AsyncSession, organization_ids: set[uuid.UUID]) -> 
             Budget.organization_id.in_(organization_ids),
             (Budget.max_budget.is_not(None) | Budget.token_limit.is_not(None) | Budget.request_limit.is_not(None)),
         )
-        .order_by(ScopedBudget.id)
-        .limit(MAX_CEILINGS_PER_PASS)
     )
-    rows = [(ceiling, budget) for ceiling, budget in (await db.execute(stmt)).all()]
-    if len(rows) == MAX_CEILINGS_PER_PASS:
-        logger.warning(
-            "Budget alert pass hit the %s-ceiling limit; some ceilings were not evaluated this tick",
-            MAX_CEILINGS_PER_PASS,
-        )
-    return rows
-
-
-async def _already_delivered(
-    db: AsyncSession, rule_ids: set[uuid.UUID], scoped_budget_ids: set[str]
-) -> set[tuple[uuid.UUID, str, datetime | None, str]]:
-    """The dedupe keys already claimed for these rules and these ceilings.
-
-    A pre-filter, not the guarantee: :func:`_claim`'s unique constraint is what
-    actually prevents a duplicate, and this only keeps a steady state from
-    attempting an insert per crossed ceiling on every tick forever.
-
-    Narrowed to the ceilings that have *actually* crossed, which is the
-    difference between a read proportional to the work and one proportional to
-    retained history. Filtering on ``alert_rule_id`` alone would load every row
-    the retention window still holds: on daily periods that is one row per
-    ceiling per kind per day, so a deployment with a few thousand ceilings would
-    pull hundreds of thousands of rows into memory on a tick that had one alert
-    to send. Both columns are covered by ``ix_alert_deliveries_alert_rule_id``
-    and the unique constraint's leading columns.
-    """
-    if not rule_ids or not scoped_budget_ids:
-        return set()
-    rows = (
-        await db.execute(
-            select(
-                AlertDelivery.alert_rule_id,
-                AlertDelivery.scoped_budget_id,
-                AlertDelivery.period_start,
-                AlertDelivery.kind,
-            ).where(
-                AlertDelivery.alert_rule_id.in_(rule_ids),
-                AlertDelivery.scoped_budget_id.in_(scoped_budget_ids),
-            )
-        )
-    ).all()
-    return {(rule_id, budget_id, _as_utc(period), kind) for rule_id, budget_id, period, kind in rows}
+    return [(ceiling, budget) for ceiling, budget in (await db.execute(stmt)).all()]
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
-    """Stamp a naive timestamp UTC, so a stored key compares equal to a read one.
-
-    ``UtcDateTime`` normalizes on the way in and out, but a value that reached
-    the set from one engine and is compared against one built in Python must
-    agree on awareness or every key would miss and every tick would re-attempt
-    the insert.
-    """
+    """Stamp a naive timestamp UTC, so the dedupe key is comparable either way."""
     if value is None:
         return None
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
@@ -287,10 +200,9 @@ def _as_utc(value: datetime | None) -> datetime | None:
 async def _claim(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind: str) -> AlertDelivery | None:
     """Take the right to send this alert, or return None if somebody else has it.
 
-    Committed before the caller dispatches, which is the whole point: the row
-    has to be visible to the other workers while the send is in flight. An
-    ``IntegrityError`` is the expected result on every worker but one and is not
-    logged as a problem.
+    Committed before the caller dispatches, which is the point: the row has to
+    be visible to sibling workers while the send is in flight. An
+    ``IntegrityError`` is the expected result on every worker but one.
     """
     delivery = AlertDelivery(
         alert_rule_id=rule.id,
@@ -311,8 +223,7 @@ async def _record_outcome(db: AsyncSession, delivery: AlertDelivery, *, delivere
     """Write back whether the send worked, best-effort.
 
     A failure here loses the outcome, not the dedupe: the claim is already
-    committed, so the alert is still not sent twice. Logged and swallowed
-    because the caller is a periodic task that must reach the next rule.
+    committed, so the alert is still not sent twice.
     """
     delivery.delivered = delivered
     delivery.detail = detail
@@ -326,13 +237,17 @@ async def _record_outcome(db: AsyncSession, delivery: AlertDelivery, *, delivere
 def _kind_for(rule: AlertRule, percent: int) -> str | None:
     """Which alert, if any, this utilization earns from this rule.
 
-    Exceeded wins over the warning when both apply, and the warning is not also
-    sent for the same pass: they are separate dedupe keys, so a ceiling that
-    passes 80 and then 100 between two ticks sends only the refusal, which is
-    the more urgent and strictly more informative of the two.
+    Exceeded wins over the warning when both apply: they are separate dedupe
+    keys, so a ceiling that passes 80 and then 100 between two ticks sends only
+    the refusal, which is the more urgent and strictly more informative.
+
+    A rule with the exceeded alert off still warns at 100. The two flags are
+    separable so a deployment that routes refusals through its own error
+    monitoring can ask for the early warning alone, and going silent at exactly
+    the moment that rule cares about would defeat it.
     """
-    if percent >= 100:
-        return KIND_EXCEEDED if rule.notify_on_exceeded else None
+    if percent >= 100 and rule.notify_on_exceeded:
+        return KIND_EXCEEDED
     if rule.warn_at_percent is not None and percent >= rule.warn_at_percent:
         return KIND_WARNING
     return None
@@ -346,23 +261,14 @@ async def evaluate_budget_alerts(db: AsyncSession) -> int:
     rules = await _load_rules(db)
     if not rules:
         return 0
-    if len(rules) == MAX_RULES_PER_PASS:
-        logger.warning("Budget alert pass hit the %s-rule limit; some rules were skipped", MAX_RULES_PER_PASS)
 
     by_organization: dict[uuid.UUID, list[AlertRule]] = {}
     for rule in rules:
         by_organization.setdefault(rule.organization_id, []).append(rule)
 
     ceilings = await _load_ceilings(db, set(by_organization))
-    if not ceilings:
-        return 0
 
-    # Everything that has crossed something, worked out before a single delivery
-    # row is read. Doing it in this order is what lets the dedupe read below be
-    # narrowed to the ceilings actually in play, and it means a tick with
-    # nothing over a threshold (the overwhelmingly common case) touches the
-    # ``alert_deliveries`` table not at all.
-    candidates: list[tuple[AlertRule, _Crossing, str]] = []
+    sent = 0
     for ceiling, budget in ceilings:
         organization_id = budget.organization_id
         if organization_id is None:
@@ -383,43 +289,22 @@ async def evaluate_budget_alerts(db: AsyncSession) -> int:
         )
         for rule in by_organization[organization_id]:
             kind = _kind_for(rule, percent)
-            if kind is not None:
-                candidates.append((rule, crossing, kind))
-
-    if not candidates:
-        return 0
-
-    claimed = await _already_delivered(
-        db,
-        {rule.id for rule, _, _ in candidates},
-        {crossing.scoped_budget_id for _, crossing, _ in candidates},
-    )
-
-    sent = 0
-    for rule, crossing, kind in candidates:
-        if (rule.id, crossing.scoped_budget_id, crossing.period_start, kind) in claimed:
-            continue
-        if await _dispatch(db, rule, crossing, kind):
-            sent += 1
+            if kind is not None and await _dispatch(db, rule, crossing, kind):
+                sent += 1
     return sent
 
 
 async def _dispatch(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind: str) -> bool:
     """Claim, decrypt, send, and record one alert. True when it went out.
 
-    The decryption happens after the claim rather than before, so a rule whose
-    destination cannot be decrypted still consumes its dedupe key and reports
-    the reason on the row instead of retrying the same broken decrypt on every
-    tick for the rest of the period.
+    Decryption happens after the claim, so a rule whose destination will not
+    decrypt still consumes its dedupe key and reports the reason on the row
+    rather than retrying the same broken decrypt every tick.
 
-    **Claiming first also keeps a pooled connection out of the send.**
-    ``create_session`` yields a commit-as-you-go session with no surrounding
-    transaction, so :func:`_claim`'s commit returns its connection to the pool
-    before ``send_alert`` runs, and :func:`_record_outcome` takes a fresh one
-    afterwards. That is what stops a destination sitting on its
-    ``SEND_TIMEOUT_SECONDS`` from holding a connection for the length of every
-    alert, which is the rule ``release_session`` enforces on the request path.
-    Wrapping a pass in ``async with db.begin()`` would silently give that up.
+    Claiming first also keeps a pooled connection out of the send:
+    ``create_session`` commits as it goes, so :func:`_claim`'s commit returns
+    the connection before ``send_alert`` runs. Wrapping a pass in
+    ``async with db.begin()`` would give that up.
     """
     delivery = await _claim(db, rule, crossing, kind)
     if delivery is None:
@@ -451,14 +336,10 @@ async def _dispatch(db: AsyncSession, rule: AlertRule, crossing: _Crossing, kind
 async def purge_delivered_before(db: AsyncSession, *, older_than: datetime) -> int:
     """Drop delivery rows created before ``older_than``, returning the count.
 
-    The ledger's rows outlive the periods they describe, and a ceiling that is
-    deleted leaves its rows behind (``scoped_budget_id`` is deliberately not a
-    foreign key, matching ``scoped_budgets``' own columns). Retention rather
-    than cascade is what keeps the table bounded.
-
-    Safe to run while a pass is in flight: a row old enough to be purged
-    belongs to a period that has long since rolled, so its dedupe key is no
-    longer one any live ceiling would produce.
+    Rows outlive the periods they describe, and a deleted ceiling leaves its
+    rows behind (``scoped_budget_id`` is deliberately not a foreign key), so
+    retention rather than cascade is what bounds the table. Safe to run during a
+    pass: a row old enough to purge belongs to a period that has long rolled.
     """
     result = await db.execute(delete(AlertDelivery).where(AlertDelivery.created_at < older_than))
     await db.commit()
@@ -468,14 +349,12 @@ async def purge_delivered_before(db: AsyncSession, *, older_than: datetime) -> i
 async def run_budget_alert_evaluator(interval: float = ALERT_EVALUATION_INTERVAL_SECONDS) -> None:
     """Evaluate budget alerts forever. Cancelled at shutdown.
 
-    Every error is swallowed and retried on the next tick, matching
-    ``run_alias_refresher``: a database blip must not kill the worker, because
+    Every error is swallowed and retried next tick, matching
+    ``run_alias_refresher``: a database blip must not kill the worker, since
     nothing would restart it and the deployment would then stop alerting
     silently, which is the exact failure this feature exists to prevent.
 
-    The retention purge rides on this loop rather than a second task, since the
-    loop is already awake, but on its own much slower schedule: see
-    :data:`PURGE_INTERVAL_SECONDS`.
+    The retention purge rides this loop on its own slower schedule.
     """
     last_purge = 0.0
     while True:

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -1147,7 +1147,88 @@ class SandboxImageNotAllowedError(TenancyValidationError):
     """
 
 
+class AlertRuleNotFoundError(TenancyNotFoundError):
+    def __init__(self, rule_id: object):
+        super().__init__(f"Alert rule {rule_id} not found")
+
+
+class AlertRuleAlreadyExistsError(TenancyConflictError):
+    """The organization already has an alert rule under this name.
+
+    Unique per organization so the name is usable as the thing an operator
+    recognizes a rule by, in the dashboard list and in the alert body itself,
+    where it is the only field identifying which rule produced the message.
+    """
+
+    def __init__(self, name: object):
+        super().__init__(f"This organization already has an alert rule named '{name}'")
+
+
+class AlertRuleUnsupportedDestinationError(TenancyValidationError):
+    """Apprise cannot deliver to this destination.
+
+    Carries the dispatcher's own message, which names some accepted schemas and
+    deliberately does not echo the rejected URL back: an unparseable destination
+    is still a string the operator may have pasted a real token into.
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+
+
+class AlertRuleUnsafeDestinationError(TenancyValidationError):
+    """The destination resolves somewhere this deployment must not post to.
+
+    Only the http-carrying Apprise schemas reach this check; see
+    `organization_alert_service._validate_destination` for which those are and
+    why the rest cannot be checked this way. Carries the reason from
+    `services.url_safety.UnsafeURLError` verbatim, matching
+    `WorkspaceMcpServerUnsafeUrlError`: it names the host and the range it
+    resolved into, and this surface is management-gated rather than
+    caller-supplied.
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+
+
+class AlertRuleInertError(TenancyValidationError):
+    """The rule has no warning threshold and no exceeded alert, so it can never fire.
+
+    Storable and meaningless: it would sit in the list looking like configured
+    alerting while being incapable of producing a message. ``enabled`` is the
+    field that means "stop sending", and it keeps saying so.
+
+    Checked on the merged row as well as in the create body, because a PATCH
+    can reach the same dead state by sending only one of the two halves.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "A rule must do something: set warn_at_percent, or notify_on_exceeded, or both. "
+            "Use enabled=false to stop a rule without discarding it"
+        )
+
+
+class AlertRuleLimitReachedError(TenancyValidationError):
+    """The organization already has as many alert rules as it may configure.
+
+    A bound on fan-out rather than on storage: every rule that matches a
+    crossing is one more outbound send the evaluator's tick waits on, so the
+    limit is what keeps one organization's rule list from setting the pace of
+    the whole deployment's alerting.
+    """
+
+    def __init__(self, limit: int):
+        super().__init__(f"An organization may configure at most {limit} alert rules")
+
 __all__ = [
+    "AlertRuleAlreadyExistsError",
+    "AlertRuleInertError",
+    "AlertRuleLimitReachedError",
+    "AlertRuleNotFoundError",
+    "AlertRuleUnsafeDestinationError",
+    "AlertRuleUnsupportedDestinationError",
     "BootstrapOperatorProtectedError",
     "CurrentPasswordIncorrectError",
     "CurrentPasswordRequiredError",

--- a/src/gateway/services/tenancy/organization_alert_service.py
+++ b/src/gateway/services/tenancy/organization_alert_service.py
@@ -112,8 +112,7 @@ class AlertRuleCreate(BaseModel):
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)] = Field(
         description="How this rule is identified in the dashboard and in the alert body, unique per organization",
     )
-    destination: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(
-        max_length=4096,
+    destination: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=4096)] = Field(
         description=(
             "Apprise destination URL, for example slack://token/channel, "
             "discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a "
@@ -174,9 +173,15 @@ class AlertRuleUpdate(BaseModel):
     name: (
         Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)] | SkipJsonSchema[None]
     ) = None
-    destination: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | SkipJsonSchema[None] = Field(
-        default=None, max_length=4096
-    )
+    # ``max_length`` lives in ``StringConstraints`` rather than on ``Field``: on
+    # an optional union a ``Field(max_length=...)`` is applied to the whole
+    # union, and pydantic then raises ``TypeError: Unable to apply constraint
+    # 'max_length' to supplied value None`` instead of a ``ValidationError``, so
+    # an explicit null reached the caller as a 500 rather than a 422.
+    destination: (
+        Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=4096)]
+        | SkipJsonSchema[None]
+    ) = None
     warn_at_percent: int | None = Field(default=None, gt=0, lt=100)
     notify_on_exceeded: bool | SkipJsonSchema[None] = None
     enabled: bool | SkipJsonSchema[None] = None

--- a/src/gateway/services/tenancy/organization_alert_service.py
+++ b/src/gateway/services/tenancy/organization_alert_service.py
@@ -1,0 +1,462 @@
+"""Organization-scoped alert rules: CRUD, and the on-demand test send.
+
+Where a tenant says how it wants to be told that one of its budgets is running
+out. The rules themselves are acted on by
+:mod:`gateway.services.alerts.evaluator`, which runs on a timer and never
+touches this module; the two meet only at the ``alert_rules`` table.
+
+**Why this lives with the tenancy services.** It shares their role gate
+(``require_active_organization_management_access``) and their error family, so a
+route over it stays thin and raises nothing, exactly as
+`organization_guardrail_service` next door does.
+
+**What a rule may watch.** The ceilings whose ``budgets`` row carries this
+organization's id. A budget with a NULL ``organization_id`` is the deployment's
+own, and `entities.Budget` records that the organization-scoped surface never
+lists, offers or repoints one, so a tenant's rule cannot reach it and is not
+meant to. Alerting on those is the deployment operator's plane and is
+deliberately not in this surface; nothing in the schema has to change to add it,
+because the dedupe key is per rule.
+
+**The destination is a credential.** ``slack://`` embeds a bot token,
+``discord://`` a webhook token, ``json://`` optional basic-auth. It is encrypted
+with ``OTARI_SECRET_KEY`` before it is stored and never returned; reads get
+``redact_alert_destination`` output, which masks path segments as well as
+userinfo because Apprise puts its tokens in the path.
+
+**SSRF.** Only the webhook-shaped schemas carry an operator-chosen host, so only
+those are address-checked (:func:`_validate_destination`). The check runs at
+write time, which is a real but partial guarantee: Apprise re-resolves DNS when
+it sends, so a name that was safe when stored can move afterwards. That is the
+same TOCTOU the MCP and web-search write paths carry, and it is why the gate is
+fail-closed by default with a startup-only override
+(``OTARI_ALERT_ALLOW_PRIVATE_HOSTS``) rather than a dashboard toggle.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Final
+from urllib.parse import urlsplit, urlunsplit
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic.json_schema import SkipJsonSchema
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import AlertRule
+from gateway.models.tenancy import User
+from gateway.services.alerts.dispatcher import (
+    UnsupportedAlertDestinationError,
+    parse_destination,
+    send_alert,
+)
+from gateway.services.secret_box import (
+    SecretBoxUnavailableError,
+    SecretDecryptionError,
+    decrypt_secret,
+    encrypt_secret,
+)
+from gateway.services.tenancy.errors import (
+    AlertRuleAlreadyExistsError,
+    AlertRuleInertError,
+    AlertRuleLimitReachedError,
+    AlertRuleNotFoundError,
+    AlertRuleUnsafeDestinationError,
+    AlertRuleUnsupportedDestinationError,
+    SecretBoxUnavailableTenancyError,
+)
+from gateway.services.tenancy.organization_service import OrganizationService
+from gateway.services.url_safety import (
+    ALERT_SCHEME_TRANSPORT,
+    UnsafeURLError,
+    redact_alert_destination,
+    validate_alert_destination_url,
+)
+
+# What one organization may configure. Every rule that matches a crossing is one
+# more outbound send the evaluator's tick waits on, so this is a fan-out bound
+# rather than a storage one, chosen near `MAX_GUARDRAILS_PER_ORGANIZATION` for
+# the same reason: an operator wanting to notify more places than this wants a
+# fan-out service on the other end of one webhook, not ten rules here.
+MAX_ALERT_RULES_PER_ORGANIZATION: Final = 10
+
+_MAX_LIST_LIMIT: Final = 1000
+
+
+class AlertRuleCreate(BaseModel):
+    """Request body for a new alert rule.
+
+    ``destination`` is an Apprise URL. It is validated for parseability at this
+    boundary rather than at send time, so an operator learns their URL is
+    unusable while the form is still open instead of discovering it from an
+    alert that never arrived.
+    """
+
+    # The generated sample would otherwise be ``"destination": "string"``, which
+    # Apprise refuses, and generated samples reach a reader through the OpenAPI
+    # spec and the Postman collection (`CreateSearchToolRequest` carries one for
+    # the same reason).
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "name": "Platform team Slack",
+                "destination": "slack://xoxb-token/C0123456789",
+                "warn_at_percent": 80,
+                "notify_on_exceeded": True,
+            }
+        }
+    )
+
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)] = Field(
+        description="How this rule is identified in the dashboard and in the alert body, unique per organization",
+    )
+    destination: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] = Field(
+        max_length=4096,
+        description=(
+            "Apprise destination URL, for example slack://token/channel, "
+            "discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a "
+            "plain webhook. Encrypted at rest and never returned"
+        ),
+    )
+    warn_at_percent: int | None = Field(
+        default=80,
+        gt=0,
+        lt=100,
+        description=(
+            "Send a warning once a ceiling reaches this percent of any of its limits. "
+            "Null sends no warning, leaving only the exceeded alert"
+        ),
+    )
+    notify_on_exceeded: bool = Field(
+        default=True,
+        description="Send an alert when a ceiling reaches a limit and starts refusing requests",
+    )
+    enabled: bool = Field(default=True, description="False stops this rule sending without discarding it")
+
+    @model_validator(mode="after")
+    def _reject_a_rule_that_can_never_fire(self) -> AlertRuleCreate:
+        """Refuse a rule with no warning threshold and no exceeded alert.
+
+        Storable and meaningless: it would sit in the list looking like
+        configured alerting while being incapable of producing a message. The
+        way to turn a rule off is ``enabled``, which keeps saying what it means.
+        """
+        if self.warn_at_percent is None and not self.notify_on_exceeded:
+            raise ValueError(
+                "A rule must do something: set warn_at_percent, or notify_on_exceeded, or both. "
+                "Use enabled=false to stop a rule without discarding it"
+            )
+        return self
+
+
+class AlertRuleUpdate(BaseModel):
+    """Partial update. Only the fields the caller sets are applied.
+
+    ``destination`` has two states rather than three, unlike the credential
+    fields on `organization_guardrail_service`: the column is NOT NULL, so there
+    is nothing to clear it to. Omit it to keep the stored destination, send a
+    value to replace it.
+
+    ``warn_at_percent`` is the opposite: an explicit ``null`` is meaningful
+    there and means "stop warning, alert only on refusal", so it is the one
+    field here where null is accepted as a value.
+    """
+
+    model_config = ConfigDict(json_schema_extra={"example": {"warn_at_percent": 90, "enabled": False}})
+
+    # ``SkipJsonSchema[None]`` on the fields backing NOT NULL columns, matching
+    # `OrganizationGuardrailUpdate`: ``None`` is this schema's "not sent" marker
+    # and the validator below refuses it as a value, so the published schema
+    # must not advertise ``null`` as accepted or the generated TypeScript client
+    # will tell a caller that ``{"name": null}`` is valid.
+    name: (
+        Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)] | SkipJsonSchema[None]
+    ) = None
+    destination: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)] | SkipJsonSchema[None] = Field(
+        default=None, max_length=4096
+    )
+    warn_at_percent: int | None = Field(default=None, gt=0, lt=100)
+    notify_on_exceeded: bool | SkipJsonSchema[None] = None
+    enabled: bool | SkipJsonSchema[None] = None
+
+    @model_validator(mode="after")
+    def _reject_explicit_nulls(self) -> AlertRuleUpdate:
+        """Refuse an explicit ``null`` for a column that cannot hold one.
+
+        Caught here rather than at the flush for the reason
+        `OrganizationGuardrailUpdate` catches it: a NOT NULL violation arrives
+        as the same ``IntegrityError`` the unique index raises, and the service
+        would report a name collision that never happened.
+
+        ``warn_at_percent`` is deliberately absent from the list: null is a
+        value there, not an omission.
+        """
+        nulled = [
+            field
+            for field in ("name", "destination", "notify_on_exceeded", "enabled")
+            if field in self.model_fields_set and getattr(self, field) is None
+        ]
+        if nulled:
+            raise ValueError(f"{', '.join(nulled)} cannot be null; omit the field to leave it unchanged")
+        return self
+
+
+class AlertRulePublic(BaseModel):
+    """The API-facing shape. Carries the redacted destination, never the real one."""
+
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    name: str
+    # Scheme and host only; see `url_safety.redact_alert_destination`.
+    destination: str
+    warn_at_percent: int | None
+    notify_on_exceeded: bool
+    enabled: bool
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, rule: AlertRule) -> AlertRulePublic:
+        return cls(
+            id=rule.id,
+            organization_id=rule.organization_id,
+            name=rule.name,
+            destination=rule.redacted_destination,
+            warn_at_percent=rule.warn_at_percent,
+            notify_on_exceeded=rule.notify_on_exceeded,
+            enabled=rule.enabled,
+            created_at=rule.created_at.isoformat(),
+            updated_at=rule.updated_at.isoformat(),
+        )
+
+
+class AlertRulesPublic(BaseModel):
+    data: list[AlertRulePublic]
+    count: int
+
+
+class AlertRuleTestResult(BaseModel):
+    """The outcome of one on-demand send.
+
+    ``detail`` carries the dispatcher's reason on failure, which names what went
+    wrong without naming the destination, since the caller already knows which
+    rule they asked about.
+    """
+
+    delivered: bool
+    detail: str | None = None
+
+
+def _transport_url(destination: str) -> str | None:
+    """The http(s) URL a webhook-shaped destination will actually be posted to.
+
+    Returns None for a vendor schema, whose endpoint is compiled into its
+    Apprise plugin and is therefore not an operator-chosen address to check.
+    """
+    parts = urlsplit(destination)
+    transport = ALERT_SCHEME_TRANSPORT.get(parts.scheme.lower())
+    if transport is None:
+        return None
+    return urlunsplit((transport, parts.netloc, parts.path, parts.query, ""))
+
+
+async def _validate_destination(destination: str) -> None:
+    """Refuse a destination Apprise cannot use, or one pointed inside the deployment.
+
+    Two separate checks with two separate errors, because they mean different
+    things to whoever is filling in the form: the first is "this is not a URL I
+    can deliver to", the second is "this is a URL I will not deliver to".
+    """
+    try:
+        parse_destination(destination)
+    except UnsupportedAlertDestinationError as exc:
+        raise AlertRuleUnsupportedDestinationError(str(exc)) from exc
+
+    transport = _transport_url(destination)
+    if transport is None:
+        return
+    try:
+        await validate_alert_destination_url(transport)
+    except UnsafeURLError as exc:
+        raise AlertRuleUnsafeDestinationError(str(exc)) from exc
+
+
+def _encrypted(destination: str) -> str:
+    try:
+        return encrypt_secret(destination)
+    except SecretBoxUnavailableError:
+        raise SecretBoxUnavailableTenancyError("alert rule destinations") from None
+
+
+class OrganizationAlertService:
+    """CRUD for the caller's organization's alert rules. Management-gated throughout."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.organizations = OrganizationService(db)
+
+    async def _manageable_organization_id(self, user: User) -> uuid.UUID:
+        """The caller's organization, having checked they may manage its alerts.
+
+        One gate for reads and writes alike, matching
+        `organization_guardrail_service` rather than the pricing overrides that
+        any member may read: a rule names an external endpoint this gateway
+        posts to, which is the same reason the MCP server list is gated. Where
+        an organization's money goes is not a secret from the people spending
+        it; where its alerts go is not something every member needs.
+        """
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(
+            user=user,
+            organization=organization,
+        )
+        return organization.id
+
+    async def _get_or_404(self, organization_id: uuid.UUID, rule_id: uuid.UUID) -> AlertRule:
+        rule = await self.db.get(AlertRule, rule_id)
+        if rule is None or rule.organization_id != organization_id:
+            raise AlertRuleNotFoundError(rule_id)
+        return rule
+
+    async def list_rules(self, *, user: User, skip: int = 0, limit: int = 100) -> AlertRulesPublic:
+        """One page of the organization's alert rules, and the total."""
+        organization_id = await self._manageable_organization_id(user)
+        limit = min(limit, _MAX_LIST_LIMIT)
+        total = (
+            await self.db.execute(
+                select(func.count()).select_from(AlertRule).where(AlertRule.organization_id == organization_id)
+            )
+        ).scalar_one()
+        rows = list(
+            (
+                await self.db.execute(
+                    select(AlertRule)
+                    .where(AlertRule.organization_id == organization_id)
+                    .order_by(AlertRule.name)
+                    .offset(skip)
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return AlertRulesPublic(data=[AlertRulePublic.from_model(row) for row in rows], count=total)
+
+    async def create_rule(self, *, user: User, request: AlertRuleCreate) -> AlertRulePublic:
+        """Add a rule, encrypting its destination before it is stored."""
+        organization_id = await self._manageable_organization_id(user)
+
+        existing = (
+            await self.db.execute(
+                select(func.count()).select_from(AlertRule).where(AlertRule.organization_id == organization_id)
+            )
+        ).scalar_one()
+        if existing >= MAX_ALERT_RULES_PER_ORGANIZATION:
+            raise AlertRuleLimitReachedError(MAX_ALERT_RULES_PER_ORGANIZATION)
+
+        await _validate_destination(request.destination)
+
+        rule = AlertRule(
+            organization_id=organization_id,
+            name=request.name,
+            encrypted_destination=_encrypted(request.destination),
+            redacted_destination=redact_alert_destination(request.destination),
+            warn_at_percent=request.warn_at_percent,
+            notify_on_exceeded=request.notify_on_exceeded,
+            enabled=request.enabled,
+        )
+        self.db.add(rule)
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            await self.db.rollback()
+            raise AlertRuleAlreadyExistsError(request.name) from exc
+        await self.db.commit()
+        await self.db.refresh(rule)
+        return AlertRulePublic.from_model(rule)
+
+    async def update_rule(self, *, user: User, rule_id: uuid.UUID, request: AlertRuleUpdate) -> AlertRulePublic:
+        """Change a rule's name, destination, thresholds, or enabled flag."""
+        organization_id = await self._manageable_organization_id(user)
+        rule = await self._get_or_404(organization_id, rule_id)
+
+        fields = request.model_fields_set
+        if request.destination is not None:
+            await _validate_destination(request.destination)
+            rule.encrypted_destination = _encrypted(request.destination)
+            rule.redacted_destination = redact_alert_destination(request.destination)
+        if request.name is not None:
+            rule.name = request.name
+        # Read from ``model_fields_set`` rather than from the value, because
+        # null is a meaningful value here and "not sent" is not.
+        if "warn_at_percent" in fields:
+            rule.warn_at_percent = request.warn_at_percent
+        if request.notify_on_exceeded is not None:
+            rule.notify_on_exceeded = request.notify_on_exceeded
+        if request.enabled is not None:
+            rule.enabled = request.enabled
+
+        if rule.warn_at_percent is None and not rule.notify_on_exceeded:
+            # The create body's own rule, re-checked against the merged row: a
+            # PATCH can reach the same dead state by sending only one half.
+            raise AlertRuleInertError()
+
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            await self.db.rollback()
+            raise AlertRuleAlreadyExistsError(request.name) from exc
+        await self.db.commit()
+        await self.db.refresh(rule)
+        return AlertRulePublic.from_model(rule)
+
+    async def delete_rule(self, *, user: User, rule_id: uuid.UUID) -> None:
+        """Discard a rule and its delivery history.
+
+        The ``alert_deliveries`` rows cascade, which is what makes a deleted and
+        recreated rule alert again on a ceiling that is still over its threshold
+        rather than staying silent for the rest of the period.
+        """
+        organization_id = await self._manageable_organization_id(user)
+        rule = await self._get_or_404(organization_id, rule_id)
+        await self.db.delete(rule)
+        await self.db.commit()
+
+    async def test_rule(self, *, user: User, rule_id: uuid.UUID) -> AlertRuleTestResult:
+        """Send a sample alert to this rule's destination now, and report the outcome.
+
+        The counterpart of ``POST /v1/settings/mail/test``, and here for the same
+        reason: a destination that silently accepts nothing is
+        indistinguishable from a budget that never crossed a threshold, so an
+        operator needs a way to prove the delivery path works while they are
+        still setting it up rather than during the incident it was meant to
+        warn about.
+
+        Writes no ``alert_deliveries`` row. A test is not an alert about a
+        ceiling and has no period to dedupe within, and claiming a key here
+        would suppress the real alert it is rehearsing for.
+        """
+        organization_id = await self._manageable_organization_id(user)
+        rule = await self._get_or_404(organization_id, rule_id)
+        try:
+            destination = decrypt_secret(rule.encrypted_destination)
+        except SecretDecryptionError:
+            # Reported as a failed test rather than raised: the caller asked
+            # whether this rule can deliver, and "the stored destination will
+            # not decrypt under the current OTARI_SECRET_KEY" is an answer to
+            # that question, not a server fault.
+            return AlertRuleTestResult(
+                delivered=False,
+                detail="The stored destination could not be decrypted; re-save the rule's destination",
+            )
+        result = await send_alert(
+            destination,
+            title=f"Otari test alert: {rule.name}",
+            body=(
+                f"This is a test of the alert rule '{rule.name}'.\n\n"
+                "If you are reading it, budget alerts for this organization will reach here."
+            ),
+        )
+        return AlertRuleTestResult(delivered=result.delivered, detail=result.detail)

--- a/src/gateway/services/tenancy/organization_alert_service.py
+++ b/src/gateway/services/tenancy/organization_alert_service.py
@@ -1,43 +1,33 @@
 """Organization-scoped alert rules: CRUD, and the on-demand test send.
 
 Where a tenant says how it wants to be told that one of its budgets is running
-out. The rules themselves are acted on by
-:mod:`gateway.services.alerts.evaluator`, which runs on a timer and never
-touches this module; the two meet only at the ``alert_rules`` table.
+out. The rules are acted on by :mod:`gateway.services.alerts.evaluator`, which
+runs on a timer and never touches this module; the two meet at the
+``alert_rules`` table.
 
-**Why this lives with the tenancy services.** It shares their role gate
+Lives with the tenancy services because it shares their role gate
 (``require_active_organization_management_access``) and their error family, so a
-route over it stays thin and raises nothing, exactly as
-`organization_guardrail_service` next door does.
+route over it stays thin and raises nothing.
 
-**What a rule may watch.** The ceilings whose ``budgets`` row carries this
-organization's id. A budget with a NULL ``organization_id`` is the deployment's
-own, and `entities.Budget` records that the organization-scoped surface never
-lists, offers or repoints one, so a tenant's rule cannot reach it and is not
-meant to. Alerting on those is the deployment operator's plane and is
-deliberately not in this surface; nothing in the schema has to change to add it,
-because the dedupe key is per rule.
+A rule watches the ceilings whose ``budgets`` row carries this organization's
+id. A budget with a NULL ``organization_id`` is the deployment's own and is out
+of reach here by design; see `entities.AlertRule`.
 
-**The destination is a credential.** ``slack://`` embeds a bot token,
-``discord://`` a webhook token, ``json://`` optional basic-auth. It is encrypted
-with ``OTARI_SECRET_KEY`` before it is stored and never returned; reads get
+The destination is a credential (``slack://`` embeds a bot token), so it is
+encrypted with ``OTARI_SECRET_KEY`` and never returned. Reads get
 ``redact_alert_destination`` output, which masks path segments as well as
 userinfo because Apprise puts its tokens in the path.
 
-**SSRF.** Only the webhook-shaped schemas carry an operator-chosen host, so only
-those are address-checked (:func:`_validate_destination`). The check runs at
-write time, which is a real but partial guarantee: Apprise re-resolves DNS when
-it sends, so a name that was safe when stored can move afterwards. That is the
-same TOCTOU the MCP and web-search write paths carry, and it is why the gate is
-fail-closed by default with a startup-only override
-(``OTARI_ALERT_ALLOW_PRIVATE_HOSTS``) rather than a dashboard toggle.
+**SSRF.** Otari accepts an allowlist of Apprise schemas, split by whether the
+netloc is an operator-chosen host or a credential; the first group is
+address-checked at write time and the second has no address to check. See
+`url_safety.ALERT_SCHEMES_WITH_OPERATOR_HOST`.
 """
 
 from __future__ import annotations
 
 import uuid
 from typing import Annotated, Final
-from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -69,10 +59,10 @@ from gateway.services.tenancy.errors import (
 )
 from gateway.services.tenancy.organization_service import OrganizationService
 from gateway.services.url_safety import (
-    ALERT_SCHEME_TRANSPORT,
+    SUPPORTED_ALERT_SCHEMES,
     UnsafeURLError,
     redact_alert_destination,
-    validate_alert_destination_url,
+    validate_alert_destination,
 )
 
 # What one organization may configure. Every rule that matches a crossing is one
@@ -116,7 +106,9 @@ class AlertRuleCreate(BaseModel):
         description=(
             "Apprise destination URL, for example slack://token/channel, "
             "discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a "
-            "plain webhook. Encrypted at rest and never returned"
+            "plain webhook. Only the schemas Otari has classified are accepted, because whether the "
+            "URL names a host decides whether the SSRF check applies; a rejection lists them. "
+            "Encrypted at rest and never returned"
         ),
     )
     warn_at_percent: int | None = Field(
@@ -254,36 +246,28 @@ class AlertRuleTestResult(BaseModel):
     detail: str | None = None
 
 
-def _transport_url(destination: str) -> str | None:
-    """The http(s) URL a webhook-shaped destination will actually be posted to.
-
-    Returns None for a vendor schema, whose endpoint is compiled into its
-    Apprise plugin and is therefore not an operator-chosen address to check.
-    """
-    parts = urlsplit(destination)
-    transport = ALERT_SCHEME_TRANSPORT.get(parts.scheme.lower())
-    if transport is None:
-        return None
-    return urlunsplit((transport, parts.netloc, parts.path, parts.query, ""))
-
-
 async def _validate_destination(destination: str) -> None:
-    """Refuse a destination Apprise cannot use, or one pointed inside the deployment.
+    """Refuse a destination Apprise cannot use, one Otari does not accept, or one
+    pointed inside the deployment.
 
-    Two separate checks with two separate errors, because they mean different
-    things to whoever is filling in the form: the first is "this is not a URL I
-    can deliver to", the second is "this is a URL I will not deliver to".
+    Three rejections with two errors, because the first two mean the same thing
+    to whoever is filling in the form ("this is not a destination I can deliver
+    to") and the third means something else ("this is one I will not deliver
+    to").
     """
     try:
-        parse_destination(destination)
+        parsed = parse_destination(destination)
     except UnsupportedAlertDestinationError as exc:
         raise AlertRuleUnsupportedDestinationError(str(exc)) from exc
 
-    transport = _transport_url(destination)
-    if transport is None:
-        return
+    if parsed.scheme not in SUPPORTED_ALERT_SCHEMES:
+        raise AlertRuleUnsupportedDestinationError(
+            f"Otari does not accept {parsed.scheme!r} alert destinations. "
+            f"Supported schemas: {', '.join(sorted(SUPPORTED_ALERT_SCHEMES))}"
+        )
+
     try:
-        await validate_alert_destination_url(transport)
+        await validate_alert_destination(parsed.scheme, parsed.host)
     except UnsafeURLError as exc:
         raise AlertRuleUnsafeDestinationError(str(exc)) from exc
 

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -38,22 +38,65 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urluns
 from gateway.core.config import parse_bool_env
 from gateway.core.env import otari_env
 
-# Apprise schemas whose netloc is a host the operator picked rather than a
-# credential Apprise parses into that position. These are the webhook-shaped
-# ones, and the only ones an SSRF check can meaningfully apply to: every other
-# schema posts to a vendor endpoint compiled into its plugin.
-_HOST_BEARING_ALERT_SCHEMES = frozenset({"json", "jsons", "xml", "xmls", "form", "forms"})
+# Which Apprise schemas Otari accepts as an alert destination, split by what
+# their netloc means.
+#
+# The split is the whole SSRF gate, so it is an allowlist in both directions: a
+# schema nobody has classified is refused rather than assumed safe. The earlier
+# shape here assumed the opposite, and that was wrong in a way that mattered:
+# `mailto://`, `gotify://`, `ntfy://`, `matrix://`, `rocket://` and `mmost://`
+# all dial a host the operator wrote, so treating everything outside the webhook
+# schemas as "posts to a vendor endpoint" let them through unchecked.
+#
+# Adding a schema is one line here plus a note in docs/dashboard.md.
 
-# What each of those maps onto on the wire, so the SSRF gate checks the address
-# Apprise will actually connect to.
-ALERT_SCHEME_TRANSPORT = {
-    "json": "http",
-    "jsons": "https",
-    "xml": "http",
-    "xmls": "https",
-    "form": "http",
-    "forms": "https",
-}
+# The netloc is a host the operator chose, so it is address-checked.
+ALERT_SCHEMES_WITH_OPERATOR_HOST = frozenset(
+    {
+        "apprise",
+        "apprises",
+        "form",
+        "forms",
+        "gotify",
+        "gotifys",
+        "json",
+        "jsons",
+        "mailto",
+        "mailtos",
+        "matrix",
+        "matrixs",
+        "mmost",
+        "mmosts",
+        "ncloud",
+        "nclouds",
+        "ntfy",
+        "rocket",
+        "rockets",
+        "xml",
+        "xmls",
+    }
+)
+
+# The netloc is a credential: the plugin posts to an endpoint compiled into it,
+# so there is no operator-chosen address to check.
+ALERT_SCHEMES_WITH_FIXED_ENDPOINT = frozenset(
+    {
+        "discord",
+        "msteams",
+        "opsgenie",
+        "pagerduty",
+        "pbul",
+        "pover",
+        "ses",
+        "signal",
+        "slack",
+        "sns",
+        "tgram",
+        "twilio",
+    }
+)
+
+SUPPORTED_ALERT_SCHEMES = ALERT_SCHEMES_WITH_OPERATOR_HOST | ALERT_SCHEMES_WITH_FIXED_ENDPOINT
 
 
 def redact_url_secrets(value: str) -> str:
@@ -106,21 +149,16 @@ def redact_url_secrets(value: str) -> str:
 def redact_alert_destination(value: str) -> str:
     """Mask an Apprise destination down to the part that is safe to display.
 
-    Stricter than :func:`redact_url_secrets`, and the difference is the whole
-    reason this exists: Apprise carries credentials in the URL **path**, not
-    only in the userinfo and query. ``slack://botA/botB/botC/#channel`` and
-    ``discord://webhook_id/webhook_token`` are both entirely path, so passing
-    one through :func:`redact_url_secrets` would return the token untouched.
+    Stricter than :func:`redact_url_secrets`, which is why it exists: Apprise
+    carries credentials in the URL **path**, not only in the userinfo and query.
+    ``discord://webhook_id/webhook_token`` is entirely path, so
+    :func:`redact_url_secrets` would return the token untouched.
 
-    Scheme and host survive, because those are what makes a row recognizable in
-    a list ("the Slack one", "the webhook at hooks.internal"). Everything that
-    can carry a secret is replaced wholesale rather than inspected: userinfo,
-    every path segment, and every query value. A vendor schema like ``slack://``
-    parses its first token into the netloc, so that is masked too, which is why
-    the result is ``slack://***`` rather than ``slack://botA``.
-
-    Not reversible and not meant to be: the ciphertext beside it is what the
-    dispatcher reads.
+    Scheme and host survive, because those are what make a row recognizable in a
+    list. Everything that can carry a secret is replaced wholesale: userinfo,
+    every path segment, every query value. A schema whose netloc is a token
+    rather than a host loses that too, so ``slack://botA/botB`` reads
+    ``slack://***``.
     """
     try:
         parts = urlsplit(value)
@@ -130,7 +168,7 @@ def redact_alert_destination(value: str) -> str:
     if not scheme:
         return "***"
 
-    host = parts.hostname if scheme in _HOST_BEARING_ALERT_SCHEMES else None
+    host = parts.hostname if scheme in ALERT_SCHEMES_WITH_OPERATOR_HOST else None
     netloc = host or "***"
     path = "/***" if parts.path.strip("/") else ""
     query = "***" if parts.query else ""
@@ -306,39 +344,33 @@ def _allow_alert_private_hosts() -> bool:
     return otari_env("ALERT_ALLOW_PRIVATE_HOSTS", "false").lower() in {"1", "true", "yes"}
 
 
-async def validate_alert_destination_url(url: str) -> None:
-    """Reject an alert webhook destination that points inside the deployment.
+async def validate_alert_destination(scheme: str, host: str | None) -> None:
+    """Reject an alert destination that points inside the deployment.
 
-    A gate of its own rather than reusing :func:`validate_outbound_fetch_url`,
-    whose override is ``OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS``: an operator
-    turning on private alert destinations must not thereby let the web-search
-    backend fetch internal hosts, and the reverse. The behavior is the same
-    fail-closed shape as the other gates, and the loop itself is shared through
+    Takes the schema and the address Apprise resolved rather than a URL, because
+    only the plugin knows which of the two the netloc was: ``slack://tokA/tokB``
+    parses ``tokA`` into the host slot and it is not one.
+
+    A gate of its own rather than :func:`validate_outbound_fetch_url`, whose
+    override is ``OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS``: an operator turning on
+    private alert destinations must not thereby let the web-search backend fetch
+    internal hosts. The loop itself is shared through
     :func:`_reject_internal_host`.
 
-    Loopback and private ranges are refused by default because the destination
-    is stored through a management API and then posted to by a background
-    worker, which is the shape that turns a configuration surface into an SSRF
-    primitive. The override exists because posting to an internal chat server is
-    a legitimate self-hosted setup, and it is deliberately a startup config flag
-    rather than a dashboard toggle, matching the rule
-    ``services/runtime_settings_service.py`` states about SSRF gates.
+    The check is at write time and Apprise re-resolves when it sends, so this is
+    TOCTOU-vulnerable to rebinding, the same as the MCP and web-search write
+    paths. It is fail-closed by default with a startup-only override
+    (``OTARI_ALERT_ALLOW_PRIVATE_HOSTS``) rather than a dashboard toggle,
+    matching what ``services/runtime_settings_service.py`` says about SSRF gates.
 
-    Only the Apprise schemas that carry an operator-chosen host reach this; see
-    ``services/tenancy/organization_alert_service._validate_destination``.
     Raises :class:`UnsafeURLError` on rejection.
     """
-    parsed = urlparse(url)
-    scheme = parsed.scheme.lower()
-    if scheme not in {"http", "https"}:
-        raise UnsafeURLError(f"alert destination must use http or https, got {scheme!r}")
-    host = parsed.hostname
+    if scheme.lower() in ALERT_SCHEMES_WITH_FIXED_ENDPOINT:
+        return
     if not host:
-        raise UnsafeURLError("alert destination must include a hostname")
-
+        raise UnsafeURLError(f"alert destination {scheme!r} must name a host")
     if _allow_alert_private_hosts():
         return
-
     await _reject_internal_host(host, host_label="alert destination", override_var="OTARI_ALERT_ALLOW_PRIVATE_HOSTS")
 
 

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -38,6 +38,23 @@ from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urluns
 from gateway.core.config import parse_bool_env
 from gateway.core.env import otari_env
 
+# Apprise schemas whose netloc is a host the operator picked rather than a
+# credential Apprise parses into that position. These are the webhook-shaped
+# ones, and the only ones an SSRF check can meaningfully apply to: every other
+# schema posts to a vendor endpoint compiled into its plugin.
+_HOST_BEARING_ALERT_SCHEMES = frozenset({"json", "jsons", "xml", "xmls", "form", "forms"})
+
+# What each of those maps onto on the wire, so the SSRF gate checks the address
+# Apprise will actually connect to.
+ALERT_SCHEME_TRANSPORT = {
+    "json": "http",
+    "jsons": "https",
+    "xml": "http",
+    "xmls": "https",
+    "form": "http",
+    "forms": "https",
+}
+
 
 def redact_url_secrets(value: str) -> str:
     """Mask credentials in a URL while keeping its shape recognizable.
@@ -84,6 +101,40 @@ def redact_url_secrets(value: str) -> str:
     if netloc == parts.netloc and query == parts.query:
         return value
     return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+
+
+def redact_alert_destination(value: str) -> str:
+    """Mask an Apprise destination down to the part that is safe to display.
+
+    Stricter than :func:`redact_url_secrets`, and the difference is the whole
+    reason this exists: Apprise carries credentials in the URL **path**, not
+    only in the userinfo and query. ``slack://botA/botB/botC/#channel`` and
+    ``discord://webhook_id/webhook_token`` are both entirely path, so passing
+    one through :func:`redact_url_secrets` would return the token untouched.
+
+    Scheme and host survive, because those are what makes a row recognizable in
+    a list ("the Slack one", "the webhook at hooks.internal"). Everything that
+    can carry a secret is replaced wholesale rather than inspected: userinfo,
+    every path segment, and every query value. A vendor schema like ``slack://``
+    parses its first token into the netloc, so that is masked too, which is why
+    the result is ``slack://***`` rather than ``slack://botA``.
+
+    Not reversible and not meant to be: the ciphertext beside it is what the
+    dispatcher reads.
+    """
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return "***"
+    scheme = parts.scheme.lower()
+    if not scheme:
+        return "***"
+
+    host = parts.hostname if scheme in _HOST_BEARING_ALERT_SCHEMES else None
+    netloc = host or "***"
+    path = "/***" if parts.path.strip("/") else ""
+    query = "***" if parts.query else ""
+    return urlunsplit((parts.scheme, netloc, path, query, ""))
 
 
 class UnsafeURLError(ValueError):
@@ -249,6 +300,46 @@ async def _reject_internal_host(host: str, *, host_label: str, override_var: str
                 f"{host_label} host {host!r} resolves to {addr} which is {reason}; "
                 f"rejecting to prevent SSRF. Set {override_var}=true to override."
             )
+
+
+def _allow_alert_private_hosts() -> bool:
+    return otari_env("ALERT_ALLOW_PRIVATE_HOSTS", "false").lower() in {"1", "true", "yes"}
+
+
+async def validate_alert_destination_url(url: str) -> None:
+    """Reject an alert webhook destination that points inside the deployment.
+
+    A gate of its own rather than reusing :func:`validate_outbound_fetch_url`,
+    whose override is ``OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS``: an operator
+    turning on private alert destinations must not thereby let the web-search
+    backend fetch internal hosts, and the reverse. The behavior is the same
+    fail-closed shape as the other gates, and the loop itself is shared through
+    :func:`_reject_internal_host`.
+
+    Loopback and private ranges are refused by default because the destination
+    is stored through a management API and then posted to by a background
+    worker, which is the shape that turns a configuration surface into an SSRF
+    primitive. The override exists because posting to an internal chat server is
+    a legitimate self-hosted setup, and it is deliberately a startup config flag
+    rather than a dashboard toggle, matching the rule
+    ``services/runtime_settings_service.py`` states about SSRF gates.
+
+    Only the Apprise schemas that carry an operator-chosen host reach this; see
+    ``services/tenancy/organization_alert_service._validate_destination``.
+    Raises :class:`UnsafeURLError` on rejection.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise UnsafeURLError(f"alert destination must use http or https, got {scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise UnsafeURLError("alert destination must include a hostname")
+
+    if _allow_alert_private_hosts():
+        return
+
+    await _reject_internal_host(host, host_label="alert destination", override_var="OTARI_ALERT_ALLOW_PRIVATE_HOSTS")
 
 
 def _allow_provider_private_hosts() -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -233,6 +233,29 @@ async def async_db(postgres_url: str, clean_database: None) -> AsyncGenerator[As
         await async_engine.dispose()
 
 
+@pytest_asyncio.fixture
+async def async_session_factory(
+    postgres_url: str, clean_database: None
+) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """A factory for *independent* async sessions on the test database.
+
+    For a test that needs more than one session at a time, which ``async_db``
+    cannot give it: the concurrency behavior of anything settled by a unique
+    constraint (the ``alert_deliveries`` claim, say) is invisible inside one
+    session, because two coroutines sharing it serialize on the session rather
+    than on the database.
+
+    Deliberately not ``gateway.core.database.create_session``: that resolves the
+    process-global engine, which these tests never point at the per-worker test
+    database.
+    """
+    async_engine = create_async_engine(_to_async_url(postgres_url), pool_pre_ping=True)
+    try:
+        yield async_sessionmaker(async_engine, expire_on_commit=False)
+    finally:
+        await async_engine.dispose()
+
+
 @pytest.fixture
 def db_session(test_config: GatewayConfig) -> Generator[Session]:
     """Create a standalone DB session for verifying state outside the test client."""

--- a/tests/integration/test_budget_alert_evaluator.py
+++ b/tests/integration/test_budget_alert_evaluator.py
@@ -1,0 +1,496 @@
+"""The budget alert evaluator: what crosses, what fires, and what fires only once.
+
+The dedupe cases carry this file. A crossed threshold stays crossed for the rest
+of the budget period and every refresher in ``gateway.main`` runs once per
+worker, so "alert once" is not a property of the evaluator's control flow but of
+the unique constraint on ``alert_deliveries``. That is why
+``test_two_concurrent_passes_send_exactly_one`` exists and why it needs a real
+PostgreSQL rather than a unit test with a fake session.
+
+``send_alert`` is stubbed throughout. What is under test is which alerts are
+produced and how many times, never whether Apprise can reach Slack.
+"""
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from gateway.models.entities import AlertDelivery, AlertRule, Budget, ScopedBudget
+from gateway.models.tenancy import Organization
+from gateway.repositories.tenancy import OrganizationRepository
+from gateway.services.alerts.dispatcher import AlertDispatchResult
+from gateway.services.alerts.evaluator import (
+    KIND_EXCEEDED,
+    KIND_WARNING,
+    evaluate_budget_alerts,
+    purge_delivered_before,
+)
+from gateway.services.secret_box import encrypt_secret, generate_secret_key
+from gateway.services.url_safety import redact_alert_destination
+
+pytestmark = pytest.mark.asyncio
+
+DESTINATION = "slack://xoxb-AAA/xoxb-BBB/xoxb-CCC/#alerts"
+PERIOD_START = datetime(2026, 9, 1, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    yield
+
+
+@pytest.fixture
+def sent(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Capture what the evaluator would have delivered, and report success."""
+    captured: list[tuple[str, str]] = []
+
+    async def _capture(destination: str, *, title: str, body: str) -> AlertDispatchResult:
+        captured.append((title, body))
+        return AlertDispatchResult(delivered=True)
+
+    monkeypatch.setattr("gateway.services.alerts.evaluator.send_alert", _capture)
+    return captured
+
+
+@pytest.fixture
+def failing_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A destination that refuses, so the delivery row's failure path is exercised."""
+
+    async def _fail(destination: str, *, title: str, body: str) -> AlertDispatchResult:
+        return AlertDispatchResult(delivered=False, detail="Delivery failed (RuntimeError)")
+
+    monkeypatch.setattr("gateway.services.alerts.evaluator.send_alert", _fail)
+
+
+async def _organization(db: AsyncSession, *, slug: str = "acme") -> Organization:
+    return await OrganizationRepository(db).create_organization(name=slug.title(), slug=slug, created_by_user_id=None)
+
+
+async def _rule(
+    db: AsyncSession,
+    organization: Organization | None,
+    *,
+    name: str = "Platform Slack",
+    warn_at_percent: int | None = 80,
+    notify_on_exceeded: bool = True,
+    enabled: bool = True,
+) -> AlertRule:
+    assert organization is not None
+    rule = AlertRule(
+        organization_id=organization.id,
+        name=name,
+        encrypted_destination=encrypt_secret(DESTINATION),
+        redacted_destination=redact_alert_destination(DESTINATION),
+        warn_at_percent=warn_at_percent,
+        notify_on_exceeded=notify_on_exceeded,
+        enabled=enabled,
+    )
+    db.add(rule)
+    await db.commit()
+    await db.refresh(rule)
+    return rule
+
+
+async def _ceiling(
+    db: AsyncSession,
+    organization: Organization | None,
+    *,
+    max_budget: Decimal | None = Decimal(100),
+    token_limit: int | None = None,
+    request_limit: int | None = None,
+    spend: Decimal = Decimal(0),
+    reserved: Decimal = Decimal(0),
+    tokens: int = 0,
+    requests: int = 0,
+    period_start: datetime | None = PERIOD_START,
+    budget_name: str = "Team cap",
+) -> ScopedBudget:
+    """One ceiling on a budget owned by ``organization`` (or by nobody, when None)."""
+    budget = Budget(
+        budget_id=str(uuid.uuid4()),
+        name=budget_name,
+        organization_id=organization.id if organization is not None else None,
+        max_budget=max_budget,
+        token_limit=token_limit,
+        request_limit=request_limit,
+    )
+    db.add(budget)
+    await db.flush()
+    ceiling = ScopedBudget(
+        id=str(uuid.uuid4()),
+        scope_type="workspace",
+        scope_id=str(uuid.uuid4()),
+        budget_id=budget.budget_id,
+        current_spend=spend,
+        reserved_spend=reserved,
+        current_tokens=tokens,
+        current_requests=requests,
+        period_start=period_start,
+        period_end=(period_start + timedelta(days=30)) if period_start else None,
+    )
+    db.add(ceiling)
+    await db.commit()
+    await db.refresh(ceiling)
+    return ceiling
+
+
+async def _deliveries(db: AsyncSession) -> list[AlertDelivery]:
+    rows = (await db.execute(select(AlertDelivery).order_by(AlertDelivery.created_at))).scalars().all()
+    return list(rows)
+
+
+# --------------------------------------------------------------------------
+# What fires
+# --------------------------------------------------------------------------
+
+
+async def test_a_warning_fires_at_the_threshold(async_db: AsyncSession, sent: list[tuple[str, str]]) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(80))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    (title, body) = sent[0]
+    assert "warning" in title.lower()
+    assert "80%" in title
+    assert "Team cap" in title
+    assert "$80.00 of $100.00" in body
+
+    rows = await _deliveries(async_db)
+    assert [row.kind for row in rows] == [KIND_WARNING]
+    assert rows[0].delivered is True
+
+
+async def test_nothing_fires_below_the_threshold(async_db: AsyncSession, sent: list[tuple[str, str]]) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(79))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert sent == []
+    assert await _deliveries(async_db) == []
+
+
+async def test_reaching_the_cap_fires_exceeded_not_a_warning(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """Exceeded is the more urgent and strictly more informative of the two."""
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(100))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert "exceeded" in sent[0][0].lower()
+    assert [row.kind for row in await _deliveries(async_db)] == [KIND_EXCEEDED]
+
+
+async def test_a_reservation_counts_toward_utilization(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """Matching the gate in ``scoped_budget_service.reserve``.
+
+    A ceiling holding 85 of a 100 cap is already refusing arrivals, so reporting
+    it as 10 percent used would be a warning that never arrives in time.
+    """
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(10), reserved=Decimal(75))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert "85%" in sent[0][0]
+
+
+async def test_a_token_capped_budget_alerts_on_tokens(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """A budget need not cap dollars at all."""
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, max_budget=None, token_limit=1000, tokens=900)
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert "90%" in sent[0][0]
+    assert "900 of 1,000 (tokens)" in sent[0][1]
+
+
+async def test_the_axis_closest_to_refusing_is_the_one_reported(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(
+        async_db,
+        organization,
+        max_budget=Decimal(100),
+        spend=Decimal(10),
+        token_limit=1000,
+        tokens=950,
+    )
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert "(tokens)" in sent[0][1]
+
+
+async def test_a_ceiling_capping_nothing_never_alerts(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, max_budget=None, spend=Decimal(10_000))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert sent == []
+
+
+async def test_a_disabled_rule_sends_nothing(async_db: AsyncSession, sent: list[tuple[str, str]]) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization, enabled=False)
+    await _ceiling(async_db, organization, spend=Decimal(100))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert await _deliveries(async_db) == []
+
+
+async def test_a_rule_that_only_wants_the_refusal_stays_quiet_at_80(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    organization = await _organization(async_db)
+    await _rule(async_db, organization, warn_at_percent=None)
+    await _ceiling(async_db, organization, spend=Decimal(90))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+
+
+async def test_no_rules_at_all_is_one_cheap_query(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """The common case for every deployment that has not configured an alert."""
+    organization = await _organization(async_db)
+    await _ceiling(async_db, organization, spend=Decimal(100))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert sent == []
+
+
+# --------------------------------------------------------------------------
+# Tenant scoping
+# --------------------------------------------------------------------------
+
+
+async def test_a_deployment_owned_budget_is_never_alerted_on(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """The documented gap of the organization-scoped design, asserted deliberately.
+
+    ``Budget.organization_id`` NULL means the deployment's own, and the
+    organization-scoped surface never lists, offers or repoints one. A tenant's
+    rule therefore cannot reach it. Deployment-wide rules are a follow-up; this
+    test is here so the gap is a decision rather than a surprise.
+    """
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, None, spend=Decimal(100))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert sent == []
+
+
+async def test_a_rule_never_sees_another_organizations_ceiling(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    first = await _organization(async_db, slug="acme")
+    second = await _organization(async_db, slug="globex")
+    await _rule(async_db, first)
+    await _ceiling(async_db, second, spend=Decimal(100), budget_name="Their cap")
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert sent == []
+
+
+async def test_each_organizations_rule_gets_its_own_ceiling(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    first = await _organization(async_db, slug="acme")
+    second = await _organization(async_db, slug="globex")
+    await _rule(async_db, first, name="Acme")
+    await _rule(async_db, second, name="Globex")
+    await _ceiling(async_db, first, spend=Decimal(100), budget_name="Acme cap")
+    await _ceiling(async_db, second, spend=Decimal(100), budget_name="Globex cap")
+
+    assert await evaluate_budget_alerts(async_db) == 2
+    subjects = {title for title, _ in sent}
+    assert any("Acme cap" in s for s in subjects)
+    assert any("Globex cap" in s for s in subjects)
+
+
+# --------------------------------------------------------------------------
+# Dedupe: the load-bearing behavior
+# --------------------------------------------------------------------------
+
+
+async def test_a_second_pass_sends_nothing(async_db: AsyncSession, sent: list[tuple[str, str]]) -> None:
+    """A crossed threshold stays crossed, so state alone would re-alert forever."""
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(85))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert len(sent) == 1
+    assert len(await _deliveries(async_db)) == 1
+
+
+async def test_crossing_from_warning_into_exceeded_sends_the_refusal_too(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """Separate dedupe keys, so the escalation is not suppressed by the warning."""
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    ceiling = await _ceiling(async_db, organization, spend=Decimal(85))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+
+    ceiling.current_spend = Decimal(100)
+    await async_db.commit()
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert {row.kind for row in await _deliveries(async_db)} == {KIND_WARNING, KIND_EXCEEDED}
+
+
+async def test_a_new_period_re_arms_the_alert(async_db: AsyncSession, sent: list[tuple[str, str]]) -> None:
+    """``period_start`` is in the dedupe key, so a reset needs no cleanup."""
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    ceiling = await _ceiling(async_db, organization, spend=Decimal(85))
+
+    assert await evaluate_budget_alerts(async_db) == 1
+
+    # The period rolls: counters zero, window moves, spend climbs again.
+    ceiling.period_start = PERIOD_START + timedelta(days=30)
+    ceiling.period_end = PERIOD_START + timedelta(days=60)
+    ceiling.current_spend = Decimal(85)
+    await async_db.commit()
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert len(sent) == 2
+    assert len(await _deliveries(async_db)) == 2
+
+
+async def test_a_periodless_ceiling_still_alerts_only_once(
+    async_db: AsyncSession, sent: list[tuple[str, str]]
+) -> None:
+    """The partial unique index, not the constraint, is what dedupes a NULL period.
+
+    PostgreSQL treats two NULL ``period_start`` values as distinct, so without
+    the partial index a never-rolling ceiling would alert on every tick forever.
+    """
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(85), period_start=None)
+
+    assert await evaluate_budget_alerts(async_db) == 1
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert len(await _deliveries(async_db)) == 1
+
+
+async def test_two_concurrent_passes_send_exactly_one(
+    async_db: AsyncSession,
+    sent: list[tuple[str, str]],
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The multi-worker case: N workers, one alert.
+
+    Every refresher in ``gateway.main`` runs once per worker, so this is the
+    real deployment shape rather than a hypothetical. Four independent sessions
+    stand in for four workers; the claim insert is the only thing serializing
+    them, which is exactly what is being asserted.
+
+    The sessions come from ``async_session_factory`` rather than from
+    ``async_db``: four coroutines sharing one session would serialize on the
+    session and prove nothing about the constraint.
+    """
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(85))
+
+    async def _pass() -> int:
+        async with async_session_factory() as db:
+            return await evaluate_budget_alerts(db)
+
+    results = await asyncio.gather(_pass(), _pass(), _pass(), _pass())
+
+    assert sum(results) == 1, f"expected exactly one alert across concurrent passes, got {results}"
+    total = (await async_db.execute(select(func.count()).select_from(AlertDelivery))).scalar_one()
+    assert total == 1
+    assert len(sent) == 1
+
+
+# --------------------------------------------------------------------------
+# Failure recording and retention
+# --------------------------------------------------------------------------
+
+
+async def test_a_failed_send_is_recorded_and_not_retried(
+    async_db: AsyncSession, failing_send: None
+) -> None:
+    """The claim is committed before the send, so a failure still consumes the key.
+
+    Deliberate: retrying a dead destination on every tick for the rest of the
+    period would turn one misconfiguration into a permanent load. The row
+    carries the reason so an operator can see what happened.
+    """
+    organization = await _organization(async_db)
+    await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(85))
+
+    assert await evaluate_budget_alerts(async_db) == 0
+
+    rows = await _deliveries(async_db)
+    assert len(rows) == 1
+    assert rows[0].delivered is False
+    assert "RuntimeError" in (rows[0].detail or "")
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    assert len(await _deliveries(async_db)) == 1
+
+
+async def test_a_destination_that_will_not_decrypt_is_recorded(
+    async_db: AsyncSession, sent: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rotated OTARI_SECRET_KEY must not crash the periodic worker."""
+    organization = await _organization(async_db)
+    rule = await _rule(async_db, organization)
+    await _ceiling(async_db, organization, spend=Decimal(85))
+
+    rule.encrypted_destination = "not-a-valid-fernet-token"
+    await async_db.commit()
+
+    assert await evaluate_budget_alerts(async_db) == 0
+    rows = await _deliveries(async_db)
+    assert len(rows) == 1
+    assert rows[0].delivered is False
+    assert "decrypt" in (rows[0].detail or "")
+    assert sent == []
+
+
+async def test_purge_drops_only_the_old_rows(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    rule = await _rule(async_db, organization)
+
+    old = AlertDelivery(alert_rule_id=rule.id, scoped_budget_id="a", kind=KIND_WARNING)
+    old.created_at = datetime.now(UTC) - timedelta(days=200)
+    recent = AlertDelivery(alert_rule_id=rule.id, scoped_budget_id="b", kind=KIND_WARNING)
+    async_db.add_all([old, recent])
+    await async_db.commit()
+
+    purged = await purge_delivered_before(async_db, older_than=datetime.now(UTC) - timedelta(days=90))
+    assert purged == 1
+    assert [row.scoped_budget_id for row in await _deliveries(async_db)] == ["b"]

--- a/tests/integration/test_organization_alerts.py
+++ b/tests/integration/test_organization_alerts.py
@@ -261,7 +261,11 @@ async def test_an_unparseable_destination_is_refused(async_db: AsyncSession) -> 
         # and every one of them used to skip the gate: the earlier split checked
         # the webhook schemas and assumed everything else posted to a vendor
         # endpoint compiled into its plugin.
-        "mailto://user:pw@10.0.0.5",
+        #
+        # ``mailto`` belongs to this group and is not here: Apprise's mail plugin
+        # refuses an IP-literal host before the gate is reached, and a hostname
+        # would make the case depend on runner DNS. Its classification is covered
+        # in ``tests/unit/test_url_safety.py`` instead.
         "gotify://192.168.1.9/token",
         "ntfy://169.254.169.254/topic",
         "matrixs://user:pw@127.0.0.1/",

--- a/tests/integration/test_organization_alerts.py
+++ b/tests/integration/test_organization_alerts.py
@@ -10,12 +10,15 @@ Webhook destinations here use IP literals in public ranges, or are rejected
 before any lookup happens. ``validate_alert_destination_url`` resolves a
 hostname through DNS, so a test naming one would pass or fail on whether the
 runner has egress.
+
+The pure request-body validation cases live in
+``tests/unit/test_alert_rule_schemas.py`` instead: they need no database, and
+keeping them here made them unrunnable on a machine without Docker.
 """
 
 from collections.abc import Iterator
 
 import pytest
-from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -347,15 +350,23 @@ async def test_a_null_warn_threshold_clears_the_warning(async_db: AsyncSession) 
     assert updated.notify_on_exceeded is True
 
 
-async def test_a_rule_that_could_never_fire_is_refused_at_create() -> None:
-    """No warning and no exceeded alert is storable and meaningless."""
-    with pytest.raises(ValidationError):
-        AlertRuleCreate(
-            name="Inert",
-            destination=SLACK_DESTINATION,
-            warn_at_percent=None,
-            notify_on_exceeded=False,
-        )
+async def test_a_rule_created_with_no_warning_keeps_it_null(async_db: AsyncSession) -> None:
+    """The service must store an explicit null rather than the schema's 80.
+
+    The end-to-end form of the bug ``warn_at_percent``'s model comment
+    describes: a column default fired on the explicit None and handed the
+    operator the early warnings they had just declined.
+    ``tests/unit/test_alert_rule_schemas.py`` guards the column itself.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create(warn_at_percent=None))
+    assert created.warn_at_percent is None
+
+    row = (await async_db.execute(select(AlertRule).where(AlertRule.id == created.id))).scalar_one()
+    assert row.warn_at_percent is None
 
 
 async def test_a_patch_cannot_reach_the_inert_state_either(async_db: AsyncSession) -> None:
@@ -373,17 +384,3 @@ async def test_a_patch_cannot_reach_the_inert_state_either(async_db: AsyncSessio
         await service.update_rule(
             user=owner, rule_id=created.id, request=AlertRuleUpdate(notify_on_exceeded=False)
         )
-
-
-@pytest.mark.parametrize("field", ["name", "destination", "notify_on_exceeded", "enabled"])
-async def test_an_explicit_null_is_refused_for_a_not_null_column(field: str) -> None:
-    """Caught in the schema so a NOT NULL violation is never reported as a name collision."""
-    with pytest.raises(ValidationError):
-        AlertRuleUpdate.model_validate({field: None})
-
-
-@pytest.mark.parametrize("percent", [0, 100, 101, -1])
-async def test_the_warn_threshold_stays_inside_its_range(percent: int) -> None:
-    """0 and 100 are both meaningless: one always fires, the other is the refusal."""
-    with pytest.raises(ValidationError):
-        AlertRuleCreate(name="Bad", destination=SLACK_DESTINATION, warn_at_percent=percent)

--- a/tests/integration/test_organization_alerts.py
+++ b/tests/integration/test_organization_alerts.py
@@ -1,0 +1,389 @@
+"""Organization alert rules: CRUD, authorization, tenant isolation, and the SSRF gate.
+
+Exercised at the service layer, matching `test_organization_guardrails.py`: the
+API can only ever act as the one bootstrap operator identity a standalone
+deployment has, who is always an owner, so the rules that matter most (a plain
+member refused, another organization's rule invisible) are only reachable by
+calling the service with identities built at whatever role a case needs.
+
+Webhook destinations here use IP literals in public ranges, or are rejected
+before any lookup happens. ``validate_alert_destination_url`` resolves a
+hostname through DNS, so a test naming one would pass or fail on whether the
+runner has egress.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import AlertDelivery, AlertRule
+from gateway.models.tenancy import Organization, User
+from gateway.repositories.tenancy import OrganizationMemberRepository, OrganizationRepository, UserRepository
+from gateway.services.secret_box import decrypt_secret, generate_secret_key
+from gateway.services.tenancy.errors import (
+    AlertRuleAlreadyExistsError,
+    AlertRuleInertError,
+    AlertRuleLimitReachedError,
+    AlertRuleNotFoundError,
+    AlertRuleUnsafeDestinationError,
+    AlertRuleUnsupportedDestinationError,
+    NotAuthorizedError,
+)
+from gateway.services.tenancy.organization_alert_service import (
+    MAX_ALERT_RULES_PER_ORGANIZATION,
+    AlertRuleCreate,
+    AlertRuleUpdate,
+    OrganizationAlertService,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# A vendor schema: its endpoint is compiled into the Apprise plugin, so storing
+# one never reaches the address check and never touches DNS.
+SLACK_DESTINATION = "slack://xoxb-AAA/xoxb-BBB/xoxb-CCC/#alerts"
+# A public IP literal, so the address check resolves nothing.
+PUBLIC_WEBHOOK = "jsons://93.184.216.34/incoming/hook"
+
+
+async def _organization(db: AsyncSession, *, slug: str = "acme") -> Organization:
+    return await OrganizationRepository(db).create_organization(name=slug.title(), slug=slug, created_by_user_id=None)
+
+
+async def _member(db: AsyncSession, organization: Organization, *, role: str, full_name: str) -> User:
+    user = await UserRepository(db).create_local_identity(
+        full_name=full_name,
+        active_organization_id=organization.id,
+    )
+    await OrganizationMemberRepository(db).create_membership(
+        organization_id=organization.id, user_id=user.id, role=role
+    )
+    return user
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    yield
+
+
+def _create(**overrides: object) -> AlertRuleCreate:
+    fields: dict[str, object] = {"name": "Platform Slack", "destination": SLACK_DESTINATION}
+    fields.update(overrides)
+    return AlertRuleCreate(**fields)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# CRUD
+# --------------------------------------------------------------------------
+
+
+async def test_crud_round_trip(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+    assert created.name == "Platform Slack"
+    assert created.warn_at_percent == 80
+    assert created.notify_on_exceeded is True
+    assert created.enabled is True
+
+    listed = await service.list_rules(user=owner)
+    assert listed.count == 1
+    assert [rule.id for rule in listed.data] == [created.id]
+
+    updated = await service.update_rule(
+        user=owner, rule_id=created.id, request=AlertRuleUpdate(warn_at_percent=95, enabled=False)
+    )
+    assert updated.warn_at_percent == 95
+    assert updated.enabled is False
+
+    await service.delete_rule(user=owner, rule_id=created.id)
+    assert (await service.list_rules(user=owner)).count == 0
+
+
+async def test_the_destination_is_encrypted_and_never_returned(async_db: AsyncSession) -> None:
+    """The stored row holds ciphertext; the API shape holds only the redaction.
+
+    The single most important assertion in this file: an Apprise URL is a live
+    bot token, and a rule list is readable by every owner and admin of the
+    organization.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+
+    row = (await async_db.execute(select(AlertRule).where(AlertRule.id == created.id))).scalar_one()
+    assert SLACK_DESTINATION not in row.encrypted_destination
+    assert decrypt_secret(row.encrypted_destination) == SLACK_DESTINATION
+
+    # Neither the returned shape nor the stored redaction carries any token.
+    for value in (created.destination, row.redacted_destination):
+        assert "xoxb-AAA" not in value
+        assert "xoxb-BBB" not in value
+        assert "xoxb-CCC" not in value
+        assert value.startswith("slack://")
+
+
+async def test_one_rule_name_per_organization(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    await service.create_rule(user=owner, request=_create(name="Duplicate"))
+    with pytest.raises(AlertRuleAlreadyExistsError):
+        await service.create_rule(user=owner, request=_create(name="Duplicate"))
+
+
+async def test_the_same_name_is_free_in_another_organization(async_db: AsyncSession) -> None:
+    """The uniqueness is per organization, not deployment-wide."""
+    first = await _organization(async_db, slug="acme")
+    second = await _organization(async_db, slug="globex")
+    owner_a = await _member(async_db, first, role="owner", full_name="A")
+    owner_b = await _member(async_db, second, role="owner", full_name="B")
+    service = OrganizationAlertService(async_db)
+
+    await service.create_rule(user=owner_a, request=_create(name="Shared"))
+    assert await service.create_rule(user=owner_b, request=_create(name="Shared"))
+
+
+async def test_the_rule_limit_is_enforced(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    for index in range(MAX_ALERT_RULES_PER_ORGANIZATION):
+        await service.create_rule(user=owner, request=_create(name=f"Rule {index}"))
+    with pytest.raises(AlertRuleLimitReachedError):
+        await service.create_rule(user=owner, request=_create(name="One too many"))
+
+
+async def test_deleting_a_rule_discards_its_deliveries(async_db: AsyncSession) -> None:
+    """The cascade is what re-arms an alert when a rule is recreated."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+    async_db.add(AlertDelivery(alert_rule_id=created.id, scoped_budget_id="ceiling-1", kind="warning"))
+    await async_db.commit()
+
+    await service.delete_rule(user=owner, rule_id=created.id)
+    remaining = (
+        await async_db.execute(select(AlertDelivery).where(AlertDelivery.alert_rule_id == created.id))
+    ).scalars().all()
+    assert list(remaining) == []
+
+
+# --------------------------------------------------------------------------
+# Authorization and tenant isolation
+# --------------------------------------------------------------------------
+
+
+async def test_a_plain_member_may_not_read_or_write(async_db: AsyncSession) -> None:
+    """One gate for reads and writes: a rule names an endpoint this gateway posts to."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    member = await _member(async_db, organization, role="member", full_name="Member")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+
+    with pytest.raises(NotAuthorizedError):
+        await service.list_rules(user=member)
+    with pytest.raises(NotAuthorizedError):
+        await service.create_rule(user=member, request=_create(name="Sneaky"))
+    with pytest.raises(NotAuthorizedError):
+        await service.update_rule(user=member, rule_id=created.id, request=AlertRuleUpdate(enabled=False))
+    with pytest.raises(NotAuthorizedError):
+        await service.delete_rule(user=member, rule_id=created.id)
+    with pytest.raises(NotAuthorizedError):
+        await service.test_rule(user=member, rule_id=created.id)
+
+
+async def test_an_admin_may_manage_rules(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    admin = await _member(async_db, organization, role="admin", full_name="Admin")
+    service = OrganizationAlertService(async_db)
+    assert await service.create_rule(user=admin, request=_create())
+
+
+async def test_another_organizations_rule_is_not_found(async_db: AsyncSession) -> None:
+    """404 rather than 403, so the id is not an existence oracle across tenants."""
+    first = await _organization(async_db, slug="acme")
+    second = await _organization(async_db, slug="globex")
+    owner_a = await _member(async_db, first, role="owner", full_name="A")
+    owner_b = await _member(async_db, second, role="owner", full_name="B")
+    service = OrganizationAlertService(async_db)
+
+    theirs = await service.create_rule(user=owner_a, request=_create())
+
+    with pytest.raises(AlertRuleNotFoundError):
+        await service.update_rule(user=owner_b, rule_id=theirs.id, request=AlertRuleUpdate(enabled=False))
+    with pytest.raises(AlertRuleNotFoundError):
+        await service.delete_rule(user=owner_b, rule_id=theirs.id)
+    with pytest.raises(AlertRuleNotFoundError):
+        await service.test_rule(user=owner_b, rule_id=theirs.id)
+    # And it does not appear in their list at all.
+    assert (await service.list_rules(user=owner_b)).count == 0
+
+
+# --------------------------------------------------------------------------
+# Destination validation and the SSRF gate
+# --------------------------------------------------------------------------
+
+
+async def test_an_unparseable_destination_is_refused(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    with pytest.raises(AlertRuleUnsupportedDestinationError):
+        await service.create_rule(user=owner, request=_create(destination="definitelynotascheme://host"))
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "json://127.0.0.1/hook",
+        "json://10.0.0.5/hook",
+        "jsons://192.168.1.10/hook",
+        "json://169.254.169.254/latest/meta-data",
+    ],
+)
+async def test_a_webhook_pointed_inside_the_deployment_is_refused(
+    async_db: AsyncSession, destination: str
+) -> None:
+    """Fail-closed by default. The cloud metadata endpoint is the case that matters."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    with pytest.raises(AlertRuleUnsafeDestinationError):
+        await service.create_rule(user=owner, request=_create(destination=destination))
+
+
+async def test_a_public_webhook_is_accepted(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+    assert await service.create_rule(user=owner, request=_create(destination=PUBLIC_WEBHOOK))
+
+
+async def test_a_vendor_schema_skips_the_address_check(async_db: AsyncSession) -> None:
+    """A slack:// URL's first token parses into the netloc and is not a host.
+
+    Address-checking it would reject a perfectly good rule (and, worse, could
+    resolve a token as a hostname), which is why only the webhook-shaped
+    schemas are checked.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+    assert await service.create_rule(user=owner, request=_create(destination="slack://10/0/0/1"))
+
+
+async def test_the_private_host_override_opens_the_gate(
+    async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The self-hosted case: an internal chat server on the deployment's network."""
+    monkeypatch.setenv("OTARI_ALERT_ALLOW_PRIVATE_HOSTS", "true")
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+    assert await service.create_rule(user=owner, request=_create(destination="json://10.0.0.5/hook"))
+
+
+async def test_the_web_search_override_does_not_open_the_alert_gate(
+    async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each SSRF gate has its own override; turning one on must not widen another."""
+    monkeypatch.setenv("OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS", "true")
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    with pytest.raises(AlertRuleUnsafeDestinationError):
+        await service.create_rule(user=owner, request=_create(destination="json://10.0.0.5/hook"))
+
+
+# --------------------------------------------------------------------------
+# Update semantics
+# --------------------------------------------------------------------------
+
+
+async def test_an_omitted_destination_keeps_the_stored_one(async_db: AsyncSession) -> None:
+    """The column is NOT NULL, so omission is the only "leave it alone" state."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+    await service.update_rule(user=owner, rule_id=created.id, request=AlertRuleUpdate(name="Renamed"))
+
+    row = (await async_db.execute(select(AlertRule).where(AlertRule.id == created.id))).scalar_one()
+    assert decrypt_secret(row.encrypted_destination) == SLACK_DESTINATION
+    assert row.name == "Renamed"
+
+
+async def test_a_null_warn_threshold_clears_the_warning(async_db: AsyncSession) -> None:
+    """The one field where an explicit null is a value rather than an omission."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create())
+    updated = await service.update_rule(
+        user=owner,
+        rule_id=created.id,
+        request=AlertRuleUpdate.model_validate({"warn_at_percent": None}),
+    )
+    assert updated.warn_at_percent is None
+    assert updated.notify_on_exceeded is True
+
+
+async def test_a_rule_that_could_never_fire_is_refused_at_create() -> None:
+    """No warning and no exceeded alert is storable and meaningless."""
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(
+            name="Inert",
+            destination=SLACK_DESTINATION,
+            warn_at_percent=None,
+            notify_on_exceeded=False,
+        )
+
+
+async def test_a_patch_cannot_reach_the_inert_state_either(async_db: AsyncSession) -> None:
+    """The create body's rule, re-checked on the merged row.
+
+    A PATCH can reach the dead state by sending only one of the two halves,
+    which is why the check lives in the service as well as in the schema.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    created = await service.create_rule(user=owner, request=_create(warn_at_percent=None))
+    with pytest.raises(AlertRuleInertError):
+        await service.update_rule(
+            user=owner, rule_id=created.id, request=AlertRuleUpdate(notify_on_exceeded=False)
+        )
+
+
+@pytest.mark.parametrize("field", ["name", "destination", "notify_on_exceeded", "enabled"])
+async def test_an_explicit_null_is_refused_for_a_not_null_column(field: str) -> None:
+    """Caught in the schema so a NOT NULL violation is never reported as a name collision."""
+    with pytest.raises(ValidationError):
+        AlertRuleUpdate.model_validate({field: None})
+
+
+@pytest.mark.parametrize("percent", [0, 100, 101, -1])
+async def test_the_warn_threshold_stays_inside_its_range(percent: int) -> None:
+    """0 and 100 are both meaningless: one always fires, the other is the refusal."""
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(name="Bad", destination=SLACK_DESTINATION, warn_at_percent=percent)

--- a/tests/integration/test_organization_alerts.py
+++ b/tests/integration/test_organization_alerts.py
@@ -7,7 +7,7 @@ member refused, another organization's rule invisible) are only reachable by
 calling the service with identities built at whatever role a case needs.
 
 Webhook destinations here use IP literals in public ranges, or are rejected
-before any lookup happens. ``validate_alert_destination_url`` resolves a
+before any lookup happens. ``validate_alert_destination`` resolves a
 hostname through DNS, so a test naming one would pass or fail on whether the
 runner has egress.
 
@@ -257,9 +257,19 @@ async def test_an_unparseable_destination_is_refused(async_db: AsyncSession) -> 
         "json://10.0.0.5/hook",
         "jsons://192.168.1.10/hook",
         "json://169.254.169.254/latest/meta-data",
+        # The self-hosted schemas. Every one of these dials the host in the URL,
+        # and every one of them used to skip the gate: the earlier split checked
+        # the webhook schemas and assumed everything else posted to a vendor
+        # endpoint compiled into its plugin.
+        "mailto://user:pw@10.0.0.5",
+        "gotify://192.168.1.9/token",
+        "ntfy://169.254.169.254/topic",
+        "matrixs://user:pw@127.0.0.1/",
+        "rocket://user:pw@10.1.2.3/#channel",
+        "mmost://10.0.0.7/token",
     ],
 )
-async def test_a_webhook_pointed_inside_the_deployment_is_refused(
+async def test_a_destination_pointed_inside_the_deployment_is_refused(
     async_db: AsyncSession, destination: str
 ) -> None:
     """Fail-closed by default. The cloud metadata endpoint is the case that matters."""
@@ -278,17 +288,34 @@ async def test_a_public_webhook_is_accepted(async_db: AsyncSession) -> None:
     assert await service.create_rule(user=owner, request=_create(destination=PUBLIC_WEBHOOK))
 
 
-async def test_a_vendor_schema_skips_the_address_check(async_db: AsyncSession) -> None:
+async def test_a_fixed_endpoint_schema_skips_the_address_check(async_db: AsyncSession) -> None:
     """A slack:// URL's first token parses into the netloc and is not a host.
 
-    Address-checking it would reject a perfectly good rule (and, worse, could
-    resolve a token as a hostname), which is why only the webhook-shaped
-    schemas are checked.
+    Address-checking it would reject a perfectly good rule and, worse, could
+    resolve a token as a hostname. Which schemas are in this group is an
+    explicit list rather than "everything not a webhook"; see
+    `url_safety.ALERT_SCHEMES_WITH_FIXED_ENDPOINT`.
     """
     organization = await _organization(async_db)
     owner = await _member(async_db, organization, role="owner", full_name="Owner")
     service = OrganizationAlertService(async_db)
     assert await service.create_rule(user=owner, request=_create(destination="slack://10/0/0/1"))
+
+
+async def test_an_unclassified_schema_is_refused_rather_than_assumed_safe(async_db: AsyncSession) -> None:
+    """The allowlist is the gate, so a schema nobody has classified does not get in.
+
+    ``zulip://`` is a real Apprise schema that parses cleanly. Whether its netloc
+    is a host Otari would dial has not been decided, and the safe answer to that
+    is no rather than a guess. Accepting it is one line in
+    `url_safety.SUPPORTED_ALERT_SCHEMES`.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationAlertService(async_db)
+
+    with pytest.raises(AlertRuleUnsupportedDestinationError):
+        await service.create_rule(user=owner, request=_create(destination="zulip://bot@org/token"))
 
 
 async def test_the_private_host_override_opens_the_gate(

--- a/tests/unit/test_alert_dispatcher.py
+++ b/tests/unit/test_alert_dispatcher.py
@@ -10,13 +10,17 @@ and query would return a live bot token to anybody who can read the rule list.
 """
 
 import asyncio
+from collections.abc import Iterator
 from decimal import Decimal
 
 import pytest
 
 from gateway.services.alerts.dispatcher import (
     SEND_TIMEOUT_SECONDS,
+    SOCKET_CONNECT_TIMEOUT_SECONDS,
+    SOCKET_READ_TIMEOUT_SECONDS,
     UnsupportedAlertDestinationError,
+    _bound_sockets,
     parse_destination,
     send_alert,
 )
@@ -224,6 +228,47 @@ async def test_send_alert_reraises_cancellation(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr("apprise.Apprise.async_notify", _cancelled)
     with pytest.raises(asyncio.CancelledError):
         await send_alert("json://example.com/hook", title="t", body="b")
+
+
+def test_socket_timeouts_are_clamped_down_from_a_greedy_url() -> None:
+    """An operator's ``?cto=&rto=`` must not park a shared executor thread.
+
+    ``asyncio.wait_for`` cannot cancel a thread already inside a socket read, so
+    the URL's own timeouts are the real bound on thread occupancy.
+    """
+    import apprise
+
+    client = apprise.Apprise()
+    assert client.add("json://example.com/hook?cto=600&rto=900")
+    _bound_sockets(client)
+    for server in client:
+        assert server.socket_connect_timeout == SOCKET_CONNECT_TIMEOUT_SECONDS
+        assert server.socket_read_timeout == SOCKET_READ_TIMEOUT_SECONDS
+
+
+def test_a_shorter_socket_timeout_is_left_alone() -> None:
+    """Clamped, not overwritten: an operator asking for less keeps it."""
+    import apprise
+
+    client = apprise.Apprise()
+    assert client.add("json://example.com/hook?cto=1&rto=2")
+    _bound_sockets(client)
+    for server in client:
+        assert server.socket_connect_timeout == 1.0
+        assert server.socket_read_timeout == 2.0
+
+
+def test_bounding_sockets_survives_a_plugin_without_the_attributes() -> None:
+    """A custom plugin need not derive the timeouts; one must not fail the pass."""
+
+    class _Bare:
+        pass
+
+    class _FakeClient:
+        def __iter__(self) -> Iterator[object]:
+            return iter([_Bare()])
+
+    _bound_sockets(_FakeClient())  # type: ignore[arg-type]
 
 
 def test_send_timeout_is_a_sane_bound() -> None:

--- a/tests/unit/test_alert_dispatcher.py
+++ b/tests/unit/test_alert_dispatcher.py
@@ -395,9 +395,12 @@ def test_worst_axis_picks_the_axis_closest_to_refusing() -> None:
         # A rule that only wants the refusal stays quiet through the warning band.
         (None, True, 90, None),
         (None, True, 100, KIND_EXCEEDED),
-        # A rule that only wants the warning does not also report the refusal.
+        # A rule that only wants the warning keeps warning past the cap. Going
+        # silent at 100 would lose the alert at the moment it matters, on the
+        # deployment that routes refusals through its own error monitoring.
         (80, False, 90, KIND_WARNING),
-        (80, False, 100, None),
+        (80, False, 100, KIND_WARNING),
+        (80, False, 250, KIND_WARNING),
     ],
 )
 def test_kind_for_picks_at_most_one_alert(

--- a/tests/unit/test_alert_dispatcher.py
+++ b/tests/unit/test_alert_dispatcher.py
@@ -1,0 +1,370 @@
+"""The alert dispatcher, the destination redaction, and the evaluator's pure math.
+
+No database and no network. Apprise is exercised for real where it is pure
+(``instantiate`` parses a URL without connecting) and stubbed where it would
+dial (``async_notify``).
+
+The redaction cases are the security-relevant half of this file: an Apprise URL
+carries its credentials in the path, so a redaction that only masked userinfo
+and query would return a live bot token to anybody who can read the rule list.
+"""
+
+import asyncio
+from decimal import Decimal
+
+import pytest
+
+from gateway.services.alerts.dispatcher import (
+    SEND_TIMEOUT_SECONDS,
+    UnsupportedAlertDestinationError,
+    parse_destination,
+    send_alert,
+)
+from gateway.services.alerts.evaluator import (
+    KIND_EXCEEDED,
+    KIND_WARNING,
+    _format_amount,
+    _kind_for,
+    _percent,
+    _worst_axis,
+)
+from gateway.services.url_safety import redact_alert_destination
+
+
+class _Rule:
+    """The two fields `_kind_for` reads, without a database row behind them."""
+
+    def __init__(self, *, warn_at_percent: int | None, notify_on_exceeded: bool) -> None:
+        self.warn_at_percent = warn_at_percent
+        self.notify_on_exceeded = notify_on_exceeded
+
+
+class _Ceiling:
+    def __init__(self, **counters: object) -> None:
+        for axis in ("current_spend", "reserved_spend"):
+            setattr(self, axis, counters.get(axis, 0))
+        for axis in (
+            "current_tokens",
+            "reserved_tokens",
+            "current_requests",
+            "reserved_requests",
+        ):
+            setattr(self, axis, counters.get(axis, 0))
+
+
+class _Budget:
+    def __init__(self, **caps: object) -> None:
+        self.max_budget = caps.get("max_budget")
+        self.token_limit = caps.get("token_limit")
+        self.request_limit = caps.get("request_limit")
+
+
+# --------------------------------------------------------------------------
+# parse_destination
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "json://example.com/hook",
+        "jsons://example.com/hook",
+        "form://example.com/hook",
+        "mailto://user:pass@example.com",
+    ],
+)
+def test_parse_destination_accepts_a_schema_apprise_knows(destination: str) -> None:
+    """A supported schema returns the plugin's service name rather than raising."""
+    assert parse_destination(destination)
+
+
+@pytest.mark.parametrize(
+    "destination",
+    [
+        "",
+        "   ",
+        "not-a-url",
+        "https://example.com/hook",  # a bare http(s) URL is not an Apprise schema
+        "definitelynotascheme://example.com",
+    ],
+)
+def test_parse_destination_rejects_what_apprise_cannot_deliver_to(destination: str) -> None:
+    with pytest.raises(UnsupportedAlertDestinationError):
+        parse_destination(destination)
+
+
+def test_parse_destination_never_echoes_the_rejected_url() -> None:
+    """The message must not contain the input: it may hold a pasted real token.
+
+    The rejection is shown to whoever submitted the form and is also carried
+    into an API error body, so quoting the value back would put a credential
+    somewhere it was never meant to be.
+    """
+    secret = "definitelynotascheme://xoxb-super-secret-token"
+    with pytest.raises(UnsupportedAlertDestinationError) as caught:
+        parse_destination(secret)
+    assert "xoxb-super-secret-token" not in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# send_alert
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_alert_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transport that accepts the notification reports delivered with no detail.
+
+    Stubbed rather than dialed: a test that made a real request would pass or
+    fail on whether the runner has egress, which `AGENTS.md` calls out as the
+    thing to avoid.
+    """
+
+    async def _accept(*_: object, **__: object) -> bool:
+        return True
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _accept)
+    result = await send_alert("json://example.com/hook", title="t", body="b")
+    assert result.delivered is True
+    assert result.detail is None
+
+
+@pytest.mark.asyncio
+async def test_send_alert_treats_no_matching_server_as_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``async_notify`` returns None when nothing matched, which is not success."""
+
+    async def _nothing_matched(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _nothing_matched)
+    result = await send_alert("json://example.com/hook", title="t", body="b")
+    assert result.delivered is False
+    assert result.detail
+
+
+@pytest.mark.asyncio
+async def test_send_alert_reports_a_rejected_destination_without_raising() -> None:
+    """A URL Apprise will not add is a failed result, not an exception.
+
+    The evaluator calls this inside a loop over rules; one unusable destination
+    must not stop the rules after it from being evaluated in the same tick.
+    """
+    result = await send_alert("definitelynotascheme://host", title="t", body="b")
+    assert result.delivered is False
+    assert result.detail
+
+
+@pytest.mark.asyncio
+async def test_send_alert_turns_a_transport_exception_into_a_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Apprise surfaces a plugin's own exception; the caller must never see it."""
+
+    async def _explode(*_: object, **__: object) -> bool:
+        raise RuntimeError("the transport blew up")
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _explode)
+    result = await send_alert("json://example.com/hook", title="t", body="b")
+    assert result.delivered is False
+    assert "RuntimeError" in (result.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_send_alert_does_not_leak_the_exception_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the exception's class name is reported, never its message.
+
+    A plugin that echoes its own URL into the error would otherwise put the
+    token into the delivery row and the gateway log.
+    """
+
+    async def _explode(*_: object, **__: object) -> bool:
+        raise RuntimeError("failed posting to json://user:hunter2@example.com/hook")
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _explode)
+    result = await send_alert("json://example.com/hook", title="t", body="b")
+    assert "hunter2" not in (result.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_send_alert_times_out_rather_than_holding_a_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A destination that never answers is bounded by SEND_TIMEOUT_SECONDS.
+
+    The timeout is patched down rather than waited out: what is under test is
+    that ``wait_for`` wraps the call at all, not the constant's value.
+    """
+    monkeypatch.setattr("gateway.services.alerts.dispatcher.SEND_TIMEOUT_SECONDS", 0.01)
+
+    async def _hang(*_: object, **__: object) -> bool:
+        await asyncio.sleep(10)
+        return True
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _hang)
+    result = await send_alert("json://example.com/hook", title="t", body="b")
+    assert result.delivered is False
+    assert "imed out" in (result.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_send_alert_reraises_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shutdown must still cancel a send in flight.
+
+    ``CancelledError`` is deliberately not swallowed by the broad handler, or a
+    cancelled lifespan would never finish.
+    """
+
+    async def _cancelled(*_: object, **__: object) -> bool:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr("apprise.Apprise.async_notify", _cancelled)
+    with pytest.raises(asyncio.CancelledError):
+        await send_alert("json://example.com/hook", title="t", body="b")
+
+
+def test_send_timeout_is_a_sane_bound() -> None:
+    """A regression guard on the constant, which bounds an executor thread."""
+    assert 0 < SEND_TIMEOUT_SECONDS <= 60
+
+
+# --------------------------------------------------------------------------
+# redact_alert_destination
+# --------------------------------------------------------------------------
+
+
+def test_redaction_masks_a_slack_token_in_the_path() -> None:
+    """The case `redact_url_secrets` gets wrong, which is why this exists."""
+    redacted = redact_alert_destination("slack://xoxb-A/xoxb-B/xoxb-C/#alerts")
+    assert "xoxb-A" not in redacted
+    assert "xoxb-B" not in redacted
+    assert "xoxb-C" not in redacted
+    assert redacted.startswith("slack://")
+
+
+def test_redaction_masks_a_discord_webhook_token() -> None:
+    redacted = redact_alert_destination("discord://123456789/abcdefTOKEN")
+    assert "abcdefTOKEN" not in redacted
+    assert "123456789" not in redacted
+    assert redacted.startswith("discord://")
+
+
+def test_redaction_keeps_the_host_of_a_webhook_destination() -> None:
+    """A json:// host is operator-chosen and is what makes the row recognizable."""
+    redacted = redact_alert_destination("json://hooks.internal.example/incoming/SECRET")
+    assert "hooks.internal.example" in redacted
+    assert "SECRET" not in redacted
+
+
+def test_redaction_masks_userinfo_and_query() -> None:
+    redacted = redact_alert_destination("json://user:hunter2@example.com/hook?token=abc123")
+    assert "hunter2" not in redacted
+    assert "abc123" not in redacted
+    assert "user" not in redacted
+
+
+def test_redaction_survives_junk() -> None:
+    """A value that will not parse redacts to the mask rather than raising.
+
+    The column is written on every create and update, so a redaction that
+    raised would turn a bad destination into a 500 instead of a validation
+    error.
+    """
+    assert redact_alert_destination("") == "***"
+    assert redact_alert_destination("no-scheme-at-all") == "***"
+
+
+# --------------------------------------------------------------------------
+# the evaluator's pure math
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("used", "cap", "expected"),
+    [
+        (0, 100, 0),
+        (50, 100, 50),
+        (799, 1000, 79),  # floored: 79.9 percent does not fire an 80 warning
+        (800, 1000, 80),
+        (1000, 1000, 100),
+        (2500, 1000, 250),
+        (0, 0, 0),  # a zero cap cannot be divided into
+    ],
+)
+def test_percent_floors_and_survives_a_zero_cap(used: int, cap: int, expected: int) -> None:
+    assert _percent(Decimal(used), Decimal(cap)) == expected
+
+
+def test_percent_saturates_rather_than_formatting_an_absurd_ratio() -> None:
+    """A cap lowered under an already-spent ceiling is clamped, not reported raw."""
+    assert _percent(Decimal(10**9), Decimal(1)) == 999
+
+
+def test_worst_axis_returns_none_when_nothing_is_capped() -> None:
+    """A ceiling whose budget caps no axis can never cross a threshold."""
+    assert _worst_axis(_Ceiling(), _Budget()) is None  # type: ignore[arg-type]
+
+
+def test_worst_axis_counts_reservations_alongside_committed_spend() -> None:
+    """Utilization matches the gate in ``scoped_budget_service.reserve``.
+
+    That gate admits on ``committed + held <= cap``, so a ceiling holding 90 of
+    a 100 cap is already refusing arrivals and must not report 10 percent.
+    """
+    axis, used, cap, percent = _worst_axis(  # type: ignore[misc]
+        _Ceiling(current_spend=Decimal(10), reserved_spend=Decimal(80)),  # type: ignore[arg-type]
+        _Budget(max_budget=Decimal(100)),  # type: ignore[arg-type]
+    )
+    assert axis == "spend"
+    assert used == Decimal(90)
+    assert cap == Decimal(100)
+    assert percent == 90
+
+
+def test_worst_axis_picks_the_axis_closest_to_refusing() -> None:
+    """Tokens at 95 percent beat dollars at 10 percent, because tokens refuse first."""
+    axis, _, _, percent = _worst_axis(  # type: ignore[misc]
+        _Ceiling(  # type: ignore[arg-type]
+            current_spend=Decimal(10),
+            current_tokens=950,
+            current_requests=1,
+        ),
+        _Budget(max_budget=Decimal(100), token_limit=1000, request_limit=1000),  # type: ignore[arg-type]
+    )
+    assert axis == "tokens"
+    assert percent == 95
+
+
+@pytest.mark.parametrize(
+    ("warn", "on_exceeded", "percent", "expected"),
+    [
+        (80, True, 10, None),
+        (80, True, 79, None),
+        (80, True, 80, KIND_WARNING),
+        (80, True, 99, KIND_WARNING),
+        (80, True, 100, KIND_EXCEEDED),
+        (80, True, 250, KIND_EXCEEDED),
+        # A rule that only wants the refusal stays quiet through the warning band.
+        (None, True, 90, None),
+        (None, True, 100, KIND_EXCEEDED),
+        # A rule that only wants the warning does not also report the refusal.
+        (80, False, 90, KIND_WARNING),
+        (80, False, 100, None),
+    ],
+)
+def test_kind_for_picks_at_most_one_alert(
+    warn: int | None, on_exceeded: bool, percent: int, expected: str | None
+) -> None:
+    """Exceeded wins over the warning, and neither fires below the threshold."""
+    rule = _Rule(warn_at_percent=warn, notify_on_exceeded=on_exceeded)
+    assert _kind_for(rule, percent) == expected  # type: ignore[arg-type]
+
+
+def test_format_amount_renders_each_unit_the_way_it_reads() -> None:
+    """Dollars keep cents; counts are whole, not Decimal-tailed."""
+    assert _format_amount("spend", Decimal("12.5")) == "$12.50"
+    assert _format_amount("tokens", Decimal(1000)) == "1,000"
+    assert _format_amount("requests", Decimal(7)) == "7"

--- a/tests/unit/test_alert_rule_schemas.py
+++ b/tests/unit/test_alert_rule_schemas.py
@@ -1,0 +1,146 @@
+"""Alert rule request-body validation, and the one column default that must not exist.
+
+These need no PostgreSQL, so they live here rather than in the integration
+suite: the pydantic cases are pure, and the column-default case runs against an
+in-memory SQLite table the way `test_tenancy_schema_chain.py` does. Both bugs
+they cover reached CI as integration failures on a machine that could not run
+that suite, which is the argument for having them here.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from gateway.models.entities import AlertRule, Base
+from gateway.services.tenancy.organization_alert_service import AlertRuleCreate, AlertRuleUpdate
+
+DESTINATION = "slack://xoxb-AAA/xoxb-BBB/xoxb-CCC/#alerts"
+
+
+# --------------------------------------------------------------------------
+# The create body
+# --------------------------------------------------------------------------
+
+
+def test_the_warning_threshold_defaults_to_eighty() -> None:
+    """The default lives in the schema, not on the column. See the model comment."""
+    assert AlertRuleCreate(name="R", destination=DESTINATION).warn_at_percent == 80
+
+
+def test_an_explicit_null_threshold_is_kept_as_null() -> None:
+    """``warn_at_percent: null`` means "alert only on refusal" and must survive.
+
+    The schema's own default must not swallow an explicit null, or the API's
+    documented way to decline early warnings would silently enable them.
+    """
+    body = AlertRuleCreate(name="R", destination=DESTINATION, warn_at_percent=None)
+    assert body.warn_at_percent is None
+    assert "warn_at_percent" in body.model_fields_set
+
+
+def test_a_rule_that_could_never_fire_is_refused() -> None:
+    """No warning and no exceeded alert is storable and meaningless."""
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(
+            name="Inert",
+            destination=DESTINATION,
+            warn_at_percent=None,
+            notify_on_exceeded=False,
+        )
+
+
+@pytest.mark.parametrize("percent", [0, 100, 101, -1])
+def test_the_warn_threshold_stays_inside_its_range(percent: int) -> None:
+    """0 always fires and 100 is the refusal; neither is a warning."""
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(name="Bad", destination=DESTINATION, warn_at_percent=percent)
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_destination_is_refused(blank: str) -> None:
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(name="Blank", destination=blank)
+
+
+def test_an_over_long_destination_is_refused() -> None:
+    """The constraint is on the string, not on the field. See `AlertRuleUpdate`."""
+    with pytest.raises(ValidationError):
+        AlertRuleCreate(name="Long", destination="json://example.com/" + "x" * 5000)
+
+
+# --------------------------------------------------------------------------
+# The update body
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["name", "destination", "notify_on_exceeded", "enabled"])
+def test_an_explicit_null_is_refused_for_a_not_null_column(field: str) -> None:
+    """A ``ValidationError``, not a ``TypeError``.
+
+    ``max_length`` on an optional ``Field`` is applied to the whole union, and
+    pydantic raises ``TypeError`` for None rather than refusing it, which
+    surfaced as a 500 instead of a 422 on ``{"destination": null}``.
+    """
+    with pytest.raises(ValidationError):
+        AlertRuleUpdate.model_validate({field: None})
+
+
+def test_a_null_warn_threshold_is_a_value_on_the_update_body() -> None:
+    """The one field where null means something rather than "not sent"."""
+    body = AlertRuleUpdate.model_validate({"warn_at_percent": None})
+    assert body.warn_at_percent is None
+    assert "warn_at_percent" in body.model_fields_set
+
+
+def test_an_omitted_field_is_absent_from_fields_set() -> None:
+    """What the service branches on to leave a stored value alone."""
+    body = AlertRuleUpdate.model_validate({"enabled": False})
+    assert "warn_at_percent" not in body.model_fields_set
+    assert body.destination is None
+
+
+# --------------------------------------------------------------------------
+# The column default that must not come back
+# --------------------------------------------------------------------------
+
+
+def test_an_explicit_none_threshold_is_stored_as_null() -> None:
+    """A scalar column default on ``warn_at_percent`` would overwrite an explicit None.
+
+    SQLAlchemy applies a scalar ``default=`` whenever the attribute is None at
+    INSERT and cannot tell an explicit ``None`` from an omission, so
+    ``default=80`` on that column stored 80 for a caller who asked for no early
+    warning at all. This is the regression guard; it fails if the default
+    returns.
+    """
+
+    async def _run() -> list[tuple[str, int | None]]:
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=[AlertRule.__table__]))  # type: ignore[list-item]
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as db:
+                db.add(
+                    AlertRule(
+                        organization_id=uuid.uuid4(),
+                        name="refusal only",
+                        encrypted_destination="ciphertext",
+                        redacted_destination="slack://***",
+                        warn_at_percent=None,
+                        notify_on_exceeded=True,
+                        enabled=True,
+                    )
+                )
+                await db.commit()
+                rows = (await db.execute(select(AlertRule.name, AlertRule.warn_at_percent))).all()
+                return [(name, warn) for name, warn in rows]
+        finally:
+            await engine.dispose()
+
+    rows = asyncio.run(_run())
+    assert rows == [("refusal only", None)]

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -220,6 +220,7 @@ def test_mail_ready_turns_on_only_with_a_transport_and_a_public_url(tmp_path: Pa
 # different access. Listed here rather than in the surface tuple itself so the
 # tuple stays the plain list of names the dashboard gates on.
 SURFACE_ROUTE_PREFIXES = {
+    "organization_alerts": "/v1/organizations/me/alert-rules",
     "organization_providers": "/v1/organizations/me/provider-keys",
     "organization_usage": "/v1/organizations/me/usage",
 }

--- a/tests/unit/test_settings_endpoint.py
+++ b/tests/unit/test_settings_endpoint.py
@@ -224,6 +224,7 @@ def test_settings_includes_full_config_view(tmp_path: Path) -> None:
         "mcp_allow_private_hosts",
         "web_search_allow_private_hosts",
         "provider_allow_private_hosts",
+        "alert_allow_private_hosts",
         "sandbox_url",
         "guardrails_url",
     ):

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -3,8 +3,11 @@
 import pytest
 
 from gateway.services.url_safety import (
+    ALERT_SCHEMES_WITH_FIXED_ENDPOINT,
+    ALERT_SCHEMES_WITH_OPERATOR_HOST,
     UnsafeURLError,
     redact_url_secrets,
+    validate_alert_destination,
     validate_mcp_url,
     validate_outbound_fetch_url,
     validate_provider_api_base,
@@ -234,3 +237,70 @@ async def test_provider_api_base_on_keeps_allow_all(monkeypatch: pytest.MonkeyPa
 )
 def test_redact_url_secrets_masks_credentials_without_raising(raw: str, expected: str) -> None:
     assert redact_url_secrets(raw) == expected
+
+
+# --------------------------------------------------------------------------
+# Alert destinations
+# --------------------------------------------------------------------------
+#
+# The two scheme groups are the SSRF gate, so what is in each one is worth
+# asserting directly. IP literals throughout: `_reject_internal_host` takes the
+# literal branch and never resolves, so none of this needs DNS.
+
+
+@pytest.mark.parametrize(
+    "scheme",
+    [
+        # The ones a self-hosted deployment reaches for, and the six that
+        # previously made up the whole gate.
+        "mailto",
+        "mailtos",
+        "gotify",
+        "ntfy",
+        "matrix",
+        "rocket",
+        "mmost",
+        "ncloud",
+        "json",
+        "jsons",
+        "xml",
+        "form",
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_schema_that_names_a_host_is_address_checked(scheme: str) -> None:
+    """Every one of these dials the host in the URL, so every one is checked.
+
+    `mailto` is the case that motivated the split: it is advertised on the form
+    and in the docs, Apprise sends it to the SMTP server named in the URL, and
+    the earlier gate let it through because it was not one of the six
+    webhook-shaped schemas.
+    """
+    assert scheme in ALERT_SCHEMES_WITH_OPERATOR_HOST
+    with pytest.raises(UnsafeURLError):
+        await validate_alert_destination(scheme, "169.254.169.254")
+
+
+@pytest.mark.parametrize("scheme", ["slack", "discord", "pagerduty", "tgram"])
+@pytest.mark.asyncio
+async def test_a_fixed_endpoint_schema_has_no_address_to_check(scheme: str) -> None:
+    """The netloc is a token, so checking it would reject a working rule."""
+    assert scheme in ALERT_SCHEMES_WITH_FIXED_ENDPOINT
+    await validate_alert_destination(scheme, "10")
+
+
+@pytest.mark.asyncio
+async def test_a_public_host_is_accepted() -> None:
+    await validate_alert_destination("json", "93.184.216.34")
+
+
+@pytest.mark.asyncio
+async def test_a_host_bearing_schema_with_no_host_is_refused() -> None:
+    """Fail closed. A schema in the checked group must produce something to check."""
+    with pytest.raises(UnsafeURLError):
+        await validate_alert_destination("json", None)
+
+
+def test_the_two_scheme_groups_do_not_overlap() -> None:
+    """A schema in both would be checked or skipped depending on read order."""
+    assert not (ALERT_SCHEMES_WITH_OPERATOR_HOST & ALERT_SCHEMES_WITH_FIXED_ENDPOINT)

--- a/uv.lock
+++ b/uv.lock
@@ -29,13 +29,13 @@ name = "aiohttp"
 version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "aiosignal", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "multidict", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "propcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "yarl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
@@ -106,7 +106,7 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -127,9 +127,9 @@ name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mako" },
-    { name = "sqlalchemy" },
-    { name = "typing-extensions" },
+    { name = "mako", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
@@ -159,14 +159,14 @@ name = "anthropic"
 version = "0.125.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "docstring-parser", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jiter", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/f8/6f0560884b5363848347bd640b6c1d04abc25e7aa61787a232f790c6b60a/anthropic-0.125.0.tar.gz", hash = "sha256:e0cdd336580cb7411c1cdab69f80973e9bf4bff7f8e08141811d46307d45c682", size = 1112593, upload-time = "2026-08-19T22:00:42.837Z" }
 wheels = [
@@ -175,7 +175,7 @@ wheels = [
 
 [package.optional-dependencies]
 vertex = [
-    { name = "google-auth", extra = ["requests"] },
+    { name = "google-auth", extra = ["requests"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -183,11 +183,11 @@ name = "any-llm-platform-client"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "httpx" },
-    { name = "pynacl" },
-    { name = "pyyaml" },
-    { name = "rich" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pynacl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/47/d72c6d90e663ab3d7a1f84d3f43fa5184b8f25ebd1b34ef4219090f3a8f0/any_llm_platform_client-0.4.0.tar.gz", hash = "sha256:c4d9a14dd4586e0530859a1c234e725f412f0a0fd99ffcfd4afbc53f6ba4d678", size = 140347, upload-time = "2026-02-24T09:28:40.398Z" }
 wheels = [
@@ -199,13 +199,13 @@ name = "any-llm-sdk"
 version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anthropic" },
-    { name = "httpx" },
-    { name = "openai" },
-    { name = "openresponses-types" },
-    { name = "pydantic" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "anthropic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "openresponses-types", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/67/e4ec7b8b065210e4069f54e4075871ad017b3dc988cf9230259c1abdad86/any_llm_sdk-1.27.1.tar.gz", hash = "sha256:605a44b24e67e3396f8cef9489bf5cf6a4cc59d25cd022ceb823aae268590cf0", size = 210430, upload-time = "2026-09-04T09:58:00.719Z" }
 wheels = [
@@ -214,26 +214,26 @@ wheels = [
 
 [package.optional-dependencies]
 all = [
-    { name = "anthropic", extra = ["vertex"] },
-    { name = "any-llm-platform-client" },
-    { name = "azure-ai-inference" },
-    { name = "boto3" },
-    { name = "cerebras-cloud-sdk" },
-    { name = "cohere" },
-    { name = "google-cloud-storage" },
-    { name = "google-genai" },
-    { name = "groq" },
-    { name = "huggingface-hub" },
-    { name = "ibm-watsonx-ai", marker = "python_full_version < '3.14'" },
-    { name = "lmstudio" },
-    { name = "mistralai" },
-    { name = "ollama" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-sdk" },
-    { name = "otari" },
-    { name = "together" },
-    { name = "voyageai", marker = "python_full_version < '3.14'" },
-    { name = "xai-sdk" },
+    { name = "anthropic", extra = ["vertex"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "any-llm-platform-client", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "azure-ai-inference", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "boto3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cerebras-cloud-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cohere", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-cloud-storage", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-genai", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "groq", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ibm-watsonx-ai", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "lmstudio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mistralai", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ollama", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "otari", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "together", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "voyageai", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "xai-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -249,13 +249,30 @@ wheels = [
 ]
 
 [[package]]
+name = "apprise"
+version = "1.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests-oauthlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/44/5965c245998c72022297e2b515d9594281a97ed1442b3fa022c2c2324102/apprise-1.13.1.tar.gz", hash = "sha256:e7689dda71aaf739244d6c8690de13cb1361b8d0a79980fb48bb397455ca0bdd", size = 2520230, upload-time = "2026-08-31T02:12:01.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7d/6852bd3fc2eb48fa432cb22f5df11d1c902137dcecab93e0d8319b8c8e16/apprise-1.13.1-py3-none-any.whl", hash = "sha256:2ded6d00562dd2ae9eb6f1e6cc8d3fb66e06f7ede6efac0ad029031b633780f4", size = 1826431, upload-time = "2026-08-31T02:11:58.263Z" },
+]
+
+[[package]]
 name = "apron-auth"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib" },
-    { name = "httpx" },
-    { name = "pydantic" },
+    { name = "authlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/a0/850f2549958a355db27751864538198d447dc392eaa4ad824f1008236704/apron_auth-0.15.1.tar.gz", hash = "sha256:0962ca59095b33f560d24085b359762770cc6bab9074520f68098f7c5bded126", size = 180077, upload-time = "2026-08-07T16:52:26.206Z" }
 wheels = [
@@ -302,8 +319,8 @@ name = "authlib"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "joserfc" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "joserfc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
@@ -315,9 +332,9 @@ name = "azure-ai-inference"
 version = "1.0.0b9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "isodate" },
-    { name = "typing-extensions" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/6a/ed85592e5c64e08c291992f58b1a94dab6869f28fb0f40fd753dced73ba6/azure_ai_inference-1.0.0b9.tar.gz", hash = "sha256:1feb496bd84b01ee2691befc04358fa25d7c344d8288e99364438859ad7cd5a4", size = 182408, upload-time = "2025-02-15T00:37:28.464Z" }
 wheels = [
@@ -329,8 +346,8 @@ name = "azure-core"
 version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531, upload-time = "2026-03-19T01:31:29.461Z" }
 wheels = [
@@ -405,8 +422,8 @@ name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
+    { name = "soupsieve", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
@@ -418,9 +435,9 @@ name = "boto3"
 version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
+    { name = "botocore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jmespath", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "s3transfer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/4d/40029c26b535c41333a0b11573127cfc548fdcb1cbcd1798ea7046c56bab/boto3-1.42.81.tar.gz", hash = "sha256:e5c0d57229763007151be6d388319514a040ccdc922fbb27e37c3100a7fbc01a", size = 112785, upload-time = "2026-04-01T19:35:34.293Z" }
 wheels = [
@@ -432,8 +449,8 @@ name = "boto3-stubs"
 version = "1.43.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore-stubs" },
-    { name = "types-s3transfer" },
+    { name = "botocore-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-s3transfer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/cb/687986860a838ab80e80c3bd5fe772eedb551a52cc54d792a12accafc2f0/boto3_stubs-1.43.55.tar.gz", hash = "sha256:a37249dcd19341e42c873025cf33fa82d3f1bac5f708a5a43f01bea064162df7", size = 103222, upload-time = "2026-07-23T19:58:49.637Z" }
 wheels = [
@@ -442,7 +459,7 @@ wheels = [
 
 [package.optional-dependencies]
 s3 = [
-    { name = "mypy-boto3-s3" },
+    { name = "mypy-boto3-s3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -450,9 +467,9 @@ name = "botocore"
 version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "jmespath", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/5f/b0bb9a8768398fb131e1fe722c9cc5b18f74d21ca1970efe8576912b2c6e/botocore-1.42.81.tar.gz", hash = "sha256:48e6f6f52de1cc107a34810309b8ca998ea9bb719a3fe4c06f903a604b3138cb", size = 15129980, upload-time = "2026-04-01T19:35:23.439Z" }
 wheels = [
@@ -464,7 +481,7 @@ name = "botocore-stubs"
 version = "1.43.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "types-awscrt" },
+    { name = "types-awscrt", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/81/79693e833291c00dc89ee610e5e915381b6f08233912e28df50106840780/botocore_stubs-1.43.14.tar.gz", hash = "sha256:9e3bc1fdd51da7473f0df726c82747a1b0ae913449d629659765c247fecc2039", size = 42738, upload-time = "2026-05-25T06:06:37.484Z" }
 wheels = [
@@ -508,12 +525,12 @@ name = "cerebras-cloud-sdk"
 version = "1.67.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", extra = ["http2"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/12/c201f07582068141e88f9a523ab02fdc97de58f2f7c0df775c6c52b9d8dd/cerebras_cloud_sdk-1.67.0.tar.gz", hash = "sha256:3aed6f86c6c7a83ee9d4cfb08a2acea089cebf2af5b8aed116ef79995a4f4813", size = 131536, upload-time = "2026-01-29T23:31:27.306Z" }
 wheels = [
@@ -534,7 +551,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(implementation_name != 'PyPy' and sys_platform == 'darwin') or (implementation_name != 'PyPy' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -636,14 +653,14 @@ name = "cohere"
 version = "5.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastavro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
+    { name = "fastavro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tokenizers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/75/4c346f6e2322e545f8452692304bd4eca15a2a0209ab9af6a0d1a7810b67/cohere-5.21.1.tar.gz", hash = "sha256:e5ade4423b928b01ff2038980e1b62b2a5bb412c8ab83e30882753b810a5509f", size = 191272, upload-time = "2026-03-26T15:09:27.857Z" }
 wheels = [
@@ -655,9 +672,9 @@ name = "courlan"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel" },
-    { name = "tld" },
-    { name = "urllib3" },
+    { name = "babel", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tld", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
 wheels = [
@@ -726,7 +743,7 @@ name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
@@ -773,10 +790,10 @@ name = "dateparser"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "regex" },
-    { name = "tzlocal" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytz", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "regex", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tzlocal", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
 wheels = [
@@ -815,8 +832,8 @@ name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
@@ -864,11 +881,11 @@ name = "fastapi"
 version = "0.135.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-doc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
@@ -907,7 +924,7 @@ name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "future" },
+    { name = "future", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
 wheels = [
@@ -1015,62 +1032,63 @@ name = "gateway"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiosqlite" },
-    { name = "alembic" },
-    { name = "any-llm-sdk", extra = ["all"] },
-    { name = "apron-auth" },
-    { name = "asyncpg" },
-    { name = "bcrypt" },
-    { name = "click" },
-    { name = "cryptography" },
-    { name = "dnspython" },
-    { name = "fastapi" },
-    { name = "genai-prices" },
-    { name = "idna" },
-    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"] },
-    { name = "mcp" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-proto" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "psycopg2-binary" },
-    { name = "pydantic-settings" },
-    { name = "pypdfium2" },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "pyyaml" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "sqlmodel" },
-    { name = "trafilatura" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "webauthn" },
+    { name = "aiosqlite", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "alembic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "any-llm-sdk", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "apprise", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "apron-auth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "asyncpg", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "bcrypt", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "dnspython", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "genai-prices", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mcp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-proto", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "prometheus-client", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "psycopg2-binary", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pypdfium2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-multipart", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sqlalchemy", extra = ["asyncio"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sqlmodel", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "trafilatura", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "webauthn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.optional-dependencies]
 ocr = [
-    { name = "numpy" },
-    { name = "rapidocr-onnxruntime" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rapidocr-onnxruntime", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 s3 = [
-    { name = "boto3" },
+    { name = "boto3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "boto3-stubs", extra = ["s3"] },
-    { name = "jsonschema" },
-    { name = "moto", extra = ["s3"] },
-    { name = "mypy" },
-    { name = "packaging" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-rerunfailures" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-    { name = "testcontainers" },
-    { name = "types-jsonschema" },
+    { name = "boto3-stubs", extra = ["s3"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "moto", extra = ["s3"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mypy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-rerunfailures", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-timeout", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest-xdist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "testcontainers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-jsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.metadata]
@@ -1078,6 +1096,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.27.1" },
+    { name = "apprise", specifier = ">=1.9.0,<2.0.0" },
     { name = "apron-auth", specifier = ">=0.15.1,<0.16.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bcrypt", specifier = ">=5.0.0" },
@@ -1133,8 +1152,8 @@ name = "genai-prices"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx2" },
-    { name = "pydantic" },
+    { name = "httpx2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/4d/cc5a70b9ea9381d36fb8ba8792569009971f504131e7d1dbd2c9a6bed69b/genai_prices-0.1.0.tar.gz", hash = "sha256:a6e3386a1de1220a49ed080f6f136069f47b1e5ff2741706d405287afcbe20d7", size = 90982, upload-time = "2026-07-30T13:01:19.969Z" }
 wheels = [
@@ -1146,11 +1165,11 @@ name = "google-api-core"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth" },
-    { name = "googleapis-common-protos" },
-    { name = "proto-plus" },
-    { name = "protobuf" },
-    { name = "requests" },
+    { name = "google-auth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "googleapis-common-protos", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "proto-plus", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
@@ -1162,8 +1181,8 @@ name = "google-auth"
 version = "2.49.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyasn1-modules", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
 wheels = [
@@ -1172,7 +1191,7 @@ wheels = [
 
 [package.optional-dependencies]
 requests = [
-    { name = "requests" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1180,8 +1199,8 @@ name = "google-cloud-core"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
+    { name = "google-api-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
 wheels = [
@@ -1193,12 +1212,12 @@ name = "google-cloud-storage"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "google-auth" },
-    { name = "google-cloud-core" },
-    { name = "google-crc32c" },
-    { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "google-api-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-auth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-cloud-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-crc32c", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-resumable-media", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
@@ -1226,16 +1245,16 @@ name = "google-genai"
 version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sniffio" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "google-auth", extra = ["requests"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tenacity", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/dd/28e4682904b183acbfad3fe6409f13a42f69bb8eab6e882d3bcbea1dde01/google_genai-1.70.0.tar.gz", hash = "sha256:36b67b0fc6f319e08d1f1efd808b790107b1809c8743a05d55dfcf9d9fad7719", size = 519550, upload-time = "2026-04-01T10:52:46.487Z" }
 wheels = [
@@ -1247,7 +1266,7 @@ name = "google-resumable-media"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-crc32c" },
+    { name = "google-crc32c", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
 wheels = [
@@ -1259,7 +1278,7 @@ name = "googleapis-common-protos"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506, upload-time = "2026-03-26T22:17:38.451Z" }
 wheels = [
@@ -1300,12 +1319,12 @@ name = "groq"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d3/c7/a2153b639062f59f9bc93a1b5507c0c4a6b654b8a9edbf432ec2f4a62d2d/groq-1.1.2.tar.gz", hash = "sha256:9ec2b5b6a1c4856a8c6c38741353c5ab37472a4e3fded02af783750d849cc988", size = 154033, upload-time = "2026-03-25T23:16:10.313Z" }
 wheels = [
@@ -1317,7 +1336,7 @@ name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
 wheels = [
@@ -1353,8 +1372,8 @@ name = "h2"
 version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
+    { name = "hpack", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "hyperframe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
@@ -1401,11 +1420,11 @@ name = "htmldate"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "charset-normalizer" },
-    { name = "dateparser" },
-    { name = "lxml" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "dateparser", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "lxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
 wheels = [
@@ -1417,8 +1436,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -1430,8 +1449,8 @@ name = "httpcore2"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "truststore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
 wheels = [
@@ -1463,10 +1482,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpcore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -1475,7 +1494,7 @@ wheels = [
 
 [package.optional-dependencies]
 http2 = [
-    { name = "h2" },
+    { name = "h2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1492,10 +1511,10 @@ name = "httpx-ws"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "wsproto" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpcore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "wsproto", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
 wheels = [
@@ -1507,10 +1526,10 @@ name = "httpx2"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpcore2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "truststore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
 wheels = [
@@ -1522,15 +1541,15 @@ name = "huggingface-hub"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'amd64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839, upload-time = "2026-03-25T16:01:28.152Z" }
 wheels = [
@@ -1551,9 +1570,9 @@ name = "ibm-cos-sdk"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cos-sdk-core" },
-    { name = "ibm-cos-sdk-s3transfer" },
-    { name = "jmespath" },
+    { name = "ibm-cos-sdk-core", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "ibm-cos-sdk-s3transfer", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "jmespath", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/b8/b99f17ece72d4bccd7e75539b9a294d0f73ace5c6c475d8f2631afd6f65b/ibm_cos_sdk-2.14.3.tar.gz", hash = "sha256:643b6f2aa1683adad7f432df23407d11ae5adb9d9ad01214115bee77dc64364a", size = 58831, upload-time = "2025-08-01T06:35:51.722Z" }
 
@@ -1562,10 +1581,10 @@ name = "ibm-cos-sdk-core"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "jmespath", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "python-dateutil", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "urllib3", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/45/80c23aa1e13175a9deefe43cbf8e853a3d3bfc8dfa8b6d6fe83e5785fe21/ibm_cos_sdk_core-2.14.3.tar.gz", hash = "sha256:85dee7790c92e8db69bf39dae4c02cac211e3c1d81bb86e64fa2d1e929674623", size = 1103637, upload-time = "2025-08-01T06:35:41.645Z" }
 
@@ -1574,7 +1593,7 @@ name = "ibm-cos-sdk-s3transfer"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ibm-cos-sdk-core" },
+    { name = "ibm-cos-sdk-core", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ff/c9baf0997266d398ae08347951a2970e5e96ed6232ed0252f649f2b9a7eb/ibm_cos_sdk_s3transfer-2.14.3.tar.gz", hash = "sha256:2251ebfc4a46144401e431f4a5d9f04c262a0d6f95c88a8e71071da056e55f72", size = 139594, upload-time = "2025-08-01T06:35:46.403Z" }
 
@@ -1583,16 +1602,16 @@ name = "ibm-watsonx-ai"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "httpx" },
-    { name = "ibm-cos-sdk" },
-    { name = "lomond" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "urllib3" },
+    { name = "cachetools", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "certifi", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "ibm-cos-sdk", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "lomond", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pandas", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "tabulate", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "urllib3", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/29/e1cbc63b5eb78656abe9f4d1dc2cb567e48cdf91f6e15d9518c73d759361/ibm_watsonx_ai-1.5.5.tar.gz", hash = "sha256:68988e554d4c735e2f70af80e741d5874bd6fc9ca20d0dc9fd2aeaae1983dd51", size = 716479, upload-time = "2026-03-25T12:08:05.439Z" }
 wheels = [
@@ -1613,7 +1632,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1692,7 +1711,7 @@ name = "joserfc"
 version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
@@ -1704,7 +1723,7 @@ name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpointer" },
+    { name = "jsonpointer", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
 wheels = [
@@ -1734,10 +1753,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jsonschema-specifications", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "referencing", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rpds-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1749,7 +1768,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1761,7 +1780,7 @@ name = "justext"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", extra = ["html-clean"] },
+    { name = "lxml", extra = ["html-clean"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
 wheels = [
@@ -1773,15 +1792,15 @@ name = "langchain-core"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonpatch" },
-    { name = "langchain-protocol" },
-    { name = "langsmith" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "uuid-utils" },
+    { name = "jsonpatch", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "langchain-protocol", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "langsmith", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "tenacity", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "uuid-utils", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
 wheels = [
@@ -1793,7 +1812,7 @@ name = "langchain-protocol"
 version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
@@ -1805,7 +1824,7 @@ name = "langchain-text-splitters"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "langchain-core" },
+    { name = "langchain-core", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
 wheels = [
@@ -1817,16 +1836,16 @@ name = "langsmith"
 version = "0.8.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "uuid-utils" },
-    { name = "websockets" },
-    { name = "xxhash" },
-    { name = "zstandard" },
+    { name = "httpx", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "orjson", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "packaging", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "requests-toolbelt", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "uuid-utils", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "websockets", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "xxhash", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "zstandard", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
 wheels = [
@@ -1876,11 +1895,11 @@ name = "lmstudio"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-ws" },
-    { name = "msgspec" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx-ws", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/6d/40876f14c759fa2072ccbc844cc3ef7c74c1824e17e7d19b2cf4ff2cea2c/lmstudio-1.5.0.tar.gz", hash = "sha256:458c34fe1f94a7dcc521d4226b4cee82b8af7ea3da8c40b31bbdac558d9a74d4", size = 200230, upload-time = "2025-08-22T13:52:42.487Z" }
 wheels = [
@@ -1892,7 +1911,7 @@ name = "lomond"
 version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/9e/ef7813c910d4a893f2bc763ce9246269f55cc68db21dc1327e376d6a2d02/lomond-0.3.3.tar.gz", hash = "sha256:427936596b144b4ec387ead99aac1560b77c8a78107d3d49415d3abbe79acbd3", size = 28789, upload-time = "2018-09-21T15:17:43.297Z" }
 wheels = [
@@ -1954,7 +1973,7 @@ wheels = [
 
 [package.optional-dependencies]
 html-clean = [
-    { name = "lxml-html-clean" },
+    { name = "lxml-html-clean", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1962,7 +1981,7 @@ name = "lxml-html-clean"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
+    { name = "lxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
 wheels = [
@@ -1974,10 +1993,10 @@ name = "magika"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "python-dotenv" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "onnxruntime", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
 wheels = [
@@ -1991,7 +2010,7 @@ name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
@@ -2003,7 +2022,7 @@ name = "mammoth"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cobble" },
+    { name = "cobble", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/3c/a58418d2af00f2da60d4a51e18cd0311307b72d48d2fffec36a97b4a5e44/mammoth-1.11.0.tar.gz", hash = "sha256:a0f59e442f34d5b6447f4b0999306cbf3e67aaabfa8cb516f878fb1456744637", size = 53142, upload-time = "2025-09-19T10:35:20.373Z" }
 wheels = [
@@ -2011,11 +2030,20 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2027,8 +2055,8 @@ name = "markdownify"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "six" },
+    { name = "beautifulsoup4", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
 wheels = [
@@ -2040,12 +2068,12 @@ name = "markitdown"
 version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "charset-normalizer" },
-    { name = "defusedxml" },
-    { name = "magika" },
-    { name = "markdownify" },
-    { name = "requests" },
+    { name = "beautifulsoup4", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "defusedxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "magika", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "markdownify", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/b7/91fe0e2df07107ab701a15c8ad3213135707e4d6206ae9bd8f457a7ad86a/markitdown-0.1.6.tar.gz", hash = "sha256:e5bdbaffd971b29598c7c39ef0e9afce2f08c0751fbfa4e4257678ebaf8cfc7e", size = 50795, upload-time = "2026-05-26T22:43:59.318Z" }
 wheels = [
@@ -2054,19 +2082,19 @@ wheels = [
 
 [package.optional-dependencies]
 docx = [
-    { name = "lxml" },
-    { name = "mammoth" },
+    { name = "lxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "mammoth", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 pdf = [
-    { name = "pdfminer-six" },
-    { name = "pdfplumber" },
+    { name = "pdfminer-six", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pdfplumber", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 pptx = [
-    { name = "python-pptx" },
+    { name = "python-pptx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 xlsx = [
-    { name = "openpyxl" },
-    { name = "pandas" },
+    { name = "openpyxl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pandas", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2114,19 +2142,19 @@ name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx-sse", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-multipart", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sse-starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "uvicorn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
@@ -2147,14 +2175,14 @@ name = "mistralai"
 version = "2.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "eval-type-backport" },
-    { name = "httpx" },
-    { name = "jsonpath-python" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-inspection" },
+    { name = "eval-type-backport", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jsonpath-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/3f/5624d57c5897c83c55d3e4c7dd4127de42ad14fd3183e26566cdc7dca1bf/mistralai-2.4.5.tar.gz", hash = "sha256:ef165bb004ec4423cbf19a440bf0983ca0c3fc92ab12a35ebca097bdf418e33a", size = 424611, upload-time = "2026-05-07T11:46:43.888Z" }
 wheels = [
@@ -2166,13 +2194,13 @@ name = "moto"
 version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "cryptography" },
-    { name = "requests" },
-    { name = "responses" },
-    { name = "werkzeug" },
-    { name = "xmltodict" },
+    { name = "boto3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "botocore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "responses", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "werkzeug", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "xmltodict", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
 wheels = [
@@ -2181,8 +2209,8 @@ wheels = [
 
 [package.optional-dependencies]
 s3 = [
-    { name = "py-partiql-parser" },
-    { name = "pyyaml" },
+    { name = "py-partiql-parser", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2285,10 +2313,10 @@ name = "mypy"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
+    { name = "librt", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "mypy-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/b0089fe7fef0a994ae5ee07029ced0526082c6cfaaa4c10d40a10e33b097/mypy-1.20.0.tar.gz", hash = "sha256:eb96c84efcc33f0b5e0e04beacf00129dd963b67226b01c00b9dfc8affb464c3", size = 3815028, upload-time = "2026-03-31T16:55:14.959Z" }
 wheels = [
@@ -2367,12 +2395,21 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "ollama"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/5a/652dac4b7affc2b37b95386f8ae78f22808af09d720689e3d7a86b6ed98e/ollama-0.6.1.tar.gz", hash = "sha256:478c67546836430034b415ed64fa890fd3d1ff91781a9d548b3325274e69d7c6", size = 51620, upload-time = "2025-11-13T23:02:17.416Z" }
 wheels = [
@@ -2384,10 +2421,10 @@ name = "onnxruntime"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "flatbuffers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
@@ -2407,14 +2444,14 @@ name = "openai"
 version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "jiter", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
@@ -2426,7 +2463,7 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
@@ -2442,7 +2479,7 @@ name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "et-xmlfile" },
+    { name = "et-xmlfile", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
@@ -2454,7 +2491,7 @@ name = "openresponses-types"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/eb/cb4a855a27c6cf04af2d47c896b6549040a86bb75e6a59cb687a8bcf19aa/openresponses_types-2.4.0.tar.gz", hash = "sha256:cd55e7fa17230d8edd46e254ef34666ca6f250b7efa3712a110aac546c7dc8d5", size = 22101, upload-time = "2026-08-05T12:22:46.167Z" }
 wheels = [
@@ -2466,8 +2503,8 @@ name = "opentelemetry-api"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
+    { name = "importlib-metadata", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
 wheels = [
@@ -2479,7 +2516,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-proto", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
 wheels = [
@@ -2491,13 +2528,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-proto", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
 wheels = [
@@ -2509,7 +2546,7 @@ name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
 wheels = [
@@ -2521,9 +2558,9 @@ name = "opentelemetry-sdk"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
 wheels = [
@@ -2535,8 +2572,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
@@ -2580,10 +2617,10 @@ name = "otari"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/57/a121d08fd41fde51948f7a8bc5176323a58988a394e0c28f5f16a550e7c6/otari-0.3.0.tar.gz", hash = "sha256:15b2408ade8cee9dfeb45adaf3396b3a3ba2a39d91f6645d53295447f96c817d", size = 259831, upload-time = "2026-08-14T08:27:57.671Z" }
 wheels = [
@@ -2604,10 +2641,10 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytz", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tzdata", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2651,8 +2688,8 @@ name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "charset-normalizer" },
-    { name = "cryptography" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload-time = "2025-12-30T15:49:13.104Z" }
 wheels = [
@@ -2664,9 +2701,9 @@ name = "pdfplumber"
 version = "0.11.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pdfminer-six" },
-    { name = "pillow" },
-    { name = "pypdfium2" },
+    { name = "pdfminer-six", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pypdfium2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
 wheels = [
@@ -2800,7 +2837,7 @@ name = "proto-plus"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
 wheels = [
@@ -2871,7 +2908,7 @@ name = "pyasn1-modules"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyasn1" },
+    { name = "pyasn1", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
@@ -2910,10 +2947,10 @@ name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -2925,7 +2962,7 @@ name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -2969,9 +3006,9 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
@@ -2998,7 +3035,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3006,7 +3043,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -3035,7 +3072,7 @@ name = "pyopenssl"
 version = "26.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
 wheels = [
@@ -3071,10 +3108,10 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
+    { name = "iniconfig", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pluggy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -3086,7 +3123,7 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
@@ -3098,9 +3135,9 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage" },
-    { name = "pluggy" },
-    { name = "pytest" },
+    { name = "coverage", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pluggy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
@@ -3112,8 +3149,8 @@ name = "pytest-rerunfailures"
 version = "16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
-    { name = "pytest" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/04/71e9520551fc8fe2cf5c1a1842e4e600265b0815f2016b7c27ec85688682/pytest_rerunfailures-16.1.tar.gz", hash = "sha256:c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e", size = 30889, upload-time = "2025-10-10T07:06:01.238Z" }
 wheels = [
@@ -3125,7 +3162,7 @@ name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
@@ -3137,8 +3174,8 @@ name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
+    { name = "execnet", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
@@ -3150,7 +3187,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -3180,10 +3217,10 @@ name = "python-pptx"
 version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
-    { name = "pillow" },
-    { name = "typing-extensions" },
-    { name = "xlsxwriter" },
+    { name = "lxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "xlsxwriter", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
@@ -3233,15 +3270,15 @@ name = "rapidocr-onnxruntime"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "onnxruntime" },
-    { name = "opencv-python" },
-    { name = "pillow" },
-    { name = "pyclipper" },
-    { name = "pyyaml" },
-    { name = "shapely" },
-    { name = "six" },
-    { name = "tqdm" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "onnxruntime", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opencv-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyclipper", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "shapely", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/12/1e5497183bdbe782dbb91bad1d0d2297dba4d2831b2652657f7517bfc6df/rapidocr_onnxruntime-1.4.4-py3-none-any.whl", hash = "sha256:971d7d5f223a7a808662229df1ef69893809d8457d834e6373d3854bc1782cbf", size = 14915192, upload-time = "2025-01-17T01:48:25.104Z" },
@@ -3252,8 +3289,8 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rpds-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -3325,10 +3362,10 @@ name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
@@ -3336,11 +3373,24 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -3352,9 +3402,9 @@ name = "responses"
 version = "0.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
 wheels = [
@@ -3366,8 +3416,8 @@ name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -3457,7 +3507,7 @@ name = "s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
+    { name = "botocore", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
@@ -3469,7 +3519,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [
@@ -3540,8 +3590,8 @@ name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-    { name = "typing-extensions" },
+    { name = "greenlet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'WIN32' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'ppc64le' and sys_platform == 'darwin') or (platform_machine == 'win32' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'WIN32' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'amd64' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and sys_platform == 'linux') or (platform_machine == 'win32' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/73/b4a9737255583b5fa858e0bb8e116eb94b88c910164ed2ed719147bde3de/sqlalchemy-2.0.48.tar.gz", hash = "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7", size = 9886075, upload-time = "2026-03-02T15:28:51.474Z" }
 wheels = [
@@ -3568,7 +3618,7 @@ wheels = [
 
 [package.optional-dependencies]
 asyncio = [
-    { name = "greenlet" },
+    { name = "greenlet", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3576,9 +3626,9 @@ name = "sqlmodel"
 version = "0.0.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "sqlalchemy" },
-    { name = "typing-extensions" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/ee/22a0559283c3cf6048678e787ed5d4959dcd00dedd8ba4567eeae684eeb1/sqlmodel-0.0.39.tar.gz", hash = "sha256:23d8e50a8d8ee936032ed79c55023a5d618dd6bc3c510bbf4909d1a7a605a570", size = 91057, upload-time = "2026-06-25T13:01:38.475Z" }
 wheels = [
@@ -3590,8 +3640,8 @@ name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
 wheels = [
@@ -3603,7 +3653,7 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -3633,11 +3683,11 @@ name = "testcontainers"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docker" },
-    { name = "python-dotenv" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "wrapt" },
+    { name = "docker", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "wrapt", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
@@ -3658,21 +3708,21 @@ name = "together"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "distro" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "rich" },
-    { name = "sniffio" },
-    { name = "tabulate" },
-    { name = "tqdm" },
-    { name = "types-pyyaml" },
-    { name = "types-tabulate" },
-    { name = "types-tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "filelock", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tabulate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-tabulate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "types-tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/48/95b6319e05e2a358d89a44b053fe64729703c05167559c995a09326ab2fe/together-2.5.0.tar.gz", hash = "sha256:8a9246b4ca131a57de3ede2563ed97ab194db478860ded530d4162010bede6c0", size = 554925, upload-time = "2026-03-18T18:27:26.833Z" }
 wheels = [
@@ -3684,7 +3734,7 @@ name = "tokenizers"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
@@ -3716,13 +3766,13 @@ name = "trafilatura"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "courlan" },
-    { name = "htmldate" },
-    { name = "justext" },
-    { name = "lxml" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "courlan", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "htmldate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "justext", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "lxml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
 wheels = [
@@ -3743,10 +3793,10 @@ name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
+    { name = "annotated-doc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "shellingham", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
@@ -3767,7 +3817,7 @@ name = "types-jsonschema"
 version = "4.26.0.20260518"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
 wheels = [
@@ -3788,7 +3838,7 @@ name = "types-requests"
 version = "2.33.0.20260402"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "urllib3" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/7b/a06527d20af1441d813360b8e0ce152a75b7d8e4aab7c7d0a156f405d7ec/types_requests-2.33.0.20260402.tar.gz", hash = "sha256:1bdd3ada9b869741c5c4b887d2c8b4e38284a1449751823b5ebbccba3eefd9da", size = 23851, upload-time = "2026-04-02T04:19:55.942Z" }
 wheels = [
@@ -3818,7 +3868,7 @@ name = "types-tqdm"
 version = "4.67.3.20260402"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "types-requests" },
+    { name = "types-requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/42/e9e6688891d8db77b5795ec02b329524170892ff81bec63c4c4ca7425b30/types_tqdm-4.67.3.20260402.tar.gz", hash = "sha256:e0739f3bc5d1c801999a202f0537280aa1bc2e669c49f5be91bfb99376690624", size = 18077, upload-time = "2026-04-02T04:22:23.049Z" }
 wheels = [
@@ -3839,7 +3889,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -3897,8 +3947,8 @@ name = "uvicorn"
 version = "0.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
@@ -3907,12 +3957,12 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "httptools", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "watchfiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3946,16 +3996,16 @@ name = "voyageai"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aiolimiter" },
-    { name = "ffmpeg-python" },
-    { name = "langchain-text-splitters" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "tenacity" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "aiolimiter", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "ffmpeg-python", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "langchain-text-splitters", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "numpy", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pillow", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "tenacity", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
+    { name = "tokenizers", marker = "(python_full_version < '3.14' and sys_platform == 'darwin') or (python_full_version < '3.14' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/16/1b46b3cd401e1717a68197c1fe336d7bb4e0a1833f8105e1738f5b1add05/voyageai-0.3.7.tar.gz", hash = "sha256:826cd97f97223f42b5babc5c459c9c80f3a8215ce5c0e007b0b276550f790d24", size = 26485, upload-time = "2025-12-16T18:43:05.26Z" }
 wheels = [
@@ -3967,7 +4017,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -4018,11 +4068,11 @@ name = "webauthn"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cbor2" },
-    { name = "cryptography" },
-    { name = "pyasn1" },
-    { name = "pyasn1-modules" },
-    { name = "pyopenssl" },
+    { name = "cbor2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyasn1", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyasn1-modules", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pyopenssl", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/22/b19c91e850c4578b7d6cdb53453c5fe2f2e99d0c56e322c65c3caf1b3051/webauthn-3.0.0.tar.gz", hash = "sha256:324e54e1f6eeef486623b5d90df6fcd74ae04ff0c137d2b818a8f709b6ca3ab8", size = 160472, upload-time = "2026-06-29T22:40:33.478Z" }
 wheels = [
@@ -4064,7 +4114,7 @@ name = "werkzeug"
 version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe" },
+    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
@@ -4117,7 +4167,7 @@ name = "wsproto"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
@@ -4129,14 +4179,14 @@ name = "xai-sdk"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-sdk" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pydantic" },
-    { name = "requests" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "googleapis-common-protos", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "grpcio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/32/bb8385f7a3b05ce406b689aa000c9a34289caa1526f1c093a1cefc0d9695/xai_sdk-1.11.0.tar.gz", hash = "sha256:ca87a830d310fb8e06fba44fb2a8c5cdf0d9f716b61126eddd51b7f416a63932", size = 404313, upload-time = "2026-03-27T18:23:10.091Z" }
 wheels = [
@@ -4222,9 +4272,9 @@ name = "yarl"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna" },
-    { name = "multidict" },
-    { name = "propcache" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "multidict", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "propcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [

--- a/web/e2e/parity.bootstrap.spec.ts
+++ b/web/e2e/parity.bootstrap.spec.ts
@@ -21,6 +21,7 @@ test("the deployment bootstrap is served unauthenticated", async ({
       "budgets",
       "keys",
       "models",
+      "organization_alerts",
       "organizations",
       "pricing",
       "providers",

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -43,6 +43,15 @@ const WORKSPACE_ROUTES: ReadonlyArray<{
     name: "organization-domains",
     heading: /email domains/i,
   },
+  // Beside the budgets it watches, on the organization rail. Its own entry
+  // because the rule table and the per-row test outcome are what this page is,
+  // and the budgets page above shows neither. Captured at rest, so the create
+  // form is covered by the vitest suite rather than here.
+  {
+    route: "/organization/alerts",
+    name: "organization-alerts",
+    heading: /budget alerts/i,
+  },
   { route: "/usage", name: "usage", heading: /usage/i },
   { route: "/activity", name: "activity", heading: /activity/i },
   { route: "/tools", name: "tools", heading: /tools/i },

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -585,6 +585,7 @@ describe("AppShell surface gating", () => {
       "Members & roles",
       "Email domains",
       "Spend & budgets",
+      "Budget alerts",
       "Model pricing",
       "Org settings",
       "Settings",

--- a/web/src/app/nav/overlayNavItems.test.ts
+++ b/web/src/app/nav/overlayNavItems.test.ts
@@ -44,7 +44,7 @@ describe("a build that replaces the nav-item module", () => {
   it("appends a contributed row after the organization section's own", () => {
     expect(
       section(ORG_NAV_SECTIONS, "org-money")?.items.map((item) => item.label),
-    ).toEqual(["Spend & budgets", "Model pricing", "Billing"])
+    ).toEqual(["Spend & budgets", "Budget alerts", "Model pricing", "Billing"])
   })
 
   it("appends into a second organization section from the same list", () => {

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -73,6 +73,7 @@ describe("nav registry", () => {
       "Email domains",
       "Providers",
       "Spend & budgets",
+      "Budget alerts",
       "Model pricing",
       "Guardrails",
       "Org settings",
@@ -152,6 +153,7 @@ describe("nav registry", () => {
     const money = ORG_NAV_SECTIONS.find((section) => section.id === "org-money")
     expect(money?.items.map((item) => [item.label, item.surface])).toEqual([
       ["Spend & budgets", "budgets"],
+      ["Budget alerts", "organization_alerts"],
       ["Model pricing", "pricing"],
     ])
     // No row gates on `users` any more. The gateway still serves that surface
@@ -276,6 +278,7 @@ describe("nav registry", () => {
       "budgets",
       "keys",
       "models",
+      "organization_alerts",
       "organizations",
       "pricing",
       "providers",

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -2,6 +2,7 @@ import {
   FiActivity,
   FiAtSign,
   FiBarChart2,
+  FiBell,
   FiBox,
   FiCode,
   FiDollarSign,
@@ -341,6 +342,17 @@ const ORGANIZATION_NAV_SECTIONS = [
         label: "Spend & budgets",
         surface: "budgets",
         icon: FiDollarSign,
+      },
+      // Beside the budgets it watches, because it is only ever configured
+      // right after one: a cap nobody is told about is the gap #410 opened.
+      // Its own surface rather than a reading of `budgets`, since the router
+      // behind it is the organization-scoped one and a deployment could serve
+      // the caps without it.
+      {
+        to: "/organization/alerts",
+        label: "Budget alerts",
+        surface: "organization_alerts",
+        icon: FiBell,
       },
       // Tenant-scoped in fact as well as in the design: a rate applies to every
       // workspace and every key in the deployment. The catalog had no home

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -327,6 +327,15 @@ export type CreateOrganizationDomainRequest =
 export type UpdateOrganizationDomainRequest =
   Schemas["OrganizationDomainUpdateRequest"]
 
+// An organization's budget alert rules. `destination` on the public shape is
+// the redaction, not the Apprise URL: the stored value is a live bot token and
+// the server never returns it, so the UI can display this field but can never
+// round-trip it back into an update.
+export type AlertRule = Schemas["AlertRulePublic"]
+export type CreateAlertRuleRequest = Schemas["AlertRuleCreate"]
+export type UpdateAlertRuleRequest = Schemas["AlertRuleUpdate"]
+export type AlertRuleTestResult = Schemas["AlertRuleTestResult"]
+
 // ---------------------------------------------------------------------------
 // Routing
 // ---------------------------------------------------------------------------

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1585,6 +1585,104 @@ export interface paths {
         patch: operations["update_active_organization_v1_organizations_me_patch"];
         trace?: never;
     };
+    "/v1/organizations/me/alert-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Alert Rules
+         * @description List where the caller's organization sends its budget alerts.
+         *
+         *     Organization owners and admins only. Each rule's destination is returned
+         *     redacted to its scheme and host: an Apprise URL carries its credentials in
+         *     the path, so the stored value is never echoed back.
+         */
+        get: operations["list_alert_rules_v1_organizations_me_alert_rules_get"];
+        put?: never;
+        /**
+         * Create Alert Rule
+         * @description Send this organization's budget alerts somewhere. Organization owners and admins only.
+         *
+         *     ``destination`` is an Apprise URL, so one field covers Slack, Discord,
+         *     PagerDuty, Telegram, mail and a plain JSON webhook. It is validated for
+         *     parseability here, and a webhook-shaped destination is additionally checked
+         *     against the same SSRF rules the MCP and web-search write paths apply.
+         *
+         *     ``warn_at_percent`` defaults to 80, which is the useful half of this
+         *     feature: a refusal is already too late to act on. Set it to null to alert
+         *     only when a ceiling starts refusing requests.
+         */
+        post: operations["create_alert_rule_v1_organizations_me_alert_rules_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/alert-rules/{rule_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Alert Rule
+         * @description Discard a rule and its delivery history. Organization owners and admins only.
+         *
+         *     Use ``enabled: false`` instead to stop the alerts while keeping the
+         *     destination. Deleting drops the record of what has already been sent, so a
+         *     ceiling that is still over its threshold alerts again once a rule is
+         *     recreated.
+         */
+        delete: operations["delete_alert_rule_v1_organizations_me_alert_rules__rule_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Alert Rule
+         * @description Change a rule's name, destination, thresholds, or enabled flag.
+         *
+         *     Organization owners and admins only. Omitted fields are left as they are.
+         *     ``warn_at_percent`` is the one field where an explicit null is a value
+         *     rather than an omission: it means stop warning and alert only on refusal.
+         */
+        patch: operations["update_alert_rule_v1_organizations_me_alert_rules__rule_id__patch"];
+        trace?: never;
+    };
+    "/v1/organizations/me/alert-rules/{rule_id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test Alert Rule
+         * @description Send a sample alert to this rule's destination now. Organization owners and admins only.
+         *
+         *     The counterpart of ``POST /v1/settings/mail/test``: a destination that
+         *     silently accepts nothing looks exactly like a budget that never crossed a
+         *     threshold, so proving the path works belongs at setup time rather than
+         *     during the incident it was meant to warn about.
+         *
+         *     Records nothing. A test is not an alert about a ceiling, and claiming a
+         *     dedupe key here would suppress the real alert it is rehearsing for.
+         */
+        post: operations["test_alert_rule_v1_organizations_me_alert_rules__rule_id__test_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/me/aliases": {
         parameters: {
             query?: never;
@@ -4892,6 +4990,131 @@ export interface components {
              * @default 0
              */
             requests: number;
+        };
+        /**
+         * AlertRuleCreate
+         * @description Request body for a new alert rule.
+         *
+         *     ``destination`` is an Apprise URL. It is validated for parseability at this
+         *     boundary rather than at send time, so an operator learns their URL is
+         *     unusable while the form is still open instead of discovering it from an
+         *     alert that never arrived.
+         * @example {
+         *       "destination": "slack://xoxb-token/C0123456789",
+         *       "name": "Platform team Slack",
+         *       "notify_on_exceeded": true,
+         *       "warn_at_percent": 80
+         *     }
+         */
+        AlertRuleCreate: {
+            /**
+             * Destination
+             * @description Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Encrypted at rest and never returned
+             */
+            destination: string;
+            /**
+             * Enabled
+             * @description False stops this rule sending without discarding it
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Name
+             * @description How this rule is identified in the dashboard and in the alert body, unique per organization
+             */
+            name: string;
+            /**
+             * Notify On Exceeded
+             * @description Send an alert when a ceiling reaches a limit and starts refusing requests
+             * @default true
+             */
+            notify_on_exceeded: boolean;
+            /**
+             * Warn At Percent
+             * @description Send a warning once a ceiling reaches this percent of any of its limits. Null sends no warning, leaving only the exceeded alert
+             * @default 80
+             */
+            warn_at_percent: number | null;
+        };
+        /**
+         * AlertRulePublic
+         * @description The API-facing shape. Carries the redacted destination, never the real one.
+         */
+        AlertRulePublic: {
+            /** Created At */
+            created_at: string;
+            /** Destination */
+            destination: string;
+            /** Enabled */
+            enabled: boolean;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Notify On Exceeded */
+            notify_on_exceeded: boolean;
+            /**
+             * Organization Id
+             * Format: uuid
+             */
+            organization_id: string;
+            /** Updated At */
+            updated_at: string;
+            /** Warn At Percent */
+            warn_at_percent: number | null;
+        };
+        /**
+         * AlertRuleTestResult
+         * @description The outcome of one on-demand send.
+         *
+         *     ``detail`` carries the dispatcher's reason on failure, which names what went
+         *     wrong without naming the destination, since the caller already knows which
+         *     rule they asked about.
+         */
+        AlertRuleTestResult: {
+            /** Delivered */
+            delivered: boolean;
+            /** Detail */
+            detail?: string | null;
+        };
+        /**
+         * AlertRuleUpdate
+         * @description Partial update. Only the fields the caller sets are applied.
+         *
+         *     ``destination`` has two states rather than three, unlike the credential
+         *     fields on `organization_guardrail_service`: the column is NOT NULL, so there
+         *     is nothing to clear it to. Omit it to keep the stored destination, send a
+         *     value to replace it.
+         *
+         *     ``warn_at_percent`` is the opposite: an explicit ``null`` is meaningful
+         *     there and means "stop warning, alert only on refusal", so it is the one
+         *     field here where null is accepted as a value.
+         * @example {
+         *       "enabled": false,
+         *       "warn_at_percent": 90
+         *     }
+         */
+        AlertRuleUpdate: {
+            /** Destination */
+            destination?: string;
+            /** Enabled */
+            enabled?: boolean;
+            /** Name */
+            name?: string;
+            /** Notify On Exceeded */
+            notify_on_exceeded?: boolean;
+            /** Warn At Percent */
+            warn_at_percent?: number | null;
+        };
+        /** AlertRulesPublic */
+        AlertRulesPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["AlertRulePublic"][];
         };
         /**
          * AliasRequest
@@ -12940,6 +13163,170 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OrganizationMembershipContextPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_alert_rules_v1_organizations_me_alert_rules_get: {
+        parameters: {
+            query?: {
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRulesPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_alert_rule_v1_organizations_me_alert_rules_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertRuleCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRulePublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_alert_rule_v1_organizations_me_alert_rules__rule_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_alert_rule_v1_organizations_me_alert_rules__rule_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AlertRuleUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRulePublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    test_alert_rule_v1_organizations_me_alert_rules__rule_id__test_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rule_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertRuleTestResult"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5009,7 +5009,7 @@ export interface components {
         AlertRuleCreate: {
             /**
              * Destination
-             * @description Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Encrypted at rest and never returned
+             * @description Apprise destination URL, for example slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, or json://host/path for a plain webhook. Only the schemas Otari has classified are accepted, because whether the URL names a host decides whether the SSRF check applies; a rejection lists them. Encrypted at rest and never returned
              */
             destination: string;
             /**

--- a/web/src/features/docs/DocsPage.test.tsx
+++ b/web/src/features/docs/DocsPage.test.tsx
@@ -176,15 +176,20 @@ describe("DocsPage code blocks", () => {
     expect(screen.queryByRole("button", { name: "Copy" })).toBeNull()
   })
 
-  it("renders the guide's one fence with the block treatment", () => {
-    // The guide carries exactly one fence outside the dropped walkthrough (a
-    // `bash` block for `otari gen-secret-key`), which is what puts the label
-    // row and copy control on this page. Pinned at one rather than at zero, so
-    // a second fence appearing still says so.
+  it("renders every fence in the guide with the block treatment", () => {
+    // The guide carries two fences outside the dropped walkthrough: a `bash`
+    // block for `otari gen-secret-key`, and the alert-destination URL examples
+    // under Budget alerts. Both are what put the label row and copy control on
+    // this page. Pinned at a count rather than at zero, so a fence appearing or
+    // disappearing still says so, and the label count is asserted against the
+    // block count rather than separately, so a fence that rendered without its
+    // label row would fail here too.
     const { container } = render(<DocsPage />)
     const blocks = container.querySelectorAll("pre")
-    expect(blocks).toHaveLength(1)
-    expect(container.querySelectorAll(".otari-code-label")).toHaveLength(1)
+    expect(blocks).toHaveLength(2)
+    expect(container.querySelectorAll(".otari-code-label")).toHaveLength(
+      blocks.length,
+    )
     expect(container.querySelectorAll("code").length).toBeGreaterThan(0)
   })
 })

--- a/web/src/features/organization/OrganizationAlertsPage.test.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.test.tsx
@@ -1,0 +1,233 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactElement } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { AlertRule, OrganizationContext } from "@/client"
+import { OrganizationAlertsPage } from "@/features/organization/OrganizationAlertsPage"
+import { alertRule, organizationContext } from "@/tests/fixtures"
+
+// Mocked at the `apiFetch` boundary (`globalThis.fetch`) rather than at the
+// hooks, per the frontend standards: the query keys, the invalidations and the
+// request bodies are part of what these tests are for.
+
+interface Request {
+  url: string
+  method: string
+  body: unknown
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+interface MockOpts {
+  rules?: AlertRule[]
+  context?: OrganizationContext
+  /** What the test-send call answers, so a test can drive the refusal path. */
+  test?: () => Response
+}
+
+function mockApi(opts: MockOpts = {}) {
+  const rules = opts.rules ?? []
+  const requests: Request[] = []
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input)
+    const method = (init?.method ?? "GET").toUpperCase()
+    requests.push({
+      url,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    })
+
+    if (url.includes("/test")) {
+      return opts.test
+        ? opts.test()
+        : jsonResponse({ delivered: true, detail: null })
+    }
+    if (url.includes("/alert-rules")) {
+      if (method === "GET") {
+        return jsonResponse({ count: rules.length, data: rules })
+      }
+      // Every write is re-read through the invalidated list, so one row serves.
+      return jsonResponse(rules[0] ?? alertRule())
+    }
+    return jsonResponse(opts.context ?? organizationContext())
+  })
+  return requests
+}
+
+function renderPage(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("OrganizationAlertsPage", () => {
+  it("lists the organization's rules", async () => {
+    mockApi({ rules: [alertRule({ name: "Platform team Slack" })] })
+    renderPage(<OrganizationAlertsPage />)
+
+    expect(await screen.findByText("Platform team Slack")).toBeInTheDocument()
+    // The kind is derived from the redacted scheme, which is all the client has.
+    expect(screen.getByText("Slack")).toBeInTheDocument()
+    expect(screen.getByText("80%")).toBeInTheDocument()
+    expect(screen.getByText("Limit reached")).toBeInTheDocument()
+    expect(screen.getByText("Active")).toBeInTheDocument()
+  })
+
+  it("never renders anything but the server's redaction", async () => {
+    // The security assertion of this file. The page has no way to obtain a real
+    // Apprise URL, and this fails if a future change starts echoing one.
+    mockApi({ rules: [alertRule({ destination: "slack://***" })] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    expect(screen.getByText("slack://***")).toBeInTheDocument()
+    expect(document.body.textContent).not.toContain("xoxb")
+  })
+
+  it("shows an empty state rather than a bare table", async () => {
+    mockApi({ rules: [] })
+    renderPage(<OrganizationAlertsPage />)
+
+    expect(
+      await screen.findByText(/No alert destinations yet/),
+    ).toBeInTheDocument()
+  })
+
+  it("creates a rule with the thresholds the form collected", async () => {
+    const requests = mockApi({ rules: [] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText(/No alert destinations yet/)
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add destination" }),
+    )
+
+    await userEvent.type(screen.getByLabelText("Name"), "Ops webhook")
+    await userEvent.type(
+      screen.getByLabelText("Destination"),
+      "json://hooks.example.com/incoming",
+    )
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add destination" }),
+    )
+
+    await waitFor(() => {
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "POST" && request.url.includes("/alert-rules"),
+        ),
+      ).toBe(true)
+    })
+    const created = requests.find((request) => request.method === "POST")
+    expect(created?.body).toMatchObject({
+      name: "Ops webhook",
+      destination: "json://hooks.example.com/incoming",
+      warn_at_percent: 80,
+      notify_on_exceeded: true,
+      enabled: true,
+    })
+  })
+
+  it("will not submit a rule that could never fire", async () => {
+    mockApi({ rules: [] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText(/No alert destinations yet/)
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add destination" }),
+    )
+    await userEvent.type(screen.getByLabelText("Name"), "Inert")
+    await userEvent.type(screen.getByLabelText("Destination"), "slack://a/b/c")
+
+    // Turn off the refusal alert, then clear the warning threshold: together
+    // these leave a rule with nothing to send.
+    await userEvent.click(
+      screen.getByRole("checkbox", {
+        name: /Also alert when a budget starts refusing requests/,
+      }),
+    )
+    await userEvent.click(screen.getByRole("button", { name: /Warn early at/ }))
+    await userEvent.click(
+      await screen.findByRole("option", { name: "No early warning" }),
+    )
+
+    expect(await screen.findByText(/would never/)).toBeInTheDocument()
+    const submit = screen
+      .getAllByRole("button", { name: "Add destination" })
+      .at(-1)
+    expect(submit).toBeDisabled()
+  })
+
+  it("pauses a rule without touching its destination", async () => {
+    const requests = mockApi({ rules: [alertRule({ enabled: true })] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Pause" }))
+
+    await waitFor(() => {
+      expect(requests.some((request) => request.method === "PATCH")).toBe(true)
+    })
+    const patch = requests.find((request) => request.method === "PATCH")
+    // Only `enabled`. Sending `destination` back would post the redaction as a
+    // real value, which is why the update body is built field by field.
+    expect(patch?.body).toEqual({ enabled: false })
+  })
+
+  it("reports a successful test send", async () => {
+    mockApi({ rules: [alertRule()] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Send test" }))
+
+    expect(await screen.findByText("Test delivered")).toBeInTheDocument()
+  })
+
+  it("reports a refused test send rather than claiming success", async () => {
+    // The case the whole test action exists for: a destination that parses,
+    // stores, and then quietly accepts nothing.
+    mockApi({
+      rules: [alertRule()],
+      test: () =>
+        jsonResponse({ delivered: false, detail: "Timed out after 15s" }),
+    })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Send test" }))
+
+    expect(await screen.findByText("Test failed")).toBeInTheDocument()
+  })
+
+  it("tells a plain member they may not manage alerts, and offers no controls", async () => {
+    mockApi({
+      rules: [],
+      context: organizationContext({ role: "member" }),
+    })
+    renderPage(<OrganizationAlertsPage />)
+
+    expect(
+      await screen.findByText(/Only organization owners and admins/),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Add destination" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Send test" }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/web/src/features/organization/OrganizationAlertsPage.test.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.test.tsx
@@ -187,6 +187,54 @@ describe("OrganizationAlertsPage", () => {
     expect(patch?.body).toEqual({ enabled: false })
   })
 
+  it("edits a rule without resending its destination", async () => {
+    const requests = mockApi({
+      rules: [alertRule({ warn_at_percent: 80 })],
+    })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }))
+    await screen.findByText("Edit Platform team Slack")
+
+    await userEvent.clear(screen.getByLabelText("Name"))
+    await userEvent.type(screen.getByLabelText("Name"), "Platform team pager")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    await waitFor(() => {
+      expect(requests.some((request) => request.method === "PATCH")).toBe(true)
+    })
+    const patch = requests.find((request) => request.method === "PATCH")
+    // No `destination` key at all. The box was left empty, and the server reads
+    // an absent destination as "keep the stored one"; sending the redaction
+    // back would overwrite a working rule with a mask.
+    expect(patch?.body).toEqual({
+      name: "Platform team pager",
+      warn_at_percent: 80,
+      notify_on_exceeded: true,
+    })
+  })
+
+  it("replaces the destination when the edit form is given a new one", async () => {
+    const requests = mockApi({ rules: [alertRule()] })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }))
+    await userEvent.type(
+      screen.getByLabelText("Destination"),
+      "discord://1/tok",
+    )
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    await waitFor(() => {
+      expect(requests.some((request) => request.method === "PATCH")).toBe(true)
+    })
+    expect(
+      requests.find((request) => request.method === "PATCH")?.body,
+    ).toMatchObject({ destination: "discord://1/tok" })
+  })
+
   it("reports a successful test send", async () => {
     mockApi({ rules: [alertRule()] })
     renderPage(<OrganizationAlertsPage />)

--- a/web/src/features/organization/OrganizationAlertsPage.test.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.test.tsx
@@ -213,6 +213,24 @@ describe("OrganizationAlertsPage", () => {
     expect(await screen.findByText("Test failed")).toBeInTheDocument()
   })
 
+  it("says so when the test request itself fails, rather than going silent", async () => {
+    // The state a chip keyed on isSuccess alone renders nothing for: the
+    // operator presses the button, the spinner clears, and nothing appears.
+    // Distinct from a refused delivery, because the fix is different.
+    mockApi({
+      rules: [alertRule()],
+      test: () => new Response("nope", { status: 503 }),
+    })
+    renderPage(<OrganizationAlertsPage />)
+
+    await screen.findByText("Platform team Slack")
+    await userEvent.click(screen.getByRole("button", { name: "Send test" }))
+
+    expect(await screen.findByText(/Couldn't send test/)).toBeInTheDocument()
+    expect(screen.queryByText("Test delivered")).not.toBeInTheDocument()
+    expect(screen.queryByText("Test failed")).not.toBeInTheDocument()
+  })
+
   it("tells a plain member they may not manage alerts, and offers no controls", async () => {
     mockApi({
       rules: [],

--- a/web/src/features/organization/OrganizationAlertsPage.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.tsx
@@ -30,28 +30,22 @@ import { canManage } from "./roles"
 
 // Where this organization's budget alerts go.
 //
-// The page is built around one asymmetry, the same shape the email-domains page
-// has: creating a rule is free and proves nothing, and the thing that decides
-// whether an alert ever arrives is whether the destination actually accepts a
-// delivery. So "Send test" is a first-class action on every row rather than
-// something buried in an edit form. A destination that silently accepts nothing
-// is indistinguishable from a budget that never crossed a threshold, and the
-// moment to discover that is while setting the rule up, not during the overspend
-// it was meant to warn about.
+// The page is built around one asymmetry: creating a rule is free and proves
+// nothing, and what decides whether an alert ever arrives is whether the
+// destination actually accepts a delivery. So "Send test" is a first-class
+// action on every row. A destination that silently accepts nothing looks
+// exactly like a budget that never crossed a threshold.
 //
 // The destination is write-only in both directions. The server stores it
-// encrypted and returns only a redaction (scheme and host, path and query
-// masked), because an Apprise URL carries its credentials in the path. So the
-// table shows the redaction, the create form takes the URL once through a
-// `SecretField`, and editing a rule never prefills it: an empty destination box
-// on an edit form means "keep the stored one", which is exactly what the API's
+// encrypted and returns only a redaction, because an Apprise URL carries its
+// credentials in the path. The table shows the redaction, the create form takes
+// the URL once through a `SecretField`, and the edit form never prefills it: an
+// empty destination box means "keep the stored one", which is what the API's
 // omit-to-keep contract expects.
 //
-// What a rule watches is not configurable here, and that is deliberate rather
-// than unfinished: a rule covers every one of the organization's budget
-// ceilings. Picking ceilings per rule would be a second scoping model on top of
-// the one `budgets` already has, and the useful default is "tell me about all of
-// my caps".
+// What a rule watches is not configurable, and that is deliberate: a rule covers
+// every one of the organization's ceilings. Picking ceilings per rule would be a
+// second scoping model on top of the one `budgets` already has.
 
 /**
  * The warning thresholds offered, plus the "no warning" case.
@@ -83,25 +77,64 @@ function destinationKind(destination: string): string {
   return "Custom"
 }
 
-function RuleForm({ onClose }: { onClose: () => void }) {
+/**
+ * The create and edit form, which are the same fields over two verbs.
+ *
+ * Editing prefills everything except the destination, which cannot be prefilled
+ * because the server never returns it. An empty box therefore means "keep the
+ * stored one", and the PATCH omits the field entirely.
+ */
+function RuleForm({
+  rule,
+  onClose,
+}: {
+  rule?: AlertRule
+  onClose: () => void
+}) {
   const create = useCreateAlertRule()
-  const [name, setName] = useState("")
+  const update = useUpdateAlertRule()
+  const [name, setName] = useState(rule?.name ?? "")
   const [destination, setDestination] = useState("")
-  const [warnAt, setWarnAt] = useState("80")
-  const [notifyOnExceeded, setNotifyOnExceeded] = useState(true)
+  const [warnAt, setWarnAt] = useState(
+    rule ? (rule.warn_at_percent?.toString() ?? "") : "80",
+  )
+  const [notifyOnExceeded, setNotifyOnExceeded] = useState(
+    rule?.notify_on_exceeded ?? true,
+  )
+
+  const editing = rule !== undefined
+  const mutation = editing ? update : create
 
   // A rule with neither threshold can never produce a message, which the server
   // refuses too. Caught here so the button is simply unavailable rather than
   // the operator submitting into a 422.
   const inert = warnAt === "" && !notifyOnExceeded
-  const incomplete = name.trim() === "" || destination.trim() === ""
+  const incomplete =
+    name.trim() === "" || (!editing && destination.trim() === "")
 
   const submit = () => {
-    const body: CreateAlertRuleRequest = {
+    const shared = {
       name: name.trim(),
-      destination: destination.trim(),
       warn_at_percent: warnAt === "" ? null : Number(warnAt),
       notify_on_exceeded: notifyOnExceeded,
+    }
+    if (editing) {
+      update.mutate(
+        {
+          ruleId: rule.id,
+          // Omitted, not sent empty: the server reads an absent destination as
+          // "keep the stored one".
+          body: destination.trim()
+            ? { ...shared, destination: destination.trim() }
+            : shared,
+        },
+        { onSuccess: onClose },
+      )
+      return
+    }
+    const body: CreateAlertRuleRequest = {
+      ...shared,
+      destination: destination.trim(),
       enabled: true,
     }
     create.mutate(body, {
@@ -118,8 +151,10 @@ function RuleForm({ onClose }: { onClose: () => void }) {
       className="border-y border-border py-5"
       contentClassName="flex flex-col gap-4"
     >
-      <h2 className="text-title">Add an alert destination</h2>
-      <ErrorBanner error={create.error} />
+      <h2 className="text-title">
+        {editing ? `Edit ${rule.name}` : "Add an alert destination"}
+      </h2>
+      <ErrorBanner error={mutation.error} />
       <Field
         label="Name"
         value={name}
@@ -134,7 +169,11 @@ function RuleForm({ onClose }: { onClose: () => void }) {
         value={destination}
         onChange={setDestination}
         placeholder="slack://token/channel"
-        description="An Apprise URL. slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, mailto://user@example.com, or json://host/path for a plain webhook. Stored encrypted and never shown again."
+        description={
+          editing
+            ? "Leave empty to keep the stored destination. Type a new Apprise URL to replace it."
+            : "An Apprise URL. slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, mailto://user:password@smtp.example.com, or json://host/path for a plain webhook. Stored encrypted and never shown again."
+        }
       />
       <FilterSelect
         label="Warn early at"
@@ -159,10 +198,10 @@ function RuleForm({ onClose }: { onClose: () => void }) {
         <Button
           variant="primary"
           isDisabled={incomplete || inert}
-          isPending={create.isPending}
+          isPending={mutation.isPending}
           onPress={submit}
         >
-          Add destination
+          {editing ? "Save changes" : "Add destination"}
         </Button>
         <Button variant="ghost" onPress={onClose}>
           Cancel
@@ -227,8 +266,10 @@ export function OrganizationAlertsPage() {
   const update = useUpdateAlertRule()
   const remove = useDeleteAlertRule()
   const [adding, setAdding] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
 
   const rows = rules.data?.data ?? []
+  const editingRule = rows.find((row) => row.id === editingId)
 
   const columns: DataTableColumn<AlertRule>[] = [
     {
@@ -302,6 +343,16 @@ export function OrganizationAlertsPage() {
           <Button
             size="sm"
             variant="ghost"
+            onPress={() => {
+              setAdding(false)
+              setEditingId(row.id)
+            }}
+          >
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
             isDisabled={update.isPending}
             onPress={() =>
               update.mutate({
@@ -329,7 +380,7 @@ export function OrganizationAlertsPage() {
       <PageIntro
         title="Budget alerts"
         action={
-          canEdit && !adding ? (
+          canEdit && !adding && editingId === null ? (
             <Button variant="primary" onPress={() => setAdding(true)}>
               Add destination
             </Button>
@@ -355,6 +406,13 @@ export function OrganizationAlertsPage() {
       ) : null}
 
       {adding ? <RuleForm onClose={() => setAdding(false)} /> : null}
+      {editingRule ? (
+        <RuleForm
+          key={editingRule.id}
+          rule={editingRule}
+          onClose={() => setEditingId(null)}
+        />
+      ) : null}
 
       {canEdit || context.isPending ? (
         <TableScrollFrame className="otari-alert-rules-table">

--- a/web/src/features/organization/OrganizationAlertsPage.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.tsx
@@ -1,0 +1,355 @@
+import { Button, Chip } from "@heroui/react"
+import { useState } from "react"
+
+import type { AlertRule, CreateAlertRuleRequest } from "@/client"
+import {
+  useAlertRules,
+  useCreateAlertRule,
+  useDeleteAlertRule,
+  useTestAlertRule,
+  useUpdateAlertRule,
+} from "@/shared/api/alerts"
+import { useOrganizationContext } from "@/shared/api/organizations"
+import { ConfirmButton } from "@/shared/components/actions/ConfirmButton"
+import {
+  DataTable,
+  type DataTableColumn,
+} from "@/shared/components/data/DataTable"
+import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
+import { InfoBanner } from "@/shared/components/feedback/InfoBanner"
+import { Checkbox } from "@/shared/components/forms/Checkbox"
+import { Field } from "@/shared/components/forms/Field"
+import { SecretField } from "@/shared/components/forms/SecretField"
+import { PageIntro } from "@/shared/components/layout/PageIntro"
+import { Section } from "@/shared/components/layout/Section"
+import { TableScrollFrame } from "@/shared/components/layout/TableScrollFrame"
+import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
+import { formatRelative } from "@/shared/helpers/format"
+
+import { canManage } from "./roles"
+
+// Where this organization's budget alerts go.
+//
+// The page is built around one asymmetry, the same shape the email-domains page
+// has: creating a rule is free and proves nothing, and the thing that decides
+// whether an alert ever arrives is whether the destination actually accepts a
+// delivery. So "Send test" is a first-class action on every row rather than
+// something buried in an edit form. A destination that silently accepts nothing
+// is indistinguishable from a budget that never crossed a threshold, and the
+// moment to discover that is while setting the rule up, not during the overspend
+// it was meant to warn about.
+//
+// The destination is write-only in both directions. The server stores it
+// encrypted and returns only a redaction (scheme and host, path and query
+// masked), because an Apprise URL carries its credentials in the path. So the
+// table shows the redaction, the create form takes the URL once through a
+// `SecretField`, and editing a rule never prefills it: an empty destination box
+// on an edit form means "keep the stored one", which is exactly what the API's
+// omit-to-keep contract expects.
+//
+// What a rule watches is not configurable here, and that is deliberate rather
+// than unfinished: a rule covers every one of the organization's budget
+// ceilings. Picking ceilings per rule would be a second scoping model on top of
+// the one `budgets` already has, and the useful default is "tell me about all of
+// my caps".
+
+/**
+ * The warning thresholds offered, plus the "no warning" case.
+ *
+ * A picker rather than a free number field: the server accepts 1 to 99 and
+ * nobody needs 63. `""` is the absent case, which the API takes as an explicit
+ * null and reads as "alert only when a ceiling starts refusing requests".
+ */
+const WARN_THRESHOLD_OPTIONS = [
+  { value: "50", label: "50% of the limit" },
+  { value: "75", label: "75% of the limit" },
+  { value: "80", label: "80% of the limit" },
+  { value: "90", label: "90% of the limit" },
+  { value: "95", label: "95% of the limit" },
+  { value: "", label: "No early warning" },
+]
+
+/** A short, non-technical hint at what a redacted destination will reach. */
+function destinationKind(destination: string): string {
+  const scheme = destination.split(":")[0]?.toLowerCase() ?? ""
+  if (scheme.startsWith("slack")) return "Slack"
+  if (scheme.startsWith("discord")) return "Discord"
+  if (scheme.startsWith("pagerduty") || scheme.startsWith("pagertree"))
+    return "PagerDuty"
+  if (scheme.startsWith("tgram") || scheme.startsWith("telegram"))
+    return "Telegram"
+  if (scheme.startsWith("mailto")) return "Email"
+  if (scheme.startsWith("json") || scheme.startsWith("form")) return "Webhook"
+  return "Custom"
+}
+
+function RuleForm({ onClose }: { onClose: () => void }) {
+  const create = useCreateAlertRule()
+  const [name, setName] = useState("")
+  const [destination, setDestination] = useState("")
+  const [warnAt, setWarnAt] = useState("80")
+  const [notifyOnExceeded, setNotifyOnExceeded] = useState(true)
+
+  // A rule with neither threshold can never produce a message, which the server
+  // refuses too. Caught here so the button is simply unavailable rather than
+  // the operator submitting into a 422.
+  const inert = warnAt === "" && !notifyOnExceeded
+  const incomplete = name.trim() === "" || destination.trim() === ""
+
+  const submit = () => {
+    const body: CreateAlertRuleRequest = {
+      name: name.trim(),
+      destination: destination.trim(),
+      warn_at_percent: warnAt === "" ? null : Number(warnAt),
+      notify_on_exceeded: notifyOnExceeded,
+      enabled: true,
+    }
+    create.mutate(body, {
+      onSuccess: () => {
+        setName("")
+        setDestination("")
+        onClose()
+      },
+    })
+  }
+
+  return (
+    <Section
+      className="border-y border-border py-5"
+      contentClassName="flex flex-col gap-4"
+    >
+      <h2 className="text-title">Add an alert destination</h2>
+      <ErrorBanner error={create.error} />
+      <Field
+        label="Name"
+        value={name}
+        onChange={setName}
+        isRequired
+        autoFocus
+        placeholder="Platform team Slack"
+        description="How this rule is identified in the alert itself, so whoever reads the message knows which rule sent it."
+      />
+      <SecretField
+        label="Destination"
+        value={destination}
+        onChange={setDestination}
+        placeholder="slack://token/channel"
+        description="An Apprise URL. slack://token/channel, discord://webhook_id/webhook_token, pagerduty://key@apikey, mailto://user@example.com, or json://host/path for a plain webhook. Stored encrypted and never shown again."
+      />
+      <FilterSelect
+        label="Warn early at"
+        value={warnAt}
+        onChange={setWarnAt}
+        options={WARN_THRESHOLD_OPTIONS}
+      />
+      <Checkbox isSelected={notifyOnExceeded} onChange={setNotifyOnExceeded}>
+        Also alert when a budget starts refusing requests
+      </Checkbox>
+      {inert ? (
+        <InfoBanner>
+          With no early warning and no alert on refusal, this rule would never
+          send anything. Pick a threshold, or leave the refusal alert on.
+        </InfoBanner>
+      ) : null}
+      <p className="text-caption">
+        The early warning is the useful one: by the time a budget starts
+        refusing requests, the overspend has already happened.
+      </p>
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          isDisabled={incomplete || inert}
+          isPending={create.isPending}
+          onPress={submit}
+        >
+          Add destination
+        </Button>
+        <Button variant="ghost" onPress={onClose}>
+          Cancel
+        </Button>
+      </div>
+    </Section>
+  )
+}
+
+/**
+ * The test action for one row, holding its own outcome.
+ *
+ * Per-row state rather than page state: two rows tested in a row must not show
+ * each other's result, and the mutation is deliberately not invalidating the
+ * list (a test writes nothing), so there is no refetch to hang the answer off.
+ */
+function TestRuleButton({ rule }: { rule: AlertRule }) {
+  const test = useTestAlertRule()
+  const result = test.data
+
+  return (
+    <div className="flex items-center justify-end gap-1.5">
+      {test.isSuccess ? (
+        <Chip size="sm" color={result?.delivered ? "accent" : "warning"}>
+          {result?.delivered ? "Test delivered" : "Test failed"}
+        </Chip>
+      ) : null}
+      <Button
+        size="sm"
+        variant="ghost"
+        isPending={test.isPending}
+        onPress={() => test.mutate(rule.id)}
+      >
+        Send test
+      </Button>
+    </div>
+  )
+}
+
+export function OrganizationAlertsPage() {
+  const context = useOrganizationContext()
+  const canEdit = canManage(context.data)
+  const rules = useAlertRules(canEdit)
+  const update = useUpdateAlertRule()
+  const remove = useDeleteAlertRule()
+  const [adding, setAdding] = useState(false)
+
+  const rows = rules.data?.data ?? []
+
+  const columns: DataTableColumn<AlertRule>[] = [
+    {
+      id: "name",
+      header: "Name",
+      isRowHeader: true,
+      cell: (row) => <span className="font-medium">{row.name}</span>,
+    },
+    {
+      id: "destination",
+      header: "Destination",
+      cell: (row) => (
+        <div className="flex flex-col">
+          <span>{destinationKind(row.destination)}</span>
+          {/* The redaction, not the URL: scheme and host only. Shown small
+              because it is for recognizing the row, not for reading. */}
+          <span className="text-caption break-all">{row.destination}</span>
+        </div>
+      ),
+    },
+    {
+      id: "thresholds",
+      header: "Alerts on",
+      cell: (row) => (
+        <div className="flex flex-wrap gap-1.5">
+          {row.warn_at_percent != null ? (
+            <Chip size="sm" color="default">{`${row.warn_at_percent}%`}</Chip>
+          ) : null}
+          {row.notify_on_exceeded ? (
+            <Chip size="sm" color="default">
+              Limit reached
+            </Chip>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "status",
+      header: "Status",
+      cell: (row) =>
+        row.enabled ? (
+          <Chip size="sm" color="accent">
+            Active
+          </Chip>
+        ) : (
+          <Chip size="sm" color="default">
+            Paused
+          </Chip>
+        ),
+    },
+    {
+      id: "added",
+      header: "Added",
+      cell: (row) => formatRelative(row.created_at),
+    },
+  ]
+
+  if (canEdit) {
+    columns.push({
+      id: "test",
+      header: "Test",
+      align: "end",
+      cell: (row) => <TestRuleButton rule={row} />,
+    })
+    columns.push({
+      id: "actions",
+      header: "Actions",
+      align: "end",
+      cell: (row) => (
+        <div className="flex items-center justify-end gap-1.5">
+          <Button
+            size="sm"
+            variant="ghost"
+            isDisabled={update.isPending}
+            onPress={() =>
+              update.mutate({
+                ruleId: row.id,
+                body: { enabled: !row.enabled },
+              })
+            }
+          >
+            {row.enabled ? "Pause" : "Resume"}
+          </Button>
+          <ConfirmButton
+            confirmLabel="Remove rule"
+            isPending={remove.isPending}
+            onConfirm={() => remove.mutate(row.id)}
+          >
+            Remove
+          </ConfirmButton>
+        </div>
+      ),
+    })
+  }
+
+  return (
+    <div className="flex flex-col">
+      <PageIntro
+        title="Budget alerts"
+        action={
+          canEdit && !adding ? (
+            <Button variant="primary" onPress={() => setAdding(true)}>
+              Add destination
+            </Button>
+          ) : null
+        }
+      >
+        Get told when this organization's budgets are running out, instead of
+        finding out when requests start being refused. Each destination is
+        checked against every budget ceiling the organization owns, and an alert
+        is sent once per budget period.
+      </PageIntro>
+
+      <ErrorBanner
+        error={context.error ?? rules.error ?? update.error ?? remove.error}
+      />
+
+      {/* Held back until the context has answered, so an admin is not told for
+          one paint that they may not be here. */}
+      {context.data && !canEdit ? (
+        <InfoBanner>
+          Only organization owners and admins can manage budget alerts.
+        </InfoBanner>
+      ) : null}
+
+      {adding ? <RuleForm onClose={() => setAdding(false)} /> : null}
+
+      {canEdit || context.isPending ? (
+        <TableScrollFrame className="otari-alert-rules-table">
+          <DataTable
+            ariaLabel="Budget alert rules"
+            columns={columns}
+            rows={rows}
+            getRowKey={(row) => row.id}
+            isLoading={context.isPending || rules.isLoading}
+            emptyContent="No alert destinations yet. Add one so a budget running out reaches you instead of waiting to be noticed."
+          />
+        </TableScrollFrame>
+      ) : null}
+    </div>
+  )
+}

--- a/web/src/features/organization/OrganizationAlertsPage.tsx
+++ b/web/src/features/organization/OrganizationAlertsPage.tsx
@@ -178,6 +178,20 @@ function RuleForm({ onClose }: { onClose: () => void }) {
  * Per-row state rather than page state: two rows tested in a row must not show
  * each other's result, and the mutation is deliberately not invalidating the
  * list (a test writes nothing), so there is no refetch to hang the answer off.
+ *
+ * Three outcomes rather than two, and the third is the one that matters. If the
+ * request itself fails (a network error, a 403, a 5xx) then `isSuccess` is
+ * false, `data` is undefined, and a chip keyed on success alone renders nothing
+ * once the spinner clears: the operator presses the button and gets silence,
+ * which is exactly the state this button exists to rule out. The page-level
+ * `ErrorBanner` does not cover it either, because this mutation belongs to one
+ * row rather than to the page.
+ *
+ * "Test failed" and "Couldn't send test" are kept apart on purpose. The first
+ * means the gateway reached the destination and the destination refused, which
+ * is a bad Apprise URL. The second means the gateway never got that far, which
+ * is a session, network or server problem. They need different fixes, so
+ * collapsing them into one label would hide the difference.
  */
 function TestRuleButton({ rule }: { rule: AlertRule }) {
   const test = useTestAlertRule()
@@ -185,7 +199,11 @@ function TestRuleButton({ rule }: { rule: AlertRule }) {
 
   return (
     <div className="flex items-center justify-end gap-1.5">
-      {test.isSuccess ? (
+      {test.isError ? (
+        <Chip size="sm" color="danger">
+          Couldn't send test
+        </Chip>
+      ) : test.isSuccess ? (
         <Chip size="sm" color={result?.delivered ? "accent" : "warning"}>
           {result?.delivered ? "Test delivered" : "Test failed"}
         </Chip>

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as UsageRouteImport } from './routes/usage'
 import { Route as WorkspacesRouteImport } from './routes/workspaces'
 import { Route as AdminAccountsRouteImport } from './routes/admin.accounts'
 import { Route as OrganizationIndexRouteImport } from './routes/organization.index'
+import { Route as OrganizationAlertsRouteImport } from './routes/organization.alerts'
 import { Route as OrganizationDomainsRouteImport } from './routes/organization.domains'
 import { Route as OrganizationGuardrailsRouteImport } from './routes/organization.guardrails'
 import { Route as OrganizationMembersRouteImport } from './routes/organization.members'
@@ -141,6 +142,11 @@ const OrganizationIndexRoute = OrganizationIndexRouteImport.update({
   path: '/',
   getParentRoute: () => OrganizationRoute,
 } as any)
+const OrganizationAlertsRoute = OrganizationAlertsRouteImport.update({
+  id: '/alerts',
+  path: '/alerts',
+  getParentRoute: () => OrganizationRoute,
+} as any)
 const OrganizationDomainsRoute = OrganizationDomainsRouteImport.update({
   id: '/domains',
   path: '/domains',
@@ -218,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/usage': typeof UsageRoute
   '/workspaces': typeof WorkspacesRoute
   '/admin/accounts': typeof AdminAccountsRoute
+  '/organization/alerts': typeof OrganizationAlertsRoute
   '/organization/domains': typeof OrganizationDomainsRoute
   '/organization/guardrails': typeof OrganizationGuardrailsRoute
   '/organization/members': typeof OrganizationMembersRoute
@@ -249,6 +256,7 @@ export interface FileRoutesByTo {
   '/usage': typeof UsageRoute
   '/workspaces': typeof WorkspacesRoute
   '/admin/accounts': typeof AdminAccountsRoute
+  '/organization/alerts': typeof OrganizationAlertsRoute
   '/organization/domains': typeof OrganizationDomainsRoute
   '/organization/guardrails': typeof OrganizationGuardrailsRoute
   '/organization/members': typeof OrganizationMembersRoute
@@ -283,6 +291,7 @@ export interface FileRoutesById {
   '/usage': typeof UsageRoute
   '/workspaces': typeof WorkspacesRoute
   '/admin/accounts': typeof AdminAccountsRoute
+  '/organization/alerts': typeof OrganizationAlertsRoute
   '/organization/domains': typeof OrganizationDomainsRoute
   '/organization/guardrails': typeof OrganizationGuardrailsRoute
   '/organization/members': typeof OrganizationMembersRoute
@@ -318,6 +327,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/workspaces'
     | '/admin/accounts'
+    | '/organization/alerts'
     | '/organization/domains'
     | '/organization/guardrails'
     | '/organization/members'
@@ -349,6 +359,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/workspaces'
     | '/admin/accounts'
+    | '/organization/alerts'
     | '/organization/domains'
     | '/organization/guardrails'
     | '/organization/members'
@@ -382,6 +393,7 @@ export interface FileRouteTypes {
     | '/usage'
     | '/workspaces'
     | '/admin/accounts'
+    | '/organization/alerts'
     | '/organization/domains'
     | '/organization/guardrails'
     | '/organization/members'
@@ -560,6 +572,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrganizationIndexRouteImport
       parentRoute: typeof OrganizationRoute
     }
+    '/organization/alerts': {
+      id: '/organization/alerts'
+      path: '/alerts'
+      fullPath: '/organization/alerts'
+      preLoaderRoute: typeof OrganizationAlertsRouteImport
+      parentRoute: typeof OrganizationRoute
+    }
     '/organization/domains': {
       id: '/organization/domains'
       path: '/domains'
@@ -641,6 +660,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface OrganizationRouteChildren {
+  OrganizationAlertsRoute: typeof OrganizationAlertsRoute
   OrganizationDomainsRoute: typeof OrganizationDomainsRoute
   OrganizationGuardrailsRoute: typeof OrganizationGuardrailsRoute
   OrganizationMembersRoute: typeof OrganizationMembersRoute
@@ -651,6 +671,7 @@ interface OrganizationRouteChildren {
 }
 
 const OrganizationRouteChildren: OrganizationRouteChildren = {
+  OrganizationAlertsRoute: OrganizationAlertsRoute,
   OrganizationDomainsRoute: OrganizationDomainsRoute,
   OrganizationGuardrailsRoute: OrganizationGuardrailsRoute,
   OrganizationMembersRoute: OrganizationMembersRoute,

--- a/web/src/routes/organization.alerts.tsx
+++ b/web/src/routes/organization.alerts.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { OrganizationAlertsPage } from "@/features/organization/OrganizationAlertsPage"
+
+export const Route = createFileRoute("/organization/alerts")({
+  component: OrganizationAlertsPage,
+})

--- a/web/src/shared/api/alerts.ts
+++ b/web/src/shared/api/alerts.ts
@@ -1,0 +1,97 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import type {
+  AlertRule,
+  AlertRuleTestResult,
+  CreateAlertRuleRequest,
+  UpdateAlertRuleRequest,
+} from "@/client"
+import { apiFetch } from "@/shared/api/client"
+import { ORGANIZATION_ALERT_RULES } from "@/shared/api/queryKeys"
+
+// Where an organization's budget alerts go. One module rather than more rows in
+// `organizations.ts`, matching the one-module-per-domain rule: the rules are
+// their own page and share no cache with the roster or the domain claims.
+//
+// The destination is write-only end to end. `AlertRule.destination` is the
+// server's redaction (scheme and host, everything else masked), so a form that
+// loaded a rule and submitted it whole would send the mask back as a real
+// value. `UpdateAlertRuleRequest.destination` is therefore omitted rather than
+// echoed whenever the operator has not typed a new one, which is what the
+// server's "omit to keep the stored destination" contract expects.
+
+const ALERT_RULES_PATH = "/v1/organizations/me/alert-rules"
+
+export function useAlertRules(enabled = true) {
+  return useQuery({
+    queryKey: [ORGANIZATION_ALERT_RULES],
+    queryFn: () =>
+      apiFetch<{ data: AlertRule[]; count: number }>(ALERT_RULES_PATH),
+    staleTime: 60_000,
+    enabled,
+  })
+}
+
+function invalidateAlertRules(queryClient: ReturnType<typeof useQueryClient>) {
+  void queryClient.invalidateQueries({ queryKey: [ORGANIZATION_ALERT_RULES] })
+}
+
+export function useCreateAlertRule() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: CreateAlertRuleRequest) =>
+      apiFetch<AlertRule>(ALERT_RULES_PATH, {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => invalidateAlertRules(queryClient),
+  })
+}
+
+export function useUpdateAlertRule() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      ruleId,
+      body,
+    }: {
+      ruleId: string
+      body: UpdateAlertRuleRequest
+    }) =>
+      apiFetch<AlertRule>(`${ALERT_RULES_PATH}/${encodeURIComponent(ruleId)}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => invalidateAlertRules(queryClient),
+  })
+}
+
+export function useDeleteAlertRule() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (ruleId: string) =>
+      apiFetch<{ message: string }>(
+        `${ALERT_RULES_PATH}/${encodeURIComponent(ruleId)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => invalidateAlertRules(queryClient),
+  })
+}
+
+/**
+ * Send a sample alert to one rule's destination now.
+ *
+ * Deliberately does not invalidate the list: a test writes no delivery row and
+ * changes nothing about the rule, so refetching would only make the table
+ * flicker. The outcome is returned to the caller instead, which is what the
+ * page renders beside the row.
+ */
+export function useTestAlertRule() {
+  return useMutation({
+    mutationFn: (ruleId: string) =>
+      apiFetch<AlertRuleTestResult>(
+        `${ALERT_RULES_PATH}/${encodeURIComponent(ruleId)}/test`,
+        { method: "POST" },
+      ),
+  })
+}

--- a/web/src/shared/api/queryKeys.ts
+++ b/web/src/shared/api/queryKeys.ts
@@ -70,6 +70,10 @@ export const ORGANIZATION_PROVIDER_KEYS = "organization-provider-keys"
 // The organization's email-domain claims. Its own key for the same reason:
 // one page reads it, and claiming a domain has no bearing on anything else.
 export const ORGANIZATION_DOMAINS = "organization-domains"
+// Its own key rather than a child of ORGANIZATION_BUDGETS: a rule is edited
+// from its own page and a budget change never invalidates the rule list, so
+// nesting them would refetch one whenever the other moved.
+export const ORGANIZATION_ALERT_RULES = "organization-alert-rules"
 export const WORKSPACES = "workspaces"
 // The first-request setup guide's state. Its own key rather than a child of
 // WORKSPACES: the guide polls while it is on screen, and nesting it would make

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -8,6 +8,7 @@
 
 import type {
   ActivationAttempt,
+  AlertRule,
   Budget,
   CallerOrganizationMembership,
   DeploymentBootstrap,
@@ -93,6 +94,7 @@ const STANDALONE_SURFACES = [
   "budgets",
   "keys",
   "models",
+  "organization_alerts",
   "organizations",
   "pricing",
   "providers",
@@ -509,6 +511,24 @@ export function organizationGuardrail(
     workspace_ids: [],
     created_at: "2026-08-24T00:00:00+00:00",
     updated_at: "2026-08-24T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+export function alertRule(overrides: Partial<AlertRule> = {}): AlertRule {
+  return {
+    id: "88888888-8888-8888-8888-888888888888",
+    organization_id: "11111111-1111-1111-1111-111111111111",
+    name: "Platform team Slack",
+    // The redaction the server returns, not an Apprise URL: the real
+    // destination is encrypted and never read back, so a fixture carrying one
+    // would let a test assert against a shape the API cannot produce.
+    destination: "slack://***",
+    warn_at_percent: 80,
+    notify_on_exceeded: true,
+    enabled: true,
+    created_at: "2026-09-09T00:00:00+00:00",
+    updated_at: "2026-09-09T00:00:00+00:00",
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

Otari had no way to tell anyone something was wrong. A budget hitting its limit bumped a Prometheus counter and returned an error to the caller. Unless an admin was logged in and looking at a page, the first sign was requests being refused.

This adds organization-scoped budget alerts. An organization adds destinations on a new **Budget alerts** page. Each destination covers every budget ceiling the organization owns, and fires when one passes a warning threshold (80% by default) or reaches its limit.

### One field, via Apprise

A destination is an [Apprise](https://github.com/caronc/apprise) URL, so `slack://`, `discord://`, `pagerduty://`, `mailto://` and a plain `json://` webhook are one column and one code path instead of one integration each.

Apprise is BSD-2-Clause, adds four packages (`requests-oauthlib`, `oauthlib`, `markdown`, itself), and `async_notify` is a real coroutine. The transports needing compiled packages sit behind an `all-plugins` extra we do not take. It is a core dependency, not an extra, because a rule configured through the dashboard must not silently deliver nothing on a deployment that resolved without it.

No port over it. A port keeps a vendor choice out of the core, and Apprise is already the vendor-neutral layer.

Otari accepts a fixed list of schemas rather than anything Apprise parses. See the security section for why.

### A timer, not the request path

I first meant to hook the three `record_budget_exceeded()` sites in `budget_service.py`. That was wrong. Those sites are inside the reserve/settle lifecycle, which `AGENTS.md` calls out as load-bearing, and alerting from there would add a query and an outbound fan-out to the path least able to take either, for latency a budget warning does not need.

So `services/alerts/evaluator.py` runs as a lifespan refresher next to the existing eight. It asks "which ceilings are over a threshold now" rather than "which crossed since last time". That makes the warning and the refusal one computation, and a ceiling that crossed while its destination was broken still alerts once the destination is fixed. The request path is untouched.

Utilization counts reservations as well as settled spend, `(current + reserved) / cap`, matching the gate in `scoped_budget_service.reserve`. Committed spend alone would report 90% on a ceiling that is already refusing requests.

### The dedupe ledger

`alert_deliveries` and its unique constraint are what make "alert once" true. Two duplicate sources collapse into it: a crossed threshold stays crossed for the rest of the period, and every refresher runs once per worker. Both are settled by inserting the row and committing it *before* dispatching, then treating an `IntegrityError` as "somebody already did it".

`period_start` is part of the key, which re-arms an alert when a period rolls without anything clearing the table. A partial unique index covers a budget with no period at all, since PostgreSQL treats two NULL `period_start` values as distinct.

`test_two_concurrent_passes_send_exactly_one` is the test that matters: four independent sessions, one alert.

### Security

**The destination is a credential.** `slack://` embeds a bot token, and Apprise carries credentials in the URL *path*, which the existing `redact_url_secrets` does not mask. `redact_alert_destination` is new for that: scheme and host survive, userinfo and every path segment and query value do not. The URL is encrypted with `OTARI_SECRET_KEY` and never returned.

**SSRF.** A destination is an outbound request to a host somebody chose, so the ones that name a host are address-checked at write time, fail-closed, with `OTARI_ALERT_ALLOW_PRIVATE_HOSTS` as a startup-only override. Its own gate, so enabling private alert destinations does not also let the web-search backend fetch internal hosts.

Which schemas name a host is an explicit allowlist, and so is which ones do not. The first version of this got it wrong: it checked the six webhook schemas and assumed everything else posted to an endpoint compiled into its plugin. `mailto`, `gotify`, `ntfy`, `matrix`, `rocket` and `mmost` all dial the host in the URL, so `ntfy://169.254.169.254/topic` went through while `json://169.254.169.254/...` was refused. An unclassified schema is now refused rather than assumed safe. That costs the "any Apprise URL, no code" claim, which was only true because the unsafe half was unchecked. Adding a schema is one line.

**Honest limit:** Apprise re-resolves DNS when it sends, so write-time validation is open to rebinding. Same exposure the MCP and web-search write paths already carry, so it is consistent with the repo rather than new, but it is real.

Apprise's own logger redacts credentials. The asset here sets `secure_logging` explicitly rather than inheriting it. Nothing in this PR passes a destination to the gateway logger.

### Scope, and one gap

Rules are organization-scoped and management-gated (owners and admins), following `organization_guardrail_service`. The ownership join is `ScopedBudget -> Budget.organization_id`, a column that already existed.

**A budget with a NULL `organization_id` is never alerted on.** That is the deployment's own budget, and the organization-scoped surface never lists, offers or repoints one. Deployment-wide operator rules are a follow-up, and would need a column saying what a rule watches. `test_a_deployment_owned_budget_is_never_alerted_on` asserts the gap so it stays a decision.

This covers the budget half of #410. Provider-health alerts are tracked separately in #982: the delivery side here is reusable as is, but the trigger side needs a column saying what a rule watches, a nullable subject on the dedupe ledger, and a source of truth for whether a provider is up.

### Notes for the reviewer

- **`uv.lock` looks much bigger than it is.** Adding a package with a platform-conditional dependency (`tzdata; platform_system == "Windows"`) makes uv re-derive markers across the whole graph. Every one of the 516 deleted lines reappears with only a marker appended, no package version moved, none was removed, and every marker introduced is a tautology under the repo's existing `[tool.uv] environments` pin. The 50 genuinely new lines are the four packages.
- `alert_evaluation_interval_sec` is `0`-to-disable. The SSRF gate is a startup config field rather than a runtime setting, matching what `runtime_settings_service.py` says about SSRF gates.
- The evaluator runs wherever local ceilings exist, so standalone and hosted but not hybrid.
- The retention purge runs hourly rather than every tick, because it filters on an unindexed `created_at`.
- `mailto://` carries its own SMTP credentials and does not use the deployment's configured mailer. Documented rather than wired up, since the two are separate things and folding them together is more than this PR needs.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #410

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

**On that third box:** `make lint`, `make typecheck`, the full `tests/unit` suite (2950 passed), `pnpm --dir web run lint`, `typecheck` and `test` (3901 passed), both generated-artifact checks and the OSS-edition smoke gate all pass locally. The **integration suite did not run**: this machine has no Docker and no reachable PostgreSQL. The integration tests added here are written and collect cleanly, but CI is the first thing to execute them. Please treat a failure there as un-run code rather than a regression.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Scoped interactively with the repo owner, who chose organization scoping over deployment-wide, DB-backed configuration over a config-file block, and asked whether an existing library could own the destinations, which is where Apprise came from. Two decisions changed during implementation and are called out above: abandoning the request-path hook after reading `scoped_budget_service.reserve`, and replacing the SSRF scheme split after finding it let six host-bearing schemas through.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

