### PR TITLE
fix(gateway): read a provider's real status when its response carries none

### DIFF
--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -660,6 +660,37 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
 UpstreamErrorKind = Literal["timeout", "conn_err"]
 
 
+def _error_status_code(exc: BaseException) -> int | None:
+    """The HTTP error status an upstream exception carries, or ``None``.
+
+    Reads ``status_code``, then an integer ``code``, then
+    ``response.status_code``, and accepts only a 4xx/5xx from any of them.
+
+    ``code`` is needed because google-genai's ``APIError`` puts the status there
+    and never sets ``status_code``; where another SDK uses ``code`` for an error
+    slug (OpenAI's ``"invalid_api_key"``) the value is not an ``int`` and is
+    skipped. ``response.status_code`` comes last because the attached object is
+    not always the response that failed: google-genai raises a mid-stream error
+    against its own stream wrapper, whose ``status_code`` is a hardcoded 200
+    because the SSE response opened fine and the error arrived in a later chunk.
+    That is how Gemini reports a quota 429 on a streaming call, so reading the
+    200 would classify a rate limit as unclassifiable (a generic 502) and record
+    200 as the request's outcome through :func:`failure_status_code`.
+
+    The 4xx/5xx bound is what rejects that 200, and also the non-HTTP integers
+    that reach ``code``: google-genai's live API raises through the same
+    ``APIError`` with a websocket close code (1006, 1008).
+    """
+    for value in (
+        getattr(exc, "status_code", None),
+        getattr(exc, "code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    ):
+        if isinstance(value, int) and 400 <= value <= 599:
+            return value
+    return None
+
+
 def upstream_exception_chain(exc: BaseException) -> Iterator[BaseException]:
     """Yield an exception and its ``original_exception`` chain once each."""
     current: BaseException | None = exc
@@ -698,8 +729,9 @@ def upstream_exception_shape(exc: BaseException) -> tuple[UpstreamErrorKind | No
        in both SDKs, so the timeout check must run first. This covers the
        majority of any-llm providers, which reuse ``BaseOpenAIProvider`` or
        ``BaseAnthropicProvider``.
-    3. An HTTP status code carried directly on the exception or on its
-       attached ``.response``.
+    3. An HTTP error status carried by the exception, on ``status_code``,
+       ``code``, or its attached ``.response`` (see
+       :func:`_error_status_code`).
     4. A conservative duck-typed fallback, by exception class name, for the
        remaining any-llm provider SDKs that don't reuse the OpenAI/Anthropic
        base classes (e.g. cohere, mistral, groq, bedrock) and whose own
@@ -733,12 +765,8 @@ def upstream_exception_shape(exc: BaseException) -> tuple[UpstreamErrorKind | No
         if isinstance(current, (httpx.NetworkError, _OpenAIAPIConnectionError, _AnthropicAPIConnectionError)):
             return "conn_err", None
 
-        status_code = getattr(current, "status_code", None)
-        if status_code is None:
-            resp = getattr(current, "response", None)
-            if resp is not None:
-                status_code = getattr(resp, "status_code", None)
-        if isinstance(status_code, int):
+        status_code = _error_status_code(current)
+        if status_code is not None:
             return None, status_code
 
         class_name = type(current).__name__

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -82,6 +82,16 @@ class _ResponseStatusError(Exception):
         self.response = httpx.Response(status_code)
 
 
+class _CodeError(Exception):
+    """Upstream error carrying its status on ``code``, as google-genai's
+    ``APIError`` does. It never sets ``status_code``."""
+
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(f"{code} {message}")
+        self.code = code
+        self.message = message
+
+
 def test_timeout_maps_to_504() -> None:
     for exc in (asyncio.TimeoutError(), TimeoutError(), httpx.TimeoutException("slow")):
         mapping = classify_provider_error(exc)
@@ -158,6 +168,42 @@ def test_status_read_from_attached_response() -> None:
     mapping = classify_provider_error(_ResponseStatusError(404))
     assert mapping is not None
     assert mapping.status_code == 404
+
+
+def test_status_read_from_an_int_code() -> None:
+    """google-genai's ``APIError`` puts the status on ``code`` and never sets
+    ``status_code``, so a Gemini rejection is unclassifiable without it."""
+    mapping = classify_provider_error(_CodeError(404, "models/gemini-9 is not found"))
+    assert mapping is not None
+    assert mapping.status_code == 404
+
+
+def test_a_string_code_is_not_read_as_a_status() -> None:
+    """OpenAI-family SDKs use ``code`` for an error slug, not a status, so it
+    must not be guessed at and the exception stays unclassifiable."""
+    exc = Exception(_RAW)
+    exc.code = "invalid_api_key"  # type: ignore[attr-defined]
+    assert classify_provider_error(exc) is None
+
+
+def test_a_non_http_int_code_is_not_read_as_a_status() -> None:
+    """google-genai's live API raises through the same ``APIError`` with a
+    websocket close code. It is an ``int`` but not a status."""
+    assert classify_provider_error(_CodeError(1008, "policy violation")) is None
+
+
+def test_a_non_error_response_status_does_not_shadow_the_real_status() -> None:
+    """Gemini reports a streaming failure in a body chunk, against a stream
+    wrapper whose ``status_code`` is a hardcoded 200: the SSE response opened
+    fine and the 429 arrived later. Reading that 200 as the failure's status is
+    what turned a rate limit into an opaque 502 and recorded 200 as the
+    request's outcome."""
+    exc = _CodeError(429, "You exceeded your current quota. Please retry in 34.6s.")
+    exc.response = httpx.Response(200)  # type: ignore[attr-defined]
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.status_code == 429
+    assert failure_status_code(exc) == 429
 
 
 @pytest.mark.parametrize("exc", [_StatusError(500), _StatusError(503), Exception(_RAW), ValueError(_RAW)])


### PR DESCRIPTION
## Description

A mid-stream Gemini failure surfaced to the caller as an opaque `502 {"detail": "LLM provider error"}` and recorded **200** on the usage log for a request that failed.

`google-genai`'s `APIError` puts the status on `code` and never sets `status_code`. For an error that arrives in a body chunk it attaches its own stream wrapper as `response`, and [that wrapper's `status_code` is a hardcoded `200`](https://github.com/googleapis/python-genai/blob/main/google/genai/_api_client.py) because the SSE response did open successfully; only a later chunk carried the error. That is exactly how Gemini reports a quota 429 on a streaming call.

`upstream_exception_shape` read the `200` and never looked at `code`, so:

- `classify_provider_error` found nothing it could act on and fell through to the generic 502, with no explanation for the caller.
- `failure_status_code` wrote `200` to `usage_logs.status_code` for a failed request, which silently breaks "how much of my error rate is what".

Reproduced against the real SDKs before the fix:

```
stream 429 -> shape=(None, 200)  classify=None  usage-log status=200
```

and after:

```
stream 429 -> shape=(None, 429)  classify=(429, ...)  usage-log status=429
```

### What changed

Status extraction is factored into `_error_status_code`, which reads `status_code`, then an integer `code`, then `response.status_code`, accepting only a 4xx/5xx from any source.

The 4xx/5xx bound is doing real work in two places. It rejects the stream wrapper's `200`, and it rejects the non-HTTP integers that reach `code`: `google-genai`'s live API raises through the same `APIError` with a websocket close code (`1006`, `1008`). A non-`int` `code` is skipped, so OpenAI's `code="invalid_api_key"` error slug is not mistaken for a status.

`upstream_exception_shape` is shared with the hybrid-mode fallback classifier (`_classify_upstream_error`) and the observability path, so both are corrected by the same change.

This is a pure classification fix. No status or detail *policy* changes here: a rate limit still returns the fixed `PROVIDER_RATE_LIMITED_DETAIL`, and credential failures and 5xx are untouched. Forwarding the provider's own 429 text is a separate change, stacked on this one.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; found while investigating a report of Gemini rate limits arriving as a bodyless 502. Related but distinct causes: #533 (Anthropic SDK timeout guard), #183 (multimodal image content).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

On the third box: `make lint` (architecture check, alembic heads, Ruff) and `mypy` both pass, and the full unit suite passes (2881 passed, 10 skipped). `make test` was **not** run: the integration suite needs PostgreSQL, and the machine this was written on has neither Docker nor a local server, so CI is the first execution of those tests. No API contract changed and `make openapi-check` confirms the spec is current.

Four unit tests added, covering each branch of the extraction:

- `test_status_read_from_an_int_code` — the `google-genai` shape.
- `test_a_string_code_is_not_read_as_a_status` — OpenAI's error slug stays unclassifiable.
- `test_a_non_http_int_code_is_not_read_as_a_status` — a websocket close code is not a status.
- `test_a_non_error_response_status_does_not_shadow_the_real_status` — the regression itself, asserting both the client status and the usage-log status.

The last two were confirmed to fail against unmodified source, per the "require a regression test that fails before the fix" rule in `.github/instructions/security-review.instructions.md`.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Root cause was found by reproducing against the installed `google-genai` and `any-llm` packages rather than by reading the traceback alone. Worth noting for reviewers: `any-llm`'s own unified exception layer (`RateLimitError` and friends, behind `ANY_LLM_UNIFIED_EXCEPTIONS=1`, which this repo does not set) has the same `.response.status_code` bug, so enabling that flag would not fix this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improve upstream error classification when the HTTP status is missing or unreliable.
- Correctly classify Gemini streaming quota errors as `429` instead of `502`.
- Record the correct status in usage logs and fallback handling.
- Add tests for valid, invalid, and conflicting status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->