### PR TITLE
feat(dashboard): give a workspace's provider-key overrides and model restrictions a surface

### DIFF
--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -499,6 +499,18 @@ export type CreateWorkspaceBudgetDefaultRequest =
 export type UpdateWorkspaceBudgetDefaultRequest =
   Schemas["WorkspaceMemberBudgetPolicyUpdate"]
 
+// One workspace's departure from the organization key above: pinned as this
+// workspace's default, opted out of, or neither. `is_default`/`disabled` are the
+// stored flags and `is_effective_*` the resolution across the provider's keys,
+// so a row can be unpinned and still effective (it is the organization default,
+// or the only key that provider has).
+export type WorkspaceProviderKeyOverride =
+  Schemas["WorkspaceProviderKeyOverridePublic"]
+// Tri-state on the way in: an omitted flag is left unchanged, so the dashboard
+// sends one at a time and lets the gateway resolve the other.
+export type SetWorkspaceProviderKeyOverrideRequest =
+  Schemas["WorkspaceProviderKeyOverrideRequest"]
+
 // The first-request setup guide's state, and the API key it issues. The wire
 // names carry the platform's "activation" vocabulary (see
 // `src/gateway/services/tenancy/workspace_activation_service.py`); the

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -63,11 +63,11 @@ import { canManage } from "./roles"
 // (`STANDALONE_SURFACES` / `HOSTED_SURFACES` in
 // `src/gateway/api/routes/bootstrap.py`).
 //
