### PR TITLE
fix(dashboard): offer the activation setup guide to tenants, not only deployment operators

### DIFF
--- a/web/src/features/onboarding/SetupGuideCard.test.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.test.tsx
@@ -110,7 +110,7 @@ function Switcher() {
 }
 
 function renderCard(
-  hasProviders = true,
+  canServeRequests = true,
   deployment: DeploymentBootstrap = bootstrap(),
 ) {
   const client = new QueryClient({
@@ -120,7 +120,7 @@ function renderCard(
     <QueryClientProvider client={client}>
       <DeploymentProvider value={deployment}>
         <SelectedWorkspaceProvider>
-          <SetupGuideCard hasProviders={hasProviders} />
+          <SetupGuideCard canServeRequests={canServeRequests} />
           <Switcher />
         </SelectedWorkspaceProvider>
       </DeploymentProvider>
@@ -147,7 +147,7 @@ describe("SetupGuideCard", () => {
     ).toBeInTheDocument()
   })
 
-  it("holds back while the gateway has no provider to serve the request", async () => {
+  it("holds back while nothing can serve the request", async () => {
     // The Overview's own getting-started panel is the guide at that point, and
     // a key handed out here would be for a call that cannot succeed.
     mockApi()

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -38,11 +38,10 @@ import { useDeployment, useSurfaces } from "@/shared/hooks/useDeployment"
  * API key scoped to the selected workspace, shows the two calls that use it, and
  * watches the workspace's traffic until one lands.
  *
- * **Offered on both Overviews, not only the operator's.** Who may be offered it
- * is the server's answer (`experience_eligible`, which ends in
- * `has_workspace_management_access`), so the caller doing a deployment's first
- * request is whoever manages the workspace, and on a multi-tenant deployment
- * that is a tenant rather than the person who operates it.
+ * **Offered on either Overview.** Who may be offered it is the server's answer
+ * (`experience_eligible`, which ends in `has_workspace_management_access`), so
+ * it goes to whoever manages the workspace: on a multi-tenant deployment a
+ * tenant, and not the person who operates the deployment.
  *
  * **Deliberately a panel and not a modal.** The platform's equivalent
  * (`otari-ai` `frontend/src/features/onboarding`) is a blocking sheet over the
@@ -63,8 +62,8 @@ export function SetupGuideCard({
    * Whether a request from this caller could succeed, which is the page's
    * answer to give rather than this card's to fetch. Each Overview reads it off
    * what it may see: the operator's from `/v1/providers`, which refuses a
-   * tenant, and the organization's from the model catalog, which is scoped to
-   * that caller's own providers.
+   * tenant, and the organization's from the model catalog, which lists the
+   * selectors that caller may name.
    *
    * Not a query of its own in here, and that is load-bearing: a page that
    * decides whether to render at all from the *fetching* state of the same

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -38,6 +38,12 @@ import { useDeployment, useSurfaces } from "@/shared/hooks/useDeployment"
  * API key scoped to the selected workspace, shows the two calls that use it, and
  * watches the workspace's traffic until one lands.
  *
+ * **Offered on both Overviews, not only the operator's.** Who may be offered it
+ * is the server's answer (`experience_eligible`, which ends in
+ * `has_workspace_management_access`), so the caller doing a deployment's first
+ * request is whoever manages the workspace, and on a multi-tenant deployment
+ * that is a tenant rather than the person who operates it.
+ *
  * **Deliberately a panel and not a modal.** The platform's equivalent
  * (`otari-ai` `frontend/src/features/onboarding`) is a blocking sheet over the
  * whole app, which suits a hosted signup: the account is new, the first request
@@ -51,29 +57,32 @@ import { useDeployment, useSurfaces } from "@/shared/hooks/useDeployment"
  * Overview page.
  */
 export function SetupGuideCard({
-  hasProviders,
+  canServeRequests,
 }: {
   /**
-   * Whether the deployment has a provider configured, which is the caller's
-   * answer to give rather than this card's to fetch.
+   * Whether a request from this caller could succeed, which is the page's
+   * answer to give rather than this card's to fetch. Each Overview reads it off
+   * what it may see: the operator's from `/v1/providers`, which refuses a
+   * tenant, and the organization's from the model catalog, which is scoped to
+   * that caller's own providers.
    *
-   * Not a `useProviders()` call in here, and that is load-bearing: the page
-   * above decides whether to render at all from the *fetching* state of that
-   * same query, so a second observer inside a child re-triggers it on mount,
-   * flips the page back to its loading branch, and unmounts the observer that
-   * asked, which remounts and asks again. One query, one owner.
+   * Not a query of its own in here, and that is load-bearing: a page that
+   * decides whether to render at all from the *fetching* state of the same
+   * query would see a second observer inside a child re-trigger it on mount,
+   * flip back to its loading branch, and unmount the observer that asked, which
+   * remounts and asks again. One query, one owner.
    */
-  hasProviders: boolean
+  canServeRequests: boolean
 }) {
   const surfaces = useSurfaces()
   const { selected } = useSelectedWorkspace()
   const workspaceId = selected?.workspace_id ?? null
-  // Held back until the deployment can actually serve a request: with no
-  // provider the Overview's own getting-started panel is the right guide, and
-  // this one would be handing out a key for a call that cannot succeed.
+  // Held back until the deployment can actually serve a request: with nothing to
+  // route to this would be handing out a key for a call that cannot succeed, and
+  // on the operator page the getting-started panel is the right guide instead.
   const activation = useWorkspaceActivation(
     workspaceId,
-    surfaces("workspaces") && hasProviders,
+    surfaces("workspaces") && canServeRequests,
   )
 
   if (!workspaceId || !activation.data) {
@@ -83,7 +92,7 @@ export function SetupGuideCard({
   return (
     // Keyed on the workspace, which is what discards the guide's own state when
     // the switcher moves: the issued key belongs to one workspace, and so do
-    // "this session saw the offer" and "the operator dismissed the payoff".
+    // "this session saw the offer" and "somebody dismissed the payoff".
     // Without the key, switching workspaces would leave workspace A's key on
     // screen under workspace B's heading.
     <SetupGuide
@@ -115,11 +124,11 @@ function SetupGuide({
   const dismiss = useDismissActivation()
   const [issued, setIssued] = useState<ActivationApiKey>()
   const [finished, setFinished] = useState(false)
-  // Only a press the operator made, never the background poll: `isFetching`
+  // Only a press somebody made, never the background poll: `isFetching`
   // would put the button in its pending state every few seconds on its own.
   const [isChecking, setIsChecking] = useState(false)
   // The card only celebrates a first request it was present for. Without this
-  // latch, an operator who never opened the guide would be congratulated on the
+  // latch, somebody who never opened the guide would be congratulated on the
   // traffic they already had, on the next page load after it arrived.
   const wasOffered = useRef(false)
 
@@ -219,7 +228,7 @@ function SetupGuide({
   )
 }
 
-/** The key, and the two calls that use it, once the operator has asked for one. */
+/** The key, and the two calls that use it, once somebody has asked for one. */
 function IssuedKey({ issued }: { issued: ActivationApiKey }) {
   const models = useModels()
   // The first model the gateway can serve, so the snippets are runnable as

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -1122,20 +1122,24 @@ describe("the setup guide on either Overview", () => {
   })
 
   it("shows nothing to a caller the server reports ineligible", async () => {
-    mockScopedApi({
+    const requested = mockScopedApi({
       context: TWO_WORKSPACES,
       activation: workspaceActivation({ experience_eligible: false }),
     })
     renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
 
-    await screen.findByText(
-      "At-a-glance spend, traffic, and recent activity in your organization.",
-    )
+    // Anchored on the answer this test varies. Without it the negative passes on
+    // its first tick, before the activation read has been made at all, and would
+    // read the same for an eligible caller.
     await waitFor(() => {
-      expect(
-        screen.queryByRole("heading", { name: "Send your first request" }),
-      ).not.toBeInTheDocument()
+      expect(requested.some((url) => url.includes("/activation"))).toBe(true)
     })
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /refresh/i })).toBeEnabled()
+    })
+    expect(
+      screen.queryByRole("heading", { name: "Send your first request" }),
+    ).not.toBeInTheDocument()
   })
 
   it("holds back, without asking, while the caller can route nowhere", async () => {
@@ -1145,12 +1149,13 @@ describe("the setup guide on either Overview", () => {
     const requested = mockScopedApi({ context: TWO_WORKSPACES, models: [] })
     renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
 
-    await screen.findByText(
-      "At-a-glance spend, traffic, and recent activity in your organization.",
-    )
+    // Settled, not merely issued: the Refresh control is disabled while any of
+    // this page's queries is in flight, the catalog included, so an enabled one
+    // is the empty answer having landed rather than being on its way.
     await waitFor(() => {
-      expect(requested.some((url) => url.includes("/v1/models"))).toBe(true)
+      expect(screen.getByRole("button", { name: /refresh/i })).toBeEnabled()
     })
+    expect(requested.some((url) => url.includes("/v1/models"))).toBe(true)
     expect(
       screen.queryByRole("heading", { name: "Send your first request" }),
     ).not.toBeInTheDocument()

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -18,6 +18,7 @@ import {
   HOSTED_SURFACES,
   organizationContext,
   usageTotals,
+  workspaceActivation,
   workspaceMember,
 } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
@@ -72,6 +73,22 @@ interface Bodies {
   /** One workspace's roster, keyed by workspace id. */
   workspaceMembers?: Record<string, unknown[]>
   context?: Parameters<typeof organizationContext>[0]
+  /** Where the selected workspace stands on its first request. */
+  activation?: unknown
+  /** Model ids the caller's catalog reports, which is what the guide gates on. */
+  models?: string[]
+}
+
+function modelCatalog(ids: string[]) {
+  return {
+    object: "list",
+    data: ids.map((id) => ({
+      id,
+      object: "model",
+      created: 0,
+      owned_by: "openai",
+    })),
+  }
 }
 
 // Order matters: /v1/usage/summary is matched BEFORE the bare /v1/usage logs
@@ -94,6 +111,12 @@ function mockApi(b: Bodies) {
     const roster = url.match(/\/v1\/workspaces\/([^/?]+)\/members/)
     if (roster) {
       return jsonResponse({ data: b.workspaceMembers?.[roster[1]] ?? [] })
+    }
+    if (url.includes("/activation")) {
+      return jsonResponse(b.activation ?? workspaceActivation())
+    }
+    if (url.includes("/v1/models")) {
+      return jsonResponse(modelCatalog(b.models ?? ["openai:gpt-4o-mini"]))
     }
     if (url.includes("/v1/usage/summary")) {
       if (url.includes("bucket=hour"))
@@ -799,7 +822,9 @@ function mockScopedApi(b: Bodies): string[] {
     const url = String(input)
     requested.push(url)
     if (url.endsWith("/v1/organizations/me")) {
-      return jsonResponse(organizationContext({ deployment_operator: false }))
+      return jsonResponse(
+        organizationContext({ deployment_operator: false, ...b.context }),
+      )
     }
     if (url.includes("/v1/organizations/me/usage/summary")) {
       if (url.includes("bucket=hour"))
@@ -809,6 +834,17 @@ function mockScopedApi(b: Bodies): string[] {
     }
     if (url.includes("/v1/organizations/me/usage")) {
       return jsonResponse(b.logs ?? [])
+    }
+    // The two reads the setup guide adds to this page. Both are open to any
+    // signed-in caller: the catalog is scoped to the caller's own providers
+    // rather than operator-gated, and the activation read answers every member
+    // who can see the workspace, reporting per caller whether the guide is on
+    // offer.
+    if (url.includes("/activation")) {
+      return jsonResponse(b.activation ?? workspaceActivation())
+    }
+    if (url.includes("/v1/models")) {
+      return jsonResponse(modelCatalog(b.models ?? ["openai:gpt-4o-mini"]))
     }
     return jsonResponse({ detail: "forbidden" }, 403)
   })
@@ -1047,5 +1083,77 @@ describe("OverviewIndex operator-ness", () => {
     for (const url of asked) {
       expect(url).toContain("/v1/organizations/me/usage")
     }
+  })
+})
+
+// Who may be offered the first-request guide is the server's answer:
+// `WorkspaceActivationService._is_eligible` ends in
+// `has_workspace_management_access` and is reported as `experience_eligible` per
+// caller. Operating the deployment is no part of that answer, so the guide
+// belongs on whichever Overview the caller landed on (otari-ai#2080).
+describe("the setup guide on either Overview", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("offers it to a caller who does not operate the deployment", async () => {
+    const requested = mockScopedApi({ context: TWO_WORKSPACES })
+    renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
+
+    expect(
+      await screen.findByRole("heading", { name: "Send your first request" }),
+    ).toBeInTheDocument()
+    // On the tenant page, rather than by falling through to the operator one.
+    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
+    // And its gate came from the catalog, which this caller may read, and not
+    // from the operator-gated provider list.
+    expect(requested.some((url) => url.includes("/v1/models"))).toBe(true)
+    expect(requested.some((url) => url.endsWith("/v1/providers"))).toBe(false)
+  })
+
+  it("still offers it to an operator", async () => {
+    mockApi({ context: TWO_WORKSPACES })
+    renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
+
+    expect(
+      await screen.findByRole("heading", { name: "Send your first request" }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows nothing to a caller the server reports ineligible", async () => {
+    mockScopedApi({
+      context: TWO_WORKSPACES,
+      activation: workspaceActivation({ experience_eligible: false }),
+    })
+    renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
+
+    await screen.findByText(
+      "At-a-glance spend, traffic, and recent activity in your organization.",
+    )
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Send your first request" }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("holds back, without asking, while the caller can route nowhere", async () => {
+    // An empty catalog is the tenant's form of "no provider configured": a key
+    // handed out here would be for a call that must fail, so the guide is not
+    // offered and the activation read is never made.
+    const requested = mockScopedApi({ context: TWO_WORKSPACES, models: [] })
+    renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
+
+    await screen.findByText(
+      "At-a-glance spend, traffic, and recent activity in your organization.",
+    )
+    await waitFor(() => {
+      expect(requested.some((url) => url.includes("/v1/models"))).toBe(true)
+    })
+    expect(
+      screen.queryByRole("heading", { name: "Send your first request" }),
+    ).not.toBeInTheDocument()
+    expect(requested.some((url) => url.includes("/activation"))).toBe(false)
   })
 })

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -324,11 +324,12 @@ export function OverviewIndex() {
 function OrganizationOverview() {
   const { scope, today, period, previous, recent } = useUsageOverview()
   // What this caller could route a request to, which is the setup guide's gate
-  // here. `/v1/providers` is the operator page's answer to the same question and
-  // refuses this caller; the catalog is deliberately not operator-gated and the
-  // server already narrows it to the organization's own providers, so an empty
-  // one is an honest "nothing to send a request to yet". Not asked on paint
-  // until a workspace is selected, since the guide is about one.
+  // here: `/v1/providers`, the operator page's answer to the same question,
+  // refuses this caller. The catalog is not operator-gated and is filtered to
+  // the selectors this caller may name, the deployment's configured instances
+  // plus their organization's own keys, so an empty one means there is nothing
+  // to send a request to yet. Not asked until a workspace is selected, since the
+  // guide is about one.
   const models = useModels(scope !== undefined)
 
   // Recent activity is excluded for the operator page's reason: it renders its
@@ -343,9 +344,10 @@ function OrganizationOverview() {
     void period.refetch()
     void previous.refetch()
     void recent.refetch()
-    // Included so a caller who has just been given a provider key can bring the
-    // guide out with the button already in front of them.
-    void models.refetch()
+    // So a caller who has just been given a provider key can bring the guide out
+    // with the button already in front of them. Guarded because `refetch` runs a
+    // disabled query, which would ask for a catalog with no workspace to use it.
+    if (scope !== undefined) void models.refetch()
   }
   const isRefreshing =
     today.isFetching ||
@@ -368,11 +370,8 @@ function OrganizationOverview() {
         }
       />
 
-      {/* The tenant's first request is the one this deployment is waiting on, so
-          the guide belongs here and not only on the operator page. It decides
-          for itself whether to render; nothing above gates on the catalog
-          query's fetching state, which is what keeps the card's own observer of
-          it from looping (see `SetupGuideCard`). */}
+      {/* Offered to whoever manages the workspace, which on a multi-tenant
+          deployment is this caller. It decides for itself whether to render. */}
       <SetupGuideCard canServeRequests={(models.data?.data.length ?? 0) > 0} />
 
       <ErrorBanner error={loadError} />

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/overview/overview"
 import { useKeys } from "@/shared/api/apiKeys"
 import { useBudgets } from "@/shared/api/budgets"
+import { useModels } from "@/shared/api/models"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import { useProviderHealth, useProviders } from "@/shared/api/providers"
 import {
@@ -321,12 +322,20 @@ export function OverviewIndex() {
  * accounts) stay on the operator page, whose endpoints refuse this caller.
  */
 function OrganizationOverview() {
-  const { today, period, previous, recent } = useUsageOverview()
+  const { scope, today, period, previous, recent } = useUsageOverview()
+  // What this caller could route a request to, which is the setup guide's gate
+  // here. `/v1/providers` is the operator page's answer to the same question and
+  // refuses this caller; the catalog is deliberately not operator-gated and the
+  // server already narrows it to the organization's own providers, so an empty
+  // one is an honest "nothing to send a request to yet". Not asked on paint
+  // until a workspace is selected, since the guide is about one.
+  const models = useModels(scope !== undefined)
 
   // Recent activity is excluded for the operator page's reason: it renders its
   // own inline banner, so including it here would double-report. The previous
   // window is included: its only reader is the trend chips, so its failure
-  // would otherwise just silently strip them.
+  // would otherwise just silently strip them. The catalog is excluded too: it
+  // decides whether an optional offer appears, not whether this page is right.
   const loadError = today.error ?? period.error ?? previous.error
 
   const refresh = () => {
@@ -334,12 +343,16 @@ function OrganizationOverview() {
     void period.refetch()
     void previous.refetch()
     void recent.refetch()
+    // Included so a caller who has just been given a provider key can bring the
+    // guide out with the button already in front of them.
+    void models.refetch()
   }
   const isRefreshing =
     today.isFetching ||
     period.isFetching ||
     previous.isFetching ||
-    recent.isFetching
+    recent.isFetching ||
+    models.isFetching
 
   return (
     <div className="flex flex-col gap-6">
@@ -354,6 +367,13 @@ function OrganizationOverview() {
           />
         }
       />
+
+      {/* The tenant's first request is the one this deployment is waiting on, so
+          the guide belongs here and not only on the operator page. It decides
+          for itself whether to render; nothing above gates on the catalog
+          query's fetching state, which is what keeps the card's own observer of
+          it from looping (see `SetupGuideCard`). */}
+      <SetupGuideCard canServeRequests={(models.data?.data.length ?? 0) > 0} />
 
       <ErrorBanner error={loadError} />
 
@@ -549,7 +569,7 @@ export function OverviewPage({
           key and watch for the first request. It decides for itself whether to
           render, including holding back while there is no provider, which is
           when the strip above is the right guide instead. */}
-      <SetupGuideCard hasProviders={hasProviders} />
+      <SetupGuideCard canServeRequests={hasProviders} />
 
       <ErrorBanner error={loadError} />
 

--- a/web/src/shared/api/models.ts
+++ b/web/src/shared/api/models.ts
@@ -12,12 +12,17 @@ import {
   NO_RETRY,
 } from "@/shared/api/queryKeys"
 
-export function useModels() {
+// `enabled` is not the operator composition the reads below use: the catalog is
+// readable by any signed-in caller and is already narrowed server-side to what
+// that caller could route to. It is for a page with nothing to ask about yet,
+// such as an overview before a workspace is selected.
+export function useModels(enabled = true) {
   return useQuery({
     ...NO_RETRY,
     queryKey: [MODELS],
     queryFn: () => apiFetch<ModelListResponse>("/v1/models"),
     staleTime: 60_000,
+    enabled,
   })
 }
 


### PR DESCRIPTION
## Description

`SetupGuideCard` mounted in one place, inside `OverviewPage`, which only `OperatorOverviewIndex` returns. `OverviewIndex` sends every non-operator to `OrganizationOverview` first, and that page had no guide. Since `deployment_operator` is `is_superuser` or the bootstrap identity, no customer on a hosted deployment could reach the first-request flow, and neither could anyone locally who is not signed in as the bootstrap identity.

The guide now renders on the organization Overview too.

**The server needed nothing.** `WorkspaceActivationService._is_eligible` already gates on `config.activation_guide`, the workspace classification, dismissal and `has_workspace_management_access`, and reports the answer per caller as `experience_eligible`. Operating the deployment is no part of it, which is why this is a client-side fix.

**The gate that could not be reused.** The operator branch derives its provider signal from `useProviders()`, and `/v1/providers` is router-level `require_deployment_operator`, so a tenant gets a 403. The organization Overview reads `GET /v1/models` instead: the catalog is deliberately not operator-gated (`api/main.py` says so, "a control plane needs it to tell a tenant which models their gateway could route to"), it is in both surface lists, and `resolve_session_catalog_scope` narrows it to the deployment's configured instances plus the caller's own organization BYO keys. An empty catalog is therefore an honest "there is nothing to send a request to yet", which is exactly what the gate exists to detect, and it is the same list the card's own snippet takes its model from. The prop is renamed `hasProviders` to `canServeRequests` so both callers are answering the question the card actually asks.

**The loop the prop's docstring warns about.** The parent still owns the query. `OrganizationOverview` never gates its own render on the catalog query's fetching state, so the card's existing `useModels()` in `IssuedKey` is a second observer with nothing to re-trigger: no mount, loading branch, unmount, remount cycle. The gate reads only `models.data`, so it is `false` while the query is pending or errored and never oscillates on the `isPending`/`isSuccess || isError` trap. `isFetched` is not owed for the same reason: a false gate renders `null` inside a page that keeps rendering, rather than swapping to a spinner that unmounts observers.

Tests cover the axis directly: a non-operator the server reports eligible sees the guide, an operator still does, an ineligible caller does not, and a caller with an empty catalog is not offered a key for a call that must fail. All three were checked against the inverted fixture and go red.

No route, schema or docstring changed, so no OpenAPI or Postman regeneration is owed, and `schema.ts` and `routeTree.gen.ts` regenerate identically. `tests/integration` is left to CI (no Docker on this machine); `make lint`, `make typecheck`, `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and the full `pnpm --dir web test` (3866 tests) are green locally.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#2080

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Except `tests/integration`, which needs Docker this machine does not have; left to CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Nothing changed here: no route, schema or route docstring was touched.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Written by Claude Opus 5 (1M context) at @khaledosman's request. Self-reviewed against the repository's `review` skill before the PR was opened.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Made `SetupGuideCard` available to organization tenants and deployment operators.
- Used the model catalog to determine whether a caller can serve requests.
- Updated loading and refresh behavior for the organization Overview.
- Renamed the component prop to `canServeRequests`.
- Added coverage for eligible, ineligible, operator, and empty-catalog cases.

This lets eligible organization tenants access the activation guide without operator-only permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->