### PR TITLE
docs: help contributors tell an Otari change from an any-llm change

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,7 @@ assignees: ''
 **Run mode:** <!-- standalone / hybrid -->
 **How you're running Otari:** <!-- Docker / docker compose / from source / Railway -->
 **Provider and model:** <!-- e.g. openai:gpt-4o-mini -->
+**Reproduces with a direct any-llm call?** <!-- yes / no / haven't tried. Otari dispatches through any-llm; if a plain any_llm call shows the same behavior, please file it at mozilla-ai/any-llm instead. -->
 
 ### What happened
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 **Run mode:** <!-- standalone / hybrid -->
 **How you're running Otari:** <!-- Docker / docker compose / from source / Railway -->
 **Provider and model:** <!-- e.g. openai:gpt-4o-mini -->
-**Reproduces with a direct any-llm call?** <!-- yes / no / haven't tried. Otari dispatches through any-llm; if a plain any_llm call shows the same behavior, please file it at mozilla-ai/any-llm instead. -->
+**Reproduces with a direct any-llm call?** <!-- yes / no / haven't tried. Otari dispatches through any-llm; if a plain any_llm call shows the same behavior, please file it at mozilla-ai/any-llm instead. Minimal repro snippet: https://github.com/mozilla-ai/otari/blob/main/CONTRIBUTING.md#is-this-an-otari-change-or-an-any-llm-change -->
 
 ### What happened
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: Discord
     url: https://discord.gg/ZfZPfTdtSe
     about: Chat with the community and maintainers in real time.
+  - name: Provider integration bug (missing provider, dropped param, bad response shape)
+    url: https://github.com/mozilla-ai/any-llm/issues
+    about: Otari dispatches provider calls through any-llm. If a plain any-llm call reproduces it, report it there so every any-llm user gets the fix.
   - name: Documentation
     url: https://github.com/mozilla-ai/otari/blob/main/docs/index.md
     about: Quickstart, configuration, and API reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,6 +14,13 @@ assignees: ''
 
 <!-- What would you like to see? How should it work? -->
 
+### Does this belong in Otari?
+
+<!-- Otari dispatches provider calls through any-llm. Requests about which
+providers or provider params are supported usually belong at
+mozilla-ai/any-llm. See
+https://github.com/mozilla-ai/otari/blob/main/CONTRIBUTING.md#is-this-an-otari-change-or-an-any-llm-change -->
+
 ### Alternatives considered
 
 <!-- Any workarounds you've tried, or other approaches you thought about. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Scope: entire repo.
 
 ## Project Snapshot
 - Project: `otari`, an OpenAI-compatible LLM gateway (API key management, budget enforcement, usage tracking). The Python package is named `gateway` (not `otari`): the `otari` distribution name on PyPI belongs to the Otari client SDK, which `any-llm-sdk` depends on, so a top-level `otari` import package here would collide with it. User-facing names (CLI, env vars, docs, OpenAPI title) are `otari`; only the internal import path stays `gateway`.