-// What is deliberately absent is the per-workspace half of the same API
-// (`/v1/workspaces/{id}/provider-keys`: pin, disable, restrict to models). Those
-// are one workspace's departure from what this page sets, so they belong beside
-// that workspace rather than here, and the organization view would have to ask
-// "which workspace" before it could show any of it.
+// The per-workspace half of the same API (`/v1/workspaces/{id}/provider-keys`:
+// pin, disable, restrict to models) is deliberately not here. Those are one
+// workspace's departure from what this page sets, so they belong beside that
+// workspace: `WorkspaceProviderKeys`, on the Workspaces page, which has already
+// asked "which workspace" before it shows any of it.
 
 /** A key's editable fields, seeded from a row when one is being edited. */
 interface KeyDraft {

--- a/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
@@ -141,7 +141,7 @@ describe("WorkspaceProviderKeys", () => {
 
     await user.click(
       await screen.findByRole("button", {
-        name: /Allow every model again by removing gpt-4o/,
+        name: "Stop allowing gpt-4o on openai / Production",
       }),
     )
 
@@ -264,10 +264,11 @@ describe("WorkspaceProviderKeys", () => {
     )
   })
 
-  it("does not read an unanswered allow-list as an open one", async () => {
+  it("says a refused allow-list was refused, not that it is open or loading", async () => {
     // An empty list is the answer "every model is allowed", so a read that
-    // failed must not borrow it: that would report a narrowing still in force
-    // as lifted.
+    // failed must not borrow it: that would report a narrowing still in force as
+    // lifted. Nor may it sit on "loading", which claims an answer is still
+    // coming from a read that already gave one.
     mockApi({
       modelsRefusal: { status: 403, detail: "Not a member of this workspace" },
     })
@@ -275,8 +276,14 @@ describe("WorkspaceProviderKeys", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/Not a member/)
     expect(
+      await screen.findByText(
+        "The allowed models for this key could not be read.",
+      ),
+    ).toBeInTheDocument()
+    expect(
       screen.queryByText("Every model this key serves is allowed."),
     ).toBeNull()
+    expect(screen.queryByText("Loading allowed models…")).toBeNull()
   })
 
   it("names a key the organization list does not carry by its id", async () => {

--- a/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
@@ -1,0 +1,271 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { OrgProviderKey, WorkspaceProviderKeyOverride } from "@/client"
+import { WorkspaceProviderKeys } from "@/features/workspaces/WorkspaceProviderKeys"
+import { orgProviderKey, workspaceProviderKeyOverride } from "@/tests/fixtures"
+import { pickOption } from "@/tests/select"
+
+const WORKSPACE = "44444444-4444-4444-4444-444444444444"
+const OPENAI_KEY = "66666666-6666-6666-6666-666666666666"
+const ANTHROPIC_KEY = "77777777-7777-7777-7777-777777777777"
+
+interface Request {
+  url: string
+  method: string
+  body: unknown
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function mockApi(
+  opts: {
+    keys?: OrgProviderKey[]
+    overrides?: WorkspaceProviderKeyOverride[]
+    /** The allow-list each key carries, by key id. Absent means every model. */
+    models?: Record<string, string[]>
+    /** A refusal for whichever write matches, for the error paths. */
+    writeRefusal?: { method: string; status: number; detail: string }
+    /** A refusal for the organization's own key list. */
+    keysRefusal?: { status: number; detail: string }
+  } = {},
+) {
+  const keys = opts.keys ?? [orgProviderKey()]
+  const overrides = opts.overrides ?? [workspaceProviderKeyOverride()]
+  const models = opts.models ?? {}
+  const requests: Request[] = []
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input)
+    const method = (init?.method ?? "GET").toUpperCase()
+    requests.push({
+      url,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    })
+
+    if (opts.writeRefusal && method === opts.writeRefusal.method) {
+      return jsonResponse(
+        { detail: opts.writeRefusal.detail },
+        opts.writeRefusal.status,
+      )
+    }
+    if (url.includes("/models")) {
+      if (method !== "GET") return jsonResponse({ message: "ok" })
+      const keyId = url.split("/provider-keys/")[1]?.split("/")[0] ?? ""
+      return jsonResponse({ models: models[keyId] ?? [] })
+    }
+    if (url.includes("/v1/workspaces/")) {
+      if (method !== "GET") return jsonResponse({ message: "ok" })
+      return jsonResponse({ data: overrides })
+    }
+    if (url.includes("/v1/organizations/me/provider-keys")) {
+      if (opts.keysRefusal) {
+        return jsonResponse(
+          { detail: opts.keysRefusal.detail },
+          opts.keysRefusal.status,
+        )
+      }
+      return jsonResponse({ data: keys, count: keys.length })
+    }
+    return jsonResponse({})
+  })
+
+  return requests
+}
+
+function renderSection() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <WorkspaceProviderKeys workspaceId={WORKSPACE} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("WorkspaceProviderKeys", () => {
+  it("names every inherited key and says nothing is narrowed", async () => {
+    mockApi()
+    renderSection()
+
+    expect(await screen.findByText("openai / Production")).toBeInTheDocument()
+    expect(
+      await screen.findByText("Every model this key serves is allowed."),
+    ).toBeInTheDocument()
+    // The key resolving for this workspace, which the flags alone do not say.
+    expect(screen.getByText("In use")).toBeInTheDocument()
+  })
+
+  it("shows a migrated restriction as the narrowing it is", async () => {
+    // The state the cutover creates: a workspace whose catalog is narrowed to
+    // named models, which until now was invisible in the dashboard.
+    mockApi({ models: { [OPENAI_KEY]: ["gpt-4o", "gpt-4o-mini"] } })
+    renderSection()
+
+    expect(await screen.findByText("gpt-4o")).toBeInTheDocument()
+    expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument()
+    expect(
+      screen.queryByText("Every model this key serves is allowed."),
+    ).toBeNull()
+  })
+
+  it("lifts a restriction through the model the operator names", async () => {
+    const requests = mockApi({ models: { [OPENAI_KEY]: ["gpt-4o"] } })
+    const user = userEvent.setup()
+    renderSection()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /Allow every model again by removing gpt-4o/,
+      }),
+    )
+
+    const removed = requests.find((request) => request.method === "DELETE")
+    expect(removed?.url).toBe(
+      `/v1/workspaces/${WORKSPACE}/provider-keys/${OPENAI_KEY}/models/gpt-4o`,
+    )
+  })
+
+  it("narrows a key to one more model", async () => {
+    const requests = mockApi()
+    const user = userEvent.setup()
+    renderSection()
+
+    await user.type(
+      await screen.findByLabelText("Allow a model on openai / Production"),
+      "gpt-4o",
+    )
+    await user.click(screen.getByRole("button", { name: "Allow" }))
+
+    const added = requests.find((request) => request.method === "POST")
+    expect(added?.url).toBe(
+      `/v1/workspaces/${WORKSPACE}/provider-keys/${OPENAI_KEY}/models`,
+    )
+    expect(added?.body).toEqual({ model: "gpt-4o" })
+  })
+
+  it("pins a key as this workspace's default with one flag", async () => {
+    // Both flags true is the one combination the gateway refuses, so the
+    // picker sends the one it means and leaves the other to auto-resolve.
+    const requests = mockApi()
+    const user = userEvent.setup()
+    renderSection()
+
+    await screen.findByText("openai / Production")
+    await pickOption(
+      user,
+      "This workspace's use of openai / Production",
+      "Workspace default",
+    )
+
+    const patch = requests.find((request) => request.method === "PATCH")
+    expect(patch?.url).toBe(
+      `/v1/workspaces/${WORKSPACE}/provider-keys/${OPENAI_KEY}`,
+    )
+    expect(patch?.body).toEqual({ is_default: true })
+  })
+
+  it("disables a key, and stops offering an allow-list it cannot write", async () => {
+    // Disabling deletes the key's allow-list server-side and refuses a later
+    // add, so the controls go with it rather than refusing on press.
+    mockApi({
+      overrides: [workspaceProviderKeyOverride({ disabled: true })],
+    })
+    renderSection()
+
+    expect(
+      await screen.findByText(
+        "No model of this key is available to this workspace.",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Allow" })).toBeNull()
+  })
+
+  it("reverts to inheritance by deleting the override", async () => {
+    const requests = mockApi({
+      overrides: [workspaceProviderKeyOverride({ is_default: true })],
+    })
+    const user = userEvent.setup()
+    renderSection()
+
+    await screen.findByText("openai / Production")
+    await pickOption(
+      user,
+      "This workspace's use of openai / Production",
+      "Inherited",
+    )
+
+    const reset = requests.find((request) => request.method === "DELETE")
+    expect(reset?.url).toBe(
+      `/v1/workspaces/${WORKSPACE}/provider-keys/${OPENAI_KEY}`,
+    )
+  })
+
+  it("reports a refused write rather than showing it as applied", async () => {
+    mockApi({
+      writeRefusal: {
+        method: "PATCH",
+        status: 403,
+        detail: "Not authorized to manage this workspace",
+      },
+    })
+    const user = userEvent.setup()
+    renderSection()
+
+    await screen.findByText("openai / Production")
+    await pickOption(
+      user,
+      "This workspace's use of openai / Production",
+      "Disabled",
+    )
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Not authorized/)
+    // The row still shows what the gateway holds, not what was asked for.
+    expect(
+      screen.queryByText(
+        "No model of this key is available to this workspace.",
+      ),
+    ).toBeNull()
+  })
+
+  it("reports a refused key list rather than naming keys by id in silence", async () => {
+    mockApi({
+      keysRefusal: { status: 403, detail: "Organization admins only" },
+    })
+    renderSection()
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Organization admins only/,
+    )
+  })
+
+  it("names a key the organization list does not carry by its id", async () => {
+    // Not a state the gateway produces, since both reads cover the same
+    // non-archived set, but the row stays addressable if it ever does.
+    mockApi({
+      overrides: [
+        workspaceProviderKeyOverride({ org_provider_key_id: ANTHROPIC_KEY }),
+      ],
+    })
+    renderSection()
+
+    expect(await screen.findByText(ANTHROPIC_KEY)).toBeInTheDocument()
+  })
+})

--- a/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.test.tsx
@@ -35,6 +35,8 @@ function mockApi(
     writeRefusal?: { method: string; status: number; detail: string }
     /** A refusal for the organization's own key list. */
     keysRefusal?: { status: number; detail: string }
+    /** A refusal for a key's allow-list read. */
+    modelsRefusal?: { status: number; detail: string }
   } = {},
 ) {
   const keys = opts.keys ?? [orgProviderKey()]
@@ -59,6 +61,12 @@ function mockApi(
     }
     if (url.includes("/models")) {
       if (method !== "GET") return jsonResponse({ message: "ok" })
+      if (opts.modelsRefusal) {
+        return jsonResponse(
+          { detail: opts.modelsRefusal.detail },
+          opts.modelsRefusal.status,
+        )
+      }
       const keyId = url.split("/provider-keys/")[1]?.split("/")[0] ?? ""
       return jsonResponse({ models: models[keyId] ?? [] })
     }
@@ -254,6 +262,21 @@ describe("WorkspaceProviderKeys", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       /Organization admins only/,
     )
+  })
+
+  it("does not read an unanswered allow-list as an open one", async () => {
+    // An empty list is the answer "every model is allowed", so a read that
+    // failed must not borrow it: that would report a narrowing still in force
+    // as lifted.
+    mockApi({
+      modelsRefusal: { status: 403, detail: "Not a member of this workspace" },
+    })
+    renderSection()
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Not a member/)
+    expect(
+      screen.queryByText("Every model this key serves is allowed."),
+    ).toBeNull()
   })
 
   it("names a key the organization list does not carry by its id", async () => {

--- a/web/src/features/workspaces/WorkspaceProviderKeys.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.tsx
@@ -78,12 +78,15 @@ function ModelAllowList({
   keyId,
   keyName,
   models,
+  failed,
 }: {
   workspaceId: string
   keyId: string
   keyName: string
   /** Undefined until this key's own read answers; an empty list is a real answer. */
   models: string[] | undefined
+  /** Whether that read was refused, which is a wait that never ends otherwise. */
+  failed: boolean
 }) {
   const add = useAddWorkspaceProviderKeyModel()
   const remove = useRemoveWorkspaceProviderKeyModel()
@@ -94,7 +97,14 @@ function ModelAllowList({
   return (
     <div className="flex flex-col gap-2">
       <ErrorBanner error={add.error ?? remove.error} />
-      {models === undefined ? (
+      {failed ? (
+        // Said on the row as well as in the banner above: without this the row
+        // waits forever on a read that already answered, and a caption saying
+        // "loading" is a claim that the answer is still coming.
+        <span className="text-caption">
+          The allowed models for this key could not be read.
+        </span>
+      ) : models === undefined ? (
         // Not "every model is allowed", which is what an empty list means and
         // what an unanswered read would otherwise be read as: a narrowed
         // workspace would say it was open for as long as the read took.
@@ -109,7 +119,10 @@ function ModelAllowList({
             <li key={model}>
               <DismissChip
                 value={model}
-                dismissLabel={`Allow every model again by removing ${model} from ${keyName}`}
+                // Only what the press does: dropping one entry leaves the rest
+                // of the allow-list in force, so a label promising every model
+                // back is true of the last entry alone.
+                dismissLabel={`Stop allowing ${model} on ${keyName}`}
                 onDismiss={() => remove.mutate({ workspaceId, keyId, model })}
               />
             </li>
@@ -247,7 +260,8 @@ export function WorkspaceProviderKeys({
                     workspaceId={workspaceId}
                     keyId={keyId}
                     keyName={name}
-                    models={models.data.get(keyId)}
+                    models={models.data.get(keyId)?.models}
+                    failed={models.data.get(keyId)?.failed ?? false}
                   />
                 )}
               </li>

--- a/web/src/features/workspaces/WorkspaceProviderKeys.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.tsx
@@ -53,6 +53,17 @@ function departureOf(row: WorkspaceProviderKeyOverride): Departure {
   return "inherited"
 }
 
+/**
+ * Narrow the picker's string back to the vocabulary above.
+ *
+ * A guard rather than a cast, following `asMembershipRole`: the options come
+ * from `DEPARTURE_OPTIONS`, and a value that is not one of them is a bug worth
+ * dropping the write for rather than sending and having refused.
+ */
+function asDeparture(value: string): Departure | undefined {
+  return DEPARTURE_OPTIONS.find((option) => option.value === value)?.value
+}
+
 /** How a key is named on screen: its provider and the name the organization gave it. */
 function keyLabel(key: OrgProviderKey | undefined, keyId: string): string {
   // A key the organization list does not carry is not a state the gateway
@@ -71,7 +82,8 @@ function ModelAllowList({
   workspaceId: string
   keyId: string
   keyName: string
-  models: string[]
+  /** Undefined until this key's own read answers; an empty list is a real answer. */
+  models: string[] | undefined
 }) {
   const add = useAddWorkspaceProviderKeyModel()
   const remove = useRemoveWorkspaceProviderKeyModel()
@@ -82,7 +94,12 @@ function ModelAllowList({
   return (
     <div className="flex flex-col gap-2">
       <ErrorBanner error={add.error ?? remove.error} />
-      {models.length === 0 ? (
+      {models === undefined ? (
+        // Not "every model is allowed", which is what an empty list means and
+        // what an unanswered read would otherwise be read as: a narrowed
+        // workspace would say it was open for as long as the read took.
+        <span className="text-caption">Loading allowed models…</span>
+      ) : models.length === 0 ? (
         <span className="text-caption">
           Every model this key serves is allowed.
         </span>
@@ -181,7 +198,7 @@ export function WorkspaceProviderKeys({
           resetOverride.error
         }
       />
-      {overrides.isPending ? (
+      {overrides.isPending && overrides.data === undefined ? (
         <span className="text-caption">Loading…</span>
       ) : rows.length === 0 ? (
         <span className="text-caption">
@@ -203,7 +220,10 @@ export function WorkspaceProviderKeys({
                   <FilterSelect
                     ariaLabel={`This workspace's use of ${name}`}
                     value={departure}
-                    onChange={(next) => choose(keyId, next as Departure)}
+                    onChange={(next) => {
+                      const chosen = asDeparture(next)
+                      if (chosen) choose(keyId, chosen)
+                    }}
                     options={DEPARTURE_OPTIONS}
                     disabled={pending}
                   />
@@ -227,7 +247,7 @@ export function WorkspaceProviderKeys({
                     workspaceId={workspaceId}
                     keyId={keyId}
                     keyName={name}
-                    models={models.data.get(keyId) ?? []}
+                    models={models.data.get(keyId)}
                   />
                 )}
               </li>

--- a/web/src/features/workspaces/WorkspaceProviderKeys.tsx
+++ b/web/src/features/workspaces/WorkspaceProviderKeys.tsx
@@ -1,0 +1,240 @@
+import { Button } from "@heroui/react"
+import { useState } from "react"
+
+import type { OrgProviderKey, WorkspaceProviderKeyOverride } from "@/client"
+import { useOrgProviderKeys } from "@/shared/api/organizations"
+import {
+  useAddWorkspaceProviderKeyModel,
+  useRemoveWorkspaceProviderKeyModel,
+  useResetWorkspaceProviderKeyOverride,
+  useSetWorkspaceProviderKeyOverride,
+  useWorkspaceProviderKeyModels,
+  useWorkspaceProviderKeys,
+} from "@/shared/api/workspaces"
+import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
+import { Field } from "@/shared/components/forms/Field"
+import { DismissChip } from "@/shared/components/indicators/DismissChip"
+import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
+
+/**
+ * One workspace's departures from the provider keys its organization holds.
+ *
+ * The other half of `OrganizationProviderKeysPage`: that page owns the
+ * credentials themselves, this owns what one workspace does with them. Absence
+ * of an override is full inheritance, so every row starts at "Inherited" and a
+ * departure is something an admin chose.
+ *
+ * The three states are the two stored flags plus their absence, because the
+ * gateway stores no no-op row (see `WorkspaceProviderKeyOverrideRequest`):
+ * pinning is `is_default`, opting out is `disabled`, and inheriting is the row
+ * being deleted. One flag is sent at a time and the other is left to
+ * auto-resolve, which is what the tri-state request is for.
+ *
+ * The allow-list is per (workspace, key) and narrows rather than widens: no rows
+ * means every model that key serves. It is what
+ * `services/tenancy/organization_model_access.py` reads when it builds a
+ * session's catalog scope, so emptying a workspace's catalog here also takes
+ * `/v1/models` down to nothing for it, and with it the first-request setup guide
+ * that asks the same endpoint whether a call could succeed (#980).
+ */
+
+/** What a row's picker is showing, which is the pair of stored flags named. */
+type Departure = "inherited" | "pinned" | "disabled"
+
+const DEPARTURE_OPTIONS: { value: Departure; label: string }[] = [
+  { value: "inherited", label: "Inherited" },
+  { value: "pinned", label: "Workspace default" },
+  { value: "disabled", label: "Disabled" },
+]
+
+function departureOf(row: WorkspaceProviderKeyOverride): Departure {
+  if (row.disabled) return "disabled"
+  if (row.is_default) return "pinned"
+  return "inherited"
+}
+
+/** How a key is named on screen: its provider and the name the organization gave it. */
+function keyLabel(key: OrgProviderKey | undefined, keyId: string): string {
+  // A key the organization list does not carry is not a state the gateway
+  // produces (both reads cover the same non-archived set), so this is a fallback
+  // rather than a case: naming the id keeps the row addressable if it happens.
+  if (!key) return keyId
+  return `${key.provider} / ${key.name}`
+}
+
+function ModelAllowList({
+  workspaceId,
+  keyId,
+  keyName,
+  models,
+}: {
+  workspaceId: string
+  keyId: string
+  keyName: string
+  models: string[]
+}) {
+  const add = useAddWorkspaceProviderKeyModel()
+  const remove = useRemoveWorkspaceProviderKeyModel()
+  const [draft, setDraft] = useState("")
+  const pending = add.isPending || remove.isPending
+  const trimmed = draft.trim()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ErrorBanner error={add.error ?? remove.error} />
+      {models.length === 0 ? (
+        <span className="text-caption">
+          Every model this key serves is allowed.
+        </span>
+      ) : (
+        <ul className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {models.map((model) => (
+            <li key={model}>
+              <DismissChip
+                value={model}
+                dismissLabel={`Allow every model again by removing ${model} from ${keyName}`}
+                onDismiss={() => remove.mutate({ workspaceId, keyId, model })}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      {/* A text input rather than a picker over the catalog: the only listing a
+          tenant may read is `/v1/models`, which is already filtered through
+          these very restrictions, so a picker built on it would stop offering
+          the models this control exists to add back. */}
+      <div className="flex items-end gap-2">
+        <Field
+          label={`Allow a model on ${keyName}`}
+          value={draft}
+          onChange={setDraft}
+          placeholder="gpt-4o"
+        />
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={pending || trimmed === ""}
+          onPress={() =>
+            add.mutate(
+              { workspaceId, keyId, model: trimmed },
+              { onSuccess: () => setDraft("") },
+            )
+          }
+        >
+          Allow
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function WorkspaceProviderKeys({
+  workspaceId,
+}: {
+  workspaceId: string
+}) {
+  const orgKeys = useOrgProviderKeys()
+  const overrides = useWorkspaceProviderKeys(workspaceId)
+  const rows = overrides.data ?? []
+  const models = useWorkspaceProviderKeyModels(
+    workspaceId,
+    rows.map((row) => row.org_provider_key_id),
+  )
+  const setOverride = useSetWorkspaceProviderKeyOverride()
+  const resetOverride = useResetWorkspaceProviderKeyOverride()
+
+  const byId = new Map((orgKeys.data ?? []).map((key) => [key.id, key]))
+  const pending = setOverride.isPending || resetOverride.isPending
+
+  const choose = (keyId: string, next: Departure) => {
+    if (next === "inherited") {
+      resetOverride.mutate({ workspaceId, keyId })
+      return
+    }
+    // One flag, never both: the gateway un-pins a key being disabled and
+    // re-enables one being pinned, and sending both true is the one combination
+    // it refuses.
+    setOverride.mutate({
+      workspaceId,
+      keyId,
+      body: next === "pinned" ? { is_default: true } : { disabled: true },
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <span className="text-body">Provider keys</span>
+        <span className="max-w-md text-caption">
+          This workspace inherits every provider key the organization holds. Pin
+          one as its default, opt out of one, or narrow a key to named models.
+          Narrowing hides every other model of that provider from this
+          workspace, including from its model list.
+        </span>
+      </div>
+      <ErrorBanner
+        error={
+          orgKeys.error ??
+          overrides.error ??
+          models.error ??
+          setOverride.error ??
+          resetOverride.error
+        }
+      />
+      {overrides.isPending ? (
+        <span className="text-caption">Loading…</span>
+      ) : rows.length === 0 ? (
+        <span className="text-caption">
+          This organization holds no provider keys, so there is nothing for this
+          workspace to depart from.
+        </span>
+      ) : (
+        <ul className="flex flex-col gap-4">
+          {rows.map((row) => {
+            const keyId = row.org_provider_key_id
+            const name = keyLabel(byId.get(keyId), keyId)
+            const departure = departureOf(row)
+            return (
+              <li key={keyId} className="flex flex-col gap-2">
+                <div className="flex flex-wrap items-end gap-2">
+                  <span className="text-mono-caption text-foreground">
+                    {name}
+                  </span>
+                  <FilterSelect
+                    ariaLabel={`This workspace's use of ${name}`}
+                    value={departure}
+                    onChange={(next) => choose(keyId, next as Departure)}
+                    options={DEPARTURE_OPTIONS}
+                    disabled={pending}
+                  />
+                  {/* Which key the provider actually resolves to, which the
+                      flags alone do not say: an unpinned key is still the one
+                      serving this workspace when it is the organization's
+                      default, or the only one that provider has. */}
+                  {row.is_effective_default ? (
+                    <span className="text-caption">In use</span>
+                  ) : null}
+                </div>
+                {departure === "disabled" ? (
+                  // Not a control: the gateway refuses an allow-list write on a
+                  // disabled key, and deletes the rows it already had when the
+                  // key is disabled.
+                  <span className="text-caption">
+                    No model of this key is available to this workspace.
+                  </span>
+                ) : (
+                  <ModelAllowList
+                    workspaceId={workspaceId}
+                    keyId={keyId}
+                    keyName={name}
+                    models={models.data.get(keyId) ?? []}
+                  />
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -72,6 +72,11 @@ function mockApi(
       }
       return jsonResponse(members[0] ?? workspaceMember())
     }
+    if (url.includes("provider-keys")) {
+      if (url.includes("/models")) return jsonResponse({ models: [] })
+      if (url.includes("/v1/workspaces/")) return jsonResponse({ data: [] })
+      return jsonResponse({ data: [], count: 0 })
+    }
     if (url.includes("member-budget-policies")) {
       const id = url.split("/v1/workspaces/")[1]?.split("/")[0] ?? ""
       const rows = budgetDefaults[id] ?? []
@@ -387,6 +392,53 @@ describe("WorkspacesPage", () => {
       requests.filter((request) =>
         operatorOnly.some((path) => request.url.includes(path)),
       ),
+    ).toEqual([])
+  })
+
+  it("offers the workspace's provider keys on an admin's edit form", async () => {
+    // The per-workspace half of the organization's provider keys, which the
+    // roles matrix has at Edit for an admin and hidden from everyone else. Not
+    // withheld from a non-operator, unlike the budget controls above it: these
+    // are the tenant's own credentials rather than the deployment's.
+    const requests = mockApi({
+      context: organizationContext({ deployment_operator: false }),
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+
+    expect(await screen.findByText("Provider keys")).toBeInTheDocument()
+    expect(
+      requests.some((request) =>
+        request.url.includes(
+          "/v1/workspaces/44444444-4444-4444-4444-444444444444/provider-keys",
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      requests.some((request) =>
+        request.url.includes("/v1/organizations/me/provider-keys"),
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps the provider keys and their reads away from a member", async () => {
+    // A member cannot open the edit form, which is where the section lives, so
+    // it is never mounted and neither of its reads is made. The gateway agrees
+    // on the writes (`require_workspace_management_access`) and refuses the
+    // organization's key list to anyone who does not manage the organization.
+    const requests = mockApi({
+      context: organizationContext({ role: "member" }),
+      workspaces: [workspace(), workspace({ id: SECOND, name: "Bravo" })],
+    })
+    renderPage(<WorkspacesPage />)
+
+    await screen.findByText("Bravo")
+    expect(screen.getAllByRole("button", { name: "Edit" })[0]).toBeDisabled()
+    expect(screen.queryByText("Provider keys")).toBeNull()
+    expect(
+      requests.filter((request) => request.url.includes("provider-keys")),
     ).toEqual([])
   })
 })

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 
 import type { Budget, Workspace, WorkspaceBudgetDefault } from "@/client"
 import { canManage, isDeploymentOperator } from "@/features/organization/roles"
+import { WorkspaceProviderKeys } from "@/features/workspaces/WorkspaceProviderKeys"
 import { useBudgets } from "@/shared/api/budgets"
 import { ApiError } from "@/shared/api/client"
 import { useOrganizationContext } from "@/shared/api/organizations"
@@ -600,6 +601,15 @@ function EditWorkspaceForm({
           />
         </>
       ) : null}
+      {/* Not withheld from a non-operator, unlike everything above it: these are
+          the tenant's own credentials rather than the deployment's, and the two
+          reads behind them (the organization's keys, and this workspace's
+          departures from them) answer an organization owner or admin. The page
+          already only opens this form to one, which is the same rule the gateway
+          applies to the writes (`require_workspace_management_access`), narrowed
+          to its organization arm because the key names come from the
+          organization-gated list. */}
+      <WorkspaceProviderKeys workspaceId={workspace.id} />
       <div className="flex gap-2">
         <Button
           variant="primary"

--- a/web/src/shared/api/workspaces.ts
+++ b/web/src/shared/api/workspaces.ts
@@ -361,14 +361,14 @@ export function useWorkspaceProviderKeyModels(
       staleTime: 60_000,
     })),
     combine: (results) => ({
+      // A key whose read has not answered maps to `undefined`, not to `[]`:
+      // an empty list is the answer "every model is allowed", so defaulting to
+      // one would report a narrowed workspace as open for as long as the read
+      // takes, and a refused read as open forever.
       data: new Map(
-        results.map((result, index) => [keyIds[index], result.data ?? []]),
+        results.map((result, index) => [keyIds[index], result.data]),
       ),
-      isLoading: results.some((result) => result.isLoading),
-      // The first failure rather than a swallowed one, as the fan-outs above do:
-      // a refused read contributes an empty list, which is exactly what "every
-      // model is allowed" looks like, so silence here would report the opposite
-      // of a narrowing that is still in force.
+      // The first failure rather than a swallowed one, as the fan-outs above do.
       error: results.find((result) => result.error)?.error ?? null,
     }),
   })
@@ -377,7 +377,8 @@ export function useWorkspaceProviderKeyModels(
 // Pinning a key clears whichever of the provider's other keys this workspace had
 // pinned, and disabling one deletes its model allow-list server-side, so every
 // write here re-reads the workspace's whole provider-key subtree rather than
-// patching the row it acted on.
+// patching the row it acted on. The key is a prefix of each per-key allow-list
+// key, so invalidating it takes those with it.
 function invalidateWorkspaceProviderKeys(
   queryClient: ReturnType<typeof useQueryClient>,
   workspaceId: string,

--- a/web/src/shared/api/workspaces.ts
+++ b/web/src/shared/api/workspaces.ts
@@ -361,12 +361,17 @@ export function useWorkspaceProviderKeyModels(
       staleTime: 60_000,
     })),
     combine: (results) => ({
-      // A key whose read has not answered maps to `undefined`, not to `[]`:
-      // an empty list is the answer "every model is allowed", so defaulting to
-      // one would report a narrowed workspace as open for as long as the read
-      // takes, and a refused read as open forever.
+      // Three states per key, not two. `models` is `undefined` rather than `[]`
+      // until the read answers, because an empty list is the answer "every model
+      // is allowed" and defaulting to one would report a narrowed workspace as
+      // open. `failed` is what separates a read still in flight from one that
+      // will never answer, so the caller can say which rather than showing a
+      // refusal as a wait that does not end.
       data: new Map(
-        results.map((result, index) => [keyIds[index], result.data]),
+        results.map((result, index) => [
+          keyIds[index],
+          { models: result.data, failed: result.error !== null },
+        ]),
       ),
       // The first failure rather than a swallowed one, as the fan-outs above do.
       error: results.find((result) => result.error)?.error ?? null,

--- a/web/src/shared/api/workspaces.ts
+++ b/web/src/shared/api/workspaces.ts
@@ -7,12 +7,14 @@ import {
 import type {
   CreateWorkspaceBudgetDefaultRequest,
   CreateWorkspaceRequest,
+  SetWorkspaceProviderKeyOverrideRequest,
   UpdateWorkspaceBudgetDefaultRequest,
   UpdateWorkspaceRequest,
   Workspace,
   WorkspaceBudgetDefault,
   WorkspaceMember,
   WorkspaceMemberRole,
+  WorkspaceProviderKeyOverride,
 } from "@/client"
 import { apiFetch } from "@/shared/api/client"
 import { fetchAllPaged } from "@/shared/api/paging"
@@ -305,6 +307,169 @@ export function useDeleteWorkspaceBudgetDefault() {
         queryKey: [WORKSPACES, workspaceId, "budget-defaults"],
       })
     },
+  })
+}
+
+/**
+ * One workspace's view of its organization's provider keys.
+ *
+ * Every non-archived organization key, each carrying this workspace's departure
+ * from it: `is_default`/`disabled` are the stored flags, `is_effective_*` the
+ * resolution once the provider's other keys are taken into account. The response
+ * names keys by id only, so the caller pairs it with `useOrgProviderKeys` for the
+ * provider and the name.
+ *
+ * Not paged: the route serves the whole set in one body, because it is bounded by
+ * the organization's key count rather than by anything a workspace accumulates.
+ */
+export function useWorkspaceProviderKeys(workspaceId: string | null) {
+  return useQuery({
+    queryKey: [WORKSPACES, workspaceId, "provider-keys"],
+    queryFn: async () =>
+      (
+        await apiFetch<{ data: WorkspaceProviderKeyOverride[] }>(
+          `/v1/workspaces/${encodeURIComponent(workspaceId as string)}/provider-keys`,
+        )
+      ).data,
+    enabled: workspaceId !== null,
+    staleTime: 60_000,
+  })
+}
+
+/**
+ * The model allow-list each of a workspace's keys carries, as one map.
+ *
+ * A fan-out for the reason the two above are: the allow-list is only served per
+ * key (`GET /v1/workspaces/{id}/provider-keys/{key}/models`), and an organization
+ * holds a handful of keys, so N small cached reads beat adding a route. An empty
+ * list is the common answer and a meaningful one: no rows means every model the
+ * key serves is allowed, not that none is.
+ */
+export function useWorkspaceProviderKeyModels(
+  workspaceId: string | null,
+  keyIds: string[],
+) {
+  return useQueries({
+    queries: (workspaceId === null ? [] : keyIds).map((keyId) => ({
+      queryKey: [WORKSPACES, workspaceId, "provider-keys", keyId, "models"],
+      queryFn: async () =>
+        (
+          await apiFetch<{ models: string[] }>(
+            `/v1/workspaces/${encodeURIComponent(workspaceId as string)}/provider-keys/${encodeURIComponent(keyId)}/models`,
+          )
+        ).models,
+      staleTime: 60_000,
+    })),
+    combine: (results) => ({
+      data: new Map(
+        results.map((result, index) => [keyIds[index], result.data ?? []]),
+      ),
+      isLoading: results.some((result) => result.isLoading),
+      // The first failure rather than a swallowed one, as the fan-outs above do:
+      // a refused read contributes an empty list, which is exactly what "every
+      // model is allowed" looks like, so silence here would report the opposite
+      // of a narrowing that is still in force.
+      error: results.find((result) => result.error)?.error ?? null,
+    }),
+  })
+}
+
+// Pinning a key clears whichever of the provider's other keys this workspace had
+// pinned, and disabling one deletes its model allow-list server-side, so every
+// write here re-reads the workspace's whole provider-key subtree rather than
+// patching the row it acted on.
+function invalidateWorkspaceProviderKeys(
+  queryClient: ReturnType<typeof useQueryClient>,
+  workspaceId: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: [WORKSPACES, workspaceId, "provider-keys"],
+  })
+}
+
+export function useSetWorkspaceProviderKeyOverride() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      keyId,
+      body,
+    }: {
+      workspaceId: string
+      keyId: string
+      body: SetWorkspaceProviderKeyOverrideRequest
+    }) =>
+      apiFetch<WorkspaceProviderKeyOverride>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/provider-keys/${encodeURIComponent(keyId)}`,
+        { method: "PATCH", body: JSON.stringify(body) },
+      ),
+    onSuccess: (_data, { workspaceId }) =>
+      invalidateWorkspaceProviderKeys(queryClient, workspaceId),
+  })
+}
+
+/** Drop the override entirely, so the workspace inherits the organization again. */
+export function useResetWorkspaceProviderKeyOverride() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      keyId,
+    }: {
+      workspaceId: string
+      keyId: string
+    }) =>
+      apiFetch<{ message: string }>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/provider-keys/${encodeURIComponent(keyId)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: (_data, { workspaceId }) =>
+      invalidateWorkspaceProviderKeys(queryClient, workspaceId),
+  })
+}
+
+export function useAddWorkspaceProviderKeyModel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      keyId,
+      model,
+    }: {
+      workspaceId: string
+      keyId: string
+      model: string
+    }) =>
+      apiFetch<{ message: string }>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/provider-keys/${encodeURIComponent(keyId)}/models`,
+        { method: "POST", body: JSON.stringify({ model }) },
+      ),
+    onSuccess: (_data, { workspaceId }) =>
+      invalidateWorkspaceProviderKeys(queryClient, workspaceId),
+  })
+}
+
+export function useRemoveWorkspaceProviderKeyModel() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      keyId,
+      model,
+    }: {
+      workspaceId: string
+      keyId: string
+      model: string
+    }) =>
+      apiFetch<{ message: string }>(
+        // The model id is the last path segment and the route declares it
+        // `:path`, so a provider that spells one with a slash still addresses
+        // its own row: the escape survives the match and the gateway unquotes it.
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/provider-keys/${encodeURIComponent(keyId)}/models/${encodeURIComponent(model)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: (_data, { workspaceId }) =>
+      invalidateWorkspaceProviderKeys(queryClient, workspaceId),
   })
 }
 

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -32,6 +32,7 @@ import type {
   WorkspaceCodeExecutionPolicy,
   WorkspaceMcpServer,
   WorkspaceMember,
+  WorkspaceProviderKeyOverride,
   WorkspaceWebSearchConfig,
 } from "@/client"
 
@@ -612,6 +613,23 @@ export function orgProviderKey(
     archived_at: null,
     created_at: "2026-08-24T00:00:00+00:00",
     updated_at: null,
+    ...overrides,
+  }
+}
+
+export function workspaceProviderKeyOverride(
+  overrides: Partial<WorkspaceProviderKeyOverride> = {},
+): WorkspaceProviderKeyOverride {
+  return {
+    workspace_id: "44444444-4444-4444-4444-444444444444",
+    org_provider_key_id: "66666666-6666-6666-6666-666666666666",
+    // Full inheritance, which is what a workspace with no override row looks
+    // like on the wire: neither flag set, and the key still resolving because
+    // it is the organization's.
+    is_default: false,
+    disabled: false,
+    is_effective_default: true,
+    is_effective_enabled: true,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

`/v1/workspaces/{workspace_id}/provider-keys` is mounted and nothing in the dashboard calls it. It serves one workspace's departures from its organization's provider keys: pin one as the workspace's default, opt out of one, or narrow it to named models.

That is not a dormant API. `services/tenancy/organization_model_access.py` loads both tables when it builds a session's catalog scope, so a narrowed workspace really does lose every model it does not name, and until now nobody could see the narrowing or lift it. mozilla-ai/otari-ai's cutover migrates both tables onto this gateway, so the state arrives populated.

This adds the section to the Workspaces page's edit form, beside the per-provider budget defaults that form already edits for one workspace. `OrganizationProviderKeysPage`'s own note says this half belongs "beside that workspace rather than here"; that comment now points at where it went instead of calling it absent.

Each key gets a three-way picker (Inherited, Workspace default, Disabled) plus its model allow-list. The three states are the two stored flags and their absence, since the gateway deletes a no-op override row rather than storing one, and only one flag is ever sent so the gateway resolves the other. A disabled key offers no allow-list, because the gateway refuses a write there and deletes the rows the key already had.

**Gating.** The role gate is the edit form's existing `canManage`. The gateway allows an organization owner/admin or an owner/admin of the workspace (`require_workspace_management_access`); this is the organization arm of that rule, narrowed in the safe direction because the key names come from `/v1/organizations/me/provider-keys`, which only an organization owner/admin may read. That matches the 11 Aug roles matrix, which has Provider keys at Hidden / Edit. No entitlement gate, since base otari has no capability name for this, and no operator gate, since these are the tenant's credentials rather than the deployment's. No new surface gate either: the page already sits behind `workspaces`, which both `STANDALONE_SURFACES` and `HOSTED_SURFACES` publish.

**Model picker.** The allow-list takes a typed model id rather than a picker over the catalog. The only listing a tenant may read is `/v1/models`, which is filtered through these very restrictions, so a picker built on it would stop offering the models the control exists to add back. `/v1/models/discoverable` is operator-gated and not available to an organization admin.

**Interaction with #980.** The setup guide derives "can a request succeed here" from `/v1/models`, which reads the same catalog scope, so a workspace narrowed to an empty catalog also loses the guide. This change does not alter that, and it is the first place the narrowing behind it becomes visible.

No route, schema or docstring changed, so no OpenAPI or Postman regeneration is owed; `web/src/client/schema.ts` regenerates identically and `routeTree.gen.ts` is untouched since no route was added. The Workspaces page already has a screenshot entry.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#2082

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard checks are the ones that matter here and all pass: `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `pnpm --dir web test` (3932 passing). `make lint` and `make typecheck` pass. `make test`'s integration half is left to CI: it needs PostgreSQL through Docker, which this machine does not run, and nothing under `src/gateway/` changed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code, at @khaledosman's request.

**Any additional AI details you'd like to share:**

Self-reviewed against the repository's own `review` skill before requesting reviewers. It found three things, fixed in the second commit: the per-key allow-list fan-out defaulted an unanswered read to an empty list, which is the wire answer for "every model is allowed", so a narrowed workspace read as open while the request was in flight and a refused read read as open permanently; the list guard was a bare `isPending` rather than `isPending && !data`; and the picker cast its string to the departure union instead of narrowing it the way `asMembershipRole` does. A regression test covers the first and was confirmed to fail without the fix.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds workspace-level provider-key controls to the Workspaces edit form.

- Set each provider key to inherited, workspace default, or disabled.
- Add optional model allow-lists for enabled keys.
- Hide allow-lists for disabled keys.
- Show read and write errors without applying stale or optimistic data.
- Add API hooks, fixtures, and regression tests for loading, refusals, and role-based access.

Dashboard lint, typecheck, and tests pass with 3,932 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->