### PR TITLE
ci: add CodeQL code scanning for Python, TypeScript, and Actions

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: Otari CodeQL
+
+paths-ignore:
+  # Both files are generated, so a fix here is lost on the next regeneration.
+  - 'web/src/client/schema.ts'
+  - 'web/src/routeTree.gen.ts'

--- a/.github/workflows/otari-codeql.yml
+++ b/.github/workflows/otari-codeql.yml
@@ -1,0 +1,53 @@
+name: Otari CodeQL
+
+# No path filter here, unlike the other workflows.
+# A filter would let some pull requests skip the scan entirely.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Runs at 04:17 UTC every Monday.
+    # GitHub delays runs scheduled on the hour, so this one is not at 04:00.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  # Cancel superseded PR scans, but let main and scheduled runs finish.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # javascript-typescript is one language, not two.
+        language: [ actions, javascript-typescript, python ]
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: none
+        config-file: .github/codeql/codeql-config.yml
+
+    - name: Analyze
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      with:
+        category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Description

This repository has no static analysis for security defects. This PR adds GitHub CodeQL, which is free for public repositories and reports its findings into the Security tab.

It uses advanced setup (a workflow file) rather than the settings switch, for two reasons. The configuration stays versioned next to the rest of CI, which is how every other check here is defined. And it can exclude generated files, which the settings switch cannot.

Three languages are scanned, matching what GitHub detects for this repo: `actions`, `javascript-typescript`, and `python`. `javascript-typescript` is one language identifier covering both, so listing them separately would analyze the same files twice.

The workflow has no path filter, unlike the others here. A filter would let some pull requests merge with no scan at all.

`.github/codeql/codeql-config.yml` ignores `web/src/client/schema.ts` and `web/src/routeTree.gen.ts`. Both are generated and committed, so a fix applied there is lost on the next regeneration.

### Verification

| Check | Result |
| --- | --- |
| `actionlint` | Clean |
| `zizmor --persona=regular` | Clean |
| `act -n` dry run, python leg | Job succeeded, exit 0 |
| `make lint` | Passed |
| `make typecheck` | Passed, 567 source files |

Action versions were resolved from the GitHub API at authoring time and pinned to full commit SHAs, matching the existing workflows.

### Follow-ups, not in this PR

- The new check is not yet required by the `protect-main` ruleset. Adding it there is a separate and deliberate step.
- #967 records a related finding: seven workflows trigger on a `develop` branch that does not exist. This workflow does not copy that line.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

The originating request is tracked in a private mozilla-ai repository, so there is no public issue to close from here. Related: #967.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Not applicable: a CI workflow has no unit or integration test surface. It was checked with `actionlint`, `zizmor`, and an `act` dry run instead.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` and `make typecheck` both passed. `make test` was not run, because no Python changed.
- [x] Documentation was updated where necessary. No documentation change was needed.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). The API contract did not change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, through Claude Code.

**Any additional AI details you'd like to share:**

Every action version was verified against the GitHub API rather than recalled, then pinned to a full commit SHA. The workflow was validated with `actionlint`, audited with `zizmor`, and dry run with `act` before this PR was opened.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