-- Provider calls go through the `any-llm` SDK (`any_llm`), not hand-rolled HTTP clients. Provider integration is therefore upstream's, and a change to how a provider call is made may not belong in this repo at all. Decide that before implementing: [CONTRIBUTING.md](CONTRIBUTING.md#is-this-an-otari-change-or-an-any-llm-change) carries the seam (any-llm talks to providers; Otari decides whether a call happens, on which credentials, and what it cost), a per-area table, and the reproduce-without-Otari test. Getting it wrong lands a patch here for a bug every any-llm user has, so say which side you concluded it falls on, and why, rather than defaulting to a local fix.
+- Provider calls go through the `any-llm` SDK (`any_llm`), not hand-rolled HTTP clients. A change to how a provider call is made may not belong in this repo. Decide that before implementing, and say which side you landed on: [CONTRIBUTING.md](CONTRIBUTING.md#is-this-an-otari-change-or-an-any-llm-change).
 
 ## Skills & Scoped Instructions
 Detailed, task-scoped guidance lives outside this file so it loads only when relevant
@@ -104,7 +104,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
 - Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
-- A workaround for an any-llm gap is a legitimate change here, under the convention the existing ones follow: keep the shim minimal, comment it with the upstream any-llm issue and the Otari issue that removes it once the pin moves, and file the upstream issue first. `service_tier` in `api/routes/chat.py` is the pattern; an undocumented shim becomes permanent by accident.
+- A workaround for an any-llm gap is a legitimate change here. Keep it minimal and follow the convention in [CONTRIBUTING.md](CONTRIBUTING.md#when-the-fix-is-upstream-but-otari-cannot-wait) (`service_tier` in `api/routes/chat.py` is the worked example).
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
 - Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
-- A workaround for an any-llm gap is a legitimate change here. Keep it minimal and follow the convention in [CONTRIBUTING.md](CONTRIBUTING.md#when-the-fix-is-upstream-but-otari-cannot-wait) (`service_tier` in `api/routes/chat.py` is the worked example).
+- A workaround for an any-llm gap is a legitimate change here. Keep it minimal and follow the convention in [CONTRIBUTING.md](CONTRIBUTING.md#when-the-fix-is-upstream-but-otari-cannot-wait) (`service_tier` in `src/gateway/api/routes/chat.py` is the worked example).
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Scope: entire repo.
 
 ## Project Snapshot
 - Project: `otari`, an OpenAI-compatible LLM gateway (API key management, budget enforcement, usage tracking). The Python package is named `gateway` (not `otari`): the `otari` distribution name on PyPI belongs to the Otari client SDK, which `any-llm-sdk` depends on, so a top-level `otari` import package here would collide with it. User-facing names (CLI, env vars, docs, OpenAPI title) are `otari`; only the internal import path stays `gateway`.
-- Provider calls go through the `any-llm` SDK (`any_llm`), not hand-rolled HTTP clients.
+- Provider calls go through the `any-llm` SDK (`any_llm`), not hand-rolled HTTP clients. Provider integration is therefore upstream's, and a change to how a provider call is made may not belong in this repo at all. Decide that before implementing: [CONTRIBUTING.md](CONTRIBUTING.md#is-this-an-otari-change-or-an-any-llm-change) carries the seam (any-llm talks to providers; Otari decides whether a call happens, on which credentials, and what it cost), a per-area table, and the reproduce-without-Otari test. Getting it wrong lands a patch here for a bug every any-llm user has, so say which side you concluded it falls on, and why, rather than defaulting to a local fix.
 
 ## Skills & Scoped Instructions
 Detailed, task-scoped guidance lives outside this file so it loads only when relevant
@@ -104,6 +104,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
 - Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
+- A workaround for an any-llm gap is a legitimate change here, under the convention the existing ones follow: keep the shim minimal, comment it with the upstream any-llm issue and the Otari issue that removes it once the pin moves, and file the upstream issue first. `service_tier` in `api/routes/chat.py` is the pattern; an undocumented shim becomes permanent by accident.
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,13 +32,21 @@ print(asyncio.run(acompletion(
 )))
 ```
 
-| Belongs in [any-llm](https://github.com/mozilla-ai/any-llm/issues) | Belongs in Otari |
-| --- | --- |
-| A provider is unsupported, or needs a new implementation | Keys, users, orgs, workspaces, budgets, usage records, pricing |
-| A request param is dropped or mistranslated on the way to a provider SDK | Route schemas, the OpenAPI spec, the Anthropic and Responses envelopes |
-| A provider's response or stream chunks are not normalized to the OpenAI shape | Routing, fallback across attempts, routing memory |
-| `list_models` behavior, provider capability flags, credential env var names, default base URLs | `config.yml` layering, the `providers:` block, provider instances and aliases |
-| A provider SDK upgrade breaks the call itself | The dashboard, built-in tools, the MCP loop, guardrails, hybrid mode |
+**File it in [any-llm](https://github.com/mozilla-ai/any-llm/issues) if:**
+
+- a provider is unsupported, or needs a new implementation
+- a request param is dropped or mistranslated on the way to a provider SDK
+- a provider's response or stream chunks are not normalized to the OpenAI shape
+- `list_models` behavior, a provider capability flag, a credential env var name, or a default base URL is wrong
+- a provider SDK upgrade breaks the call itself
+
+**File it here if it touches:**
+
+- keys, users, orgs, workspaces, budgets, usage records, or pricing
+- route schemas, the OpenAPI spec, or the Anthropic and Responses envelopes
+- routing, fallback across attempts, or routing memory
+- `config.yml` layering, the `providers:` block, or provider instances and aliases
+- the dashboard, built-in tools, the MCP loop, guardrails, or hybrid mode
 
 Two things that look upstream but are ours: the per-provider setup guides in
 `docs/providers/`, and how a provider error becomes a status code and a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,53 @@
 - For significant changes (new endpoints, auth changes, breaking config changes, new dependencies), open an issue first to align on approach.
 - All contributors must follow Mozilla's [Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
 
+## Is this an Otari change or an any-llm change?
+
+Otari dispatches every provider call through
+[any-llm](https://github.com/mozilla-ai/any-llm). Much of what looks like an
+Otari bug is a provider integration bug, and fixing it here means patching
+around the SDK instead of fixing it for every any-llm user. Work out which repo
+owns the change before writing code.
+
+**The seam:** any-llm owns talking to a provider. Otari owns deciding whether a
+call happens, with which credentials, and what it cost.
+
+**The test:** reproduce it without Otari. If a direct any-llm call shows the same
+behavior, it belongs upstream.
+
+```python
+# pip install "any-llm-sdk[all]"
+import asyncio
+from any_llm import acompletion
+
+print(asyncio.run(acompletion(
+    model="openai:gpt-4o-mini",   # your provider:model
+    messages=[{"role": "user", "content": "hi"}],
+    # plus the param or option you think Otari is mishandling
+)))
+```
+
+| Belongs in [any-llm](https://github.com/mozilla-ai/any-llm/issues) | Belongs in Otari |
+| --- | --- |
+| A provider is unsupported, or needs a new implementation | Keys, users, orgs, workspaces, budgets, usage records, pricing |
+| A request param is dropped or mistranslated on the way to a provider SDK | Route schemas, the OpenAPI spec, the Anthropic and Responses envelopes |
+| A provider's response or stream chunks are not normalized to the OpenAI shape | Routing, fallback across attempts, routing memory |
+| `list_models` behavior, provider capability flags, credential env var names, default base URLs | `config.yml` layering, the `providers:` block, provider instances and aliases |
+| A provider SDK upgrade breaks the call itself | The dashboard, built-in tools, the MCP loop, guardrails, hybrid mode |
+
+Two things that look upstream but are ours: the per-provider setup guides in
+`docs/providers/`, and how a provider error becomes a status code and a
+sanitized message.
+
+### When the fix is upstream but Otari cannot wait
+
+Otari sometimes has to carry a workaround while any-llm catches up. That is a
+legitimate PR here, with conditions: keep the shim as small as the problem
+allows, comment it with a link to the any-llm issue, and open an Otari issue to
+remove it once the SDK pin moves. `service_tier` in
+`src/gateway/api/routes/chat.py` is the worked example. File the upstream issue
+first; a shim with no upstream issue is permanent by accident.
+
 ## Dev setup
 
 **Prerequisites:** Python 3.13+, `uv`, Docker (for integration tests).


### PR DESCRIPTION
## Description

Provider integration fixes get filed here that belong in any-llm: Otari's HTTP surface is where a user meets the bug, any-llm is where the call is made. Adds the decision procedure at three points, each firing at a different moment. CONTRIBUTING carries the seam, an area table, and a reproduce-without-Otari snippet. The issue templates ask the question before a PR exists. AGENTS.md asks an agent to decide before implementing.

Three outcomes, not two. An Otari-side shim for an any-llm gap is legitimate, and this repo already carries several (`service_tier`, keyless custom endpoints, Anthropic `container`) under a convention that lived only in the code: minimal shim, a comment naming the upstream issue, a tracking issue to remove it when the pin moves. Now written down.

PR template left unchanged.

## PR Type

- [x] Documentation

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Not applicable: docs and issue templates only.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Not applicable: no code changed.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. Not applicable.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5, via the Claude Code CLI

**Any additional AI details you'd like to share:**

Scope was set by @njbrake, who cut a proposed PR-template checkbox from the change. The three-bucket framing came out of reading the repo's own merged shim PRs.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added guidance to distinguish Otari issues from any-llm issues.
- Updated issue templates to direct provider-layer reports to any-llm.
- Linked `AGENTS.md` to the shared contribution guidance.
- Documented when Otari may use a temporary workaround for an any-llm limitation.

These changes should help contributors file issues in the correct repository and keep workarounds small and traceable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->