### PR TITLE
feat(dashboard): rebuild the Web search page on an autosaving row grammar

### DIFF
--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -46,7 +46,7 @@ classifier and the meter that reads it).
 | Module | Exports you will reach for |
 | --- | --- |
 | `@heroui/react` | `Button`, `Select`, `Tooltip`, `Spinner`, and the rest of HeroUI v3 |
-| `layout/Section` · `/PageIntro` · `/SettingsGroup` · `/Toolbar` · `/TableScrollFrame` | one component each, named for its file |
+| `layout/Section` · `/PageIntro` · `/SettingsGroup` · `/SettingRow` · `/Toolbar` · `/TableScrollFrame` | one component each, named for its file |
 | `metrics/KpiStrip` · `/KpiCell` · `/Meter` | one each |
 | `metrics/SpendMeter` | `SpendMeter`, `spendState`, and the `SpendState` type |
 | `metrics/SeverityMark` | `SeverityMark`, and the `Severity` type |
@@ -65,7 +65,7 @@ classifier and the meter that reads it).
 | `data/TablePagination` | `TablePagination`, `PAGE_SIZE_OPTIONS` |
 | `data/BulkActionBar` | `BulkActionBar` |
 | `navigation/TabRow` | `TabRow`, `Tab` |
-| `navigation/Segmented` · `/FilterSelect` · `/FilterMultiComboBox` | one each |
+| `navigation/Segmented` · `/FilterSelect` · `/FilterMultiComboBox` · `/DisclosureRow` · `/DocsLink` | one each |
 | `navigation/FilterChips` | `FilterChips`, and the `FilterChip` type |
 | `indicators/Dot` · `/Badge` · `/DismissChip` | one each |
 | `access/EntitlementGate` · `/UnavailableHere` · `/MissingGatewayAddressNotice` | one each |
@@ -101,7 +101,7 @@ and [web/AGENTS.md](../AGENTS.md).
 | --- | --- |
 | [colors.md](colors.md) | Surfaces, text ramp, borders, the accent's five jobs, status, chart slots |
 | [typography.md](typography.md) | The 12 type roles, the ladder rule, the three families |
-| [layout.md](layout.md) | Bands, the bleed rule, `Section`, `PageIntro`, `SettingsGroup`, page recipes |
+| [layout.md](layout.md) | Bands, the bleed rule, `Section`, `PageIntro`, `SettingsGroup`, `SettingRow`, page recipes |
 | [actions.md](actions.md) | The three button variants, sizes, places, icon-only, the two-step confirm, and the other action shapes (`RowAction`, `RefreshButton`, `CopyButton`) |
 | [forms.md](forms.md) | `Field`, `SecretField`, `Toggle`, `Checkbox`, selects, validation timing |
 | [data.md](data.md) | `DataTable`, pagination, bulk actions |

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -85,6 +85,14 @@ Validate on submit and on blur. Never on the first keystroke: a message that
 appears while someone is halfway through typing their own key name is telling them
 they are wrong before they have finished being right.
 
+On an autosaving page (see [layout.md](layout.md)) blur is also the commit, so
+the two coincide: a text field validates and saves when it is left or when Enter
+is pressed, and only if the value changed. A select saves on change, having
+nothing typed to lose. Success is silent; a refused save keeps the value that
+caused it, marks the control `aria-invalid`, and puts the message in the row
+through `SettingRow`'s `error`. `useAutosave` owns that state, one instance per
+control, and its `isSaving` is what disables the control mid-write.
+
 ## Toggle
 
 `Toggle` is `role="switch"` with an `aria-label`. The visible track is 44x24 with a

--- a/web/design/layout.md
+++ b/web/design/layout.md
@@ -37,7 +37,8 @@ constants for these; `Section` is the one place the pair is named.
 | `Section` | `className`, `contentClassName`, `bleed = true`, children | Any band of a page |
 | `PageIntro` | `title`, `action?`, children | The opening of every page |
 | `Toolbar` | `className?`, children | Above a table or list |
-| `SettingsGroup` | `title?`, `description?`, `count?`, children | A form page |
+| `SettingsGroup` | `title?`, `description?`, `docsHref?`, `count?`, `bounded?`, children | A form page |
+| `SettingRow` | `label`, `configKey?`, `help?`, `control`, `nested?`, `error?` | One setting inside a group |
 | `KpiStrip` + `KpiCell` | see [metrics.md](metrics.md) | The metrics band |
 | `TableScrollFrame` | `className`, children | Around a wide table |
 
@@ -87,6 +88,26 @@ InfoBanner         only if there is a standing condition to state
 SettingsGroup      one per topic, each with its own Save at its own foot
 ```
 
+An autosaving settings page, which is the other shape:
+
+```
+PageIntro          title, sentence, a trailing docsHref
+SettingsGroup      bounded, one per topic
+  SettingRow       label + key left, control right
+  DisclosureRow    a list or an explanation that belongs to the row
+```
+
+No Save anywhere on that one: a text field commits on blur and on Enter, a
+select on change. Reach for it when the settings are independent of one another,
+so no single button could say what it is about to write.
+`features/tools/ToolsGuardrailsPage` is the worked example.
+
+**A save that worked says nothing.** The control disables while the write is in
+flight and that is the whole acknowledgement: a confirmation mark on every row
+is one the reader learns to ignore by the third row, and it has to be held out
+of flow to keep from moving the row it is congratulating. Only a refusal gets a
+line.
+
 `EmptyState`, `PageLoading` and a page-level `ErrorBanner` are bands like any other
 and need no bleed helper; they already run the width they should.
 
@@ -115,15 +136,25 @@ lines.
 </SettingsGroup>
 ```
 
-There is no shared `SettingsRow` component; a row is a flex div the feature writes,
-label left and control right in a shared lane. Copy the shape from a sibling group
-rather than inventing a width.
+**A row is a `SettingRow`.** Label and config key left, help under them, control
+right in a lane every row shares; below `md` the control stacks full width. The
+row draws no rule of its own, because the group divides its children. `nested`
+indents it to `pl-8`, which is how a row says it belongs to the one above it: a
+`DisclosureRow`'s panel is rows, not prose.
+
+`bounded` frames the rows inside the page column instead of bleeding them, and
+the frame is also the dense place (`.otari-settings`), so its controls come out
+32px on a desk and 36px at 16px on a phone. **No row picks a field height or a
+field font size.** Use it where a page stacks several small groups, which run
+together into one striped field as full-width bands. `docsHref` trails the
+description with a `DocsLink`.
 
 - Two border strengths and that is the whole hierarchy: `border-border-subtle`
   between rows (supplied), `border-border` around the group (supplied).
-- **One Save per group, at that group's foot**, as the group's last child. Never a
-  floating Save for the whole page: a page-level Save cannot say what it is about to
-  write.
+- **One Save per group, at that group's foot**, as the group's last child, on a
+  group that submits as a unit. Never a floating Save for the whole page: a
+  page-level Save cannot say what it is about to write. A group of independent
+  settings autosaves instead and has no Save at all.
 - `count` puts a muted number beside the title, for a group that lists things.
 
 ## Spacing

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -46,10 +46,19 @@ const WORKSPACE_ROUTES: ReadonlyArray<{
   { route: "/usage", name: "usage", heading: /usage/i },
   { route: "/activity", name: "activity", heading: /activity/i },
   { route: "/tools", name: "tools", heading: /tools/i },
-  // The one Tools child with an entry of its own. The other two render the
-  // page above filtered to one service, so its entry covers them; this one is a
-  // page in its own right, and nothing else captures its table. Captured at
-  // rest, so its two dialogs are covered by neither this nor the vitest suite.
+  // A narrowed Tools child is no longer the page above with two services
+  // hidden: it heads with the tool's own status row, and its group titles drop
+  // the service prefix the combined page needs. One of the two is enough for
+  // that difference, and web search is the one that also carries the search
+  // tools drill-in.
+  {
+    route: "/tools/web-search",
+    name: "tools-web-search",
+    heading: /web search/i,
+  },
+  // A page in its own right rather than a filtered view, and nothing else
+  // captures its table. Captured at rest, so its two dialogs are covered by
+  // neither this nor the vitest suite.
   {
     route: "/tools/mcp-servers",
     name: "tools-mcp-servers",

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -173,7 +173,6 @@ function PendingProof({ row }: { row: OrganizationDomain }) {
       <CopyField
         label={`TXT record for ${row.domain}`}
         value={row.verification_record}
-        inFieldCopy
         action={
           <Button
             variant="primary"

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -173,6 +173,7 @@ function PendingProof({ row }: { row: OrganizationDomain }) {
       <CopyField
         label={`TXT record for ${row.domain}`}
         value={row.verification_record}
+        inFieldCopy
         action={
           <Button
             variant="primary"

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -457,6 +457,7 @@ export function OrganizationGuardrailsCard({
 
   return (
     <SettingsGroup
+      bounded
       title="Organization guardrails"
       description="Guardrails that run on every request from the workspaces below, whether the caller asked for them or not. They compose with the deployment settings above rather than replacing them: an entry with no endpoint of its own is sent to the guardrails URL set there, and an organization that mandates nothing leaves every request checked exactly as it is today."
     >

--- a/web/src/features/tools/PolicyRow.test.tsx
+++ b/web/src/features/tools/PolicyRow.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { ceilingParser, parsePhrase } from "@/features/tools/PolicyRow"
+
+// The row itself is exercised through both policy cards, which drive it against
+// a real mutation. What is worth asserting here is the parsing, because it is
+// what decides whether a value reaches the server at all.
+
+describe("ceilingParser", () => {
+  const parse = ceilingParser(25, "rounds")
+
+  it("reads a whole number inside the bound", () => {
+    expect(parse("10")).toEqual({ value: 10, error: "" })
+  })
+
+  it("reads blank as no ceiling rather than as an error", () => {
+    expect(parse("  ")).toEqual({ value: null, error: "" })
+  })
+
+  it.each(["0x10", "1e1", "1.5", "-3", "ten", "10px"])(
+    "refuses %s rather than letting Number read it",
+    (raw) => {
+      // `Number` would take "0x10" as 16 and "1e1" as 10, so a value the
+      // operator never typed would reach the server.
+      expect(parse(raw).value).toBeNull()
+      expect(parse(raw).error).toContain("whole number of rounds")
+    },
+  )
+
+  it.each(["0", "26"])(
+    "refuses %s, which is outside the server's bound",
+    (raw) => {
+      expect(parse(raw).value).toBeNull()
+    },
+  )
+
+  it("names its own unit and bound, so two rows do not share a message", () => {
+    expect(ceilingParser(60, "seconds")("600").error).toBe(
+      "A whole number of seconds from 1 to 60.",
+    )
+  })
+})
+
+describe("parsePhrase", () => {
+  it("trims what it stores", () => {
+    expect(parsePhrase("  show your working  ")).toEqual({
+      value: "show your working",
+      error: "",
+    })
+  })
+
+  it("clears the stored phrase when the field is emptied", () => {
+    expect(parsePhrase("   ")).toEqual({ value: null, error: "" })
+  })
+})

--- a/web/src/features/tools/PolicyRow.tsx
+++ b/web/src/features/tools/PolicyRow.tsx
@@ -86,7 +86,7 @@ export function PolicyRow<T>({
             numeric
               ? "text-right tabular-nums md:w-[5.5rem]"
               : "md:w-[13.75rem]"
-          } ${INPUT_CLASS} ${message ? "border-danger" : ""}`}
+          } ${INPUT_CLASS}`}
         />
       }
     />

--- a/web/src/features/tools/PolicyRow.tsx
+++ b/web/src/features/tools/PolicyRow.tsx
@@ -1,0 +1,115 @@
+import { useId, useState } from "react"
+
+import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
+import { SettingRow } from "@/shared/components/layout/SettingRow"
+import { commitOnEnter, useAutosave } from "@/shared/hooks/useAutosave"
+
+/** What a typed value has to become before it can be sent, or why it cannot. */
+export type Parse<T> = (raw: string) => { value: T; error: string }
+
+/**
+ * One typed row of a workspace policy: it holds a draft and commits the whole
+ * policy when the field is left.
+ *
+ * Both policy groups are a stance select over a handful of these, and the
+ * shapes they need differ only in how the value is parsed and how wide the
+ * lane is. `ToolSettingRows` is the other row family and stays separate: those
+ * are keyed on a backend field descriptor and carry a config key, a
+ * reachability note and a Test button, none of which a policy row has.
+ */
+export function PolicyRow<T>({
+  label,
+  help,
+  placeholder,
+  committed,
+  parse,
+  commit,
+  disabled,
+  machine = false,
+  numeric = false,
+}: {
+  label: string
+  help: string
+  /** A representative value, never the word "default": blank already means that. */
+  placeholder: string
+  committed: string
+  parse: Parse<T>
+  commit: (value: T) => Promise<unknown>
+  disabled: boolean
+  /** Mono, for a value a machine reads. Off for a sentence a model reads. */
+  machine?: boolean
+  /** A short right-aligned lane, for a number rather than a list or a phrase. */
+  numeric?: boolean
+}) {
+  const [draft, setDraft] = useState(committed)
+  const [synced, setSynced] = useState(committed)
+  const save = useAutosave()
+  const errorId = useId()
+
+  // Re-hydrated from the server's answer rather than from an effect: the row is
+  // remounted by its key when the workspace changes, and a save is the only
+  // other thing that moves the stored value.
+  if (committed !== synced) {
+    setSynced(committed)
+    setDraft(committed)
+  }
+
+  const parsed = parse(draft)
+  const message = save.error || parsed.error
+
+  return (
+    <SettingRow
+      label={label}
+      help={help}
+      error={message}
+      errorId={errorId}
+      control={
+        <input
+          type="text"
+          inputMode={numeric ? "numeric" : undefined}
+          aria-label={label}
+          aria-invalid={message ? true : undefined}
+          aria-describedby={message ? errorId : undefined}
+          value={draft}
+          disabled={disabled || save.isSaving}
+          placeholder={placeholder}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={commitOnEnter}
+          onBlur={() => {
+            if (parsed.error || draft.trim() === committed) return
+            void save.run(() => commit(parsed.value))
+          }}
+          className={`w-full ${machine || numeric ? "field-machine" : ""} ${
+            numeric
+              ? "text-right tabular-nums md:w-[5.5rem]"
+              : "md:w-[13.75rem]"
+          } ${INPUT_CLASS} ${message ? "border-danger" : ""}`}
+        />
+      }
+    />
+  )
+}
+
+/** A whole number the server will accept, or the reason it will not. */
+export function ceilingParser(max: number, unit: string): Parse<number | null> {
+  return (raw) => {
+    const trimmed = raw.trim()
+    if (trimmed === "") return { value: null, error: "" }
+    // Digits only, so `0x10` and `1e1` are refused rather than silently read as
+    // 16 and 10 by `Number`.
+    const parsed = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN
+    if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > max) {
+      return {
+        value: null,
+        error: `A whole number of ${unit} from 1 to ${max}.`,
+      }
+    }
+    return { value: parsed, error: "" }
+  }
+}
+
+/** A phrase, or nothing. Blank clears the stored one. */
+export const parsePhrase: Parse<string | null> = (raw) => ({
+  value: raw.trim() === "" ? null : raw.trim(),
+  error: "",
+})

--- a/web/src/features/tools/PolicyRow.tsx
+++ b/web/src/features/tools/PolicyRow.tsx
@@ -45,6 +45,7 @@ export function PolicyRow<T>({
   const [synced, setSynced] = useState(committed)
   const save = useAutosave()
   const errorId = useId()
+  const controlId = useId()
 
   // Re-hydrated from the server's answer rather than from an effect: the row is
   // remounted by its key when the workspace changes, and a save is the only
@@ -60,11 +61,13 @@ export function PolicyRow<T>({
   return (
     <SettingRow
       label={label}
+      controlId={controlId}
       help={help}
       error={message}
       errorId={errorId}
       control={
         <input
+          id={controlId}
           type="text"
           inputMode={numeric ? "numeric" : undefined}
           aria-label={label}

--- a/web/src/features/tools/PolicyRow.tsx
+++ b/web/src/features/tools/PolicyRow.tsx
@@ -82,7 +82,7 @@ export function PolicyRow<T>({
             if (parsed.error || draft.trim() === committed) return
             void save.run(() => commit(parsed.value))
           }}
-          className={`w-full ${machine || numeric ? "field-machine" : ""} ${
+          className={`w-full ${machine || numeric ? "otari-machine-field" : ""} ${
             numeric
               ? "text-right tabular-nums md:w-[5.5rem]"
               : "md:w-[13.75rem]"

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -211,7 +211,7 @@ describe("SearchToolsCard", () => {
     const input = screen.getByLabelText("Backend URL for local")
     await user.clear(input)
     await user.type(input, "http://moved:8080")
-    await user.click(screen.getByRole("button", { name: "Save local" }))
+    await user.tab()
 
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(
@@ -240,9 +240,88 @@ describe("SearchToolsCard", () => {
     const input = screen.getByLabelText("Backend URL for local")
     await user.clear(input)
     await user.type(input, "http://moved:8080")
-    await user.click(screen.getByRole("button", { name: "Save local" }))
+    await user.tab()
 
     expect(await screen.findByText(/api_key is required/)).toBeInTheDocument()
+  })
+
+  it("saves the row on blur, with no Save button of its own", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    await renderOpened(user)
+    await screen.findByText("local")
+
+    expect(screen.queryByRole("button", { name: "Save local" })).toBeNull()
+
+    const input = screen.getByLabelText("Backend URL for local")
+    await user.clear(input)
+    await user.type(input, "http://moved:8080{Enter}")
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(
+          ([, init]) => (init?.method ?? "") === "PATCH",
+        ),
+      ).toBe(true),
+    )
+  })
+
+  it("leaves the stored key alone when the key field is left empty", async () => {
+    // Blank is not a value in that field, it is "keep what is stored", so a
+    // focus and a blur must not write anything at all.
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    await renderOpened(user)
+    await screen.findByText("local")
+
+    await user.click(screen.getByLabelText("New API key for local"))
+    await user.tab()
+
+    expect(
+      fetchMock.mock.calls.some(([, init]) => (init?.method ?? "") === "PATCH"),
+    ).toBe(false)
+  })
+
+  it("carries the fresh expected_updated_at into a second write on one row", async () => {
+    // Under a Save button this was one write per click. Under autosave, leaving
+    // the URL and then the key fires two, and the second would otherwise still
+    // carry the `updated_at` captured before the first, which optimistic
+    // concurrency refuses.
+    const bodies: Record<string, unknown>[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (url.includes("/v1/search-tools/providers")) {
+        return jsonResponse(PROVIDERS)
+      }
+      if (url.includes("/v1/search-tools") && method === "PATCH") {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+        bodies.push(body)
+        return jsonResponse({
+          ...TOOLS.stored[0],
+          ...body,
+          updated_at: `2026-08-14T00:00:0${bodies.length}+00:00`,
+        })
+      }
+      return jsonResponse(TOOLS)
+    })
+    const user = userEvent.setup()
+    await renderOpened(user)
+    await screen.findByText("local")
+
+    const url = screen.getByLabelText("Backend URL for local")
+    await user.clear(url)
+    await user.type(url, "http://moved:8080")
+    await user.tab()
+    await waitFor(() => expect(bodies).toHaveLength(1))
+
+    await user.type(screen.getByLabelText("New API key for local"), "sk-second")
+    await user.tab()
+
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies[0].expected_updated_at).toBe("2026-08-14T00:00:00+00:00")
+    expect(bodies[1].expected_updated_at).toBe("2026-08-14T00:00:01+00:00")
+    expect(bodies[1].api_key).toBe("sk-second")
   })
 
   it("removes a tool after the confirm step", async () => {

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -56,6 +56,14 @@ function renderWithClient(ui: ReactElement) {
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 
+// The list is a drill-in now, so every assertion about it opens the row first.
+async function renderOpened(user: ReturnType<typeof userEvent.setup>) {
+  renderWithClient(<SearchToolsCard docsHref="https://docs.example/tools" />)
+  await user.click(
+    await screen.findByRole("button", { name: /Configure search tools/ }),
+  )
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -105,14 +113,15 @@ describe("SearchToolsCard", () => {
 
   it("lists stored tools as editable and config-file tools as read-only", async () => {
     mockApi()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    const user = userEvent.setup()
+    await renderOpened(user)
 
     expect(await screen.findByText("local")).toBeInTheDocument()
     expect(screen.getByLabelText("Backend URL for local")).toHaveValue(
       "http://searxng:8080",
     )
     expect(screen.getByText("from-file")).toBeInTheDocument()
-    expect(screen.getByText("Config file")).toBeInTheDocument()
+    expect(screen.getByText(/config file/)).toBeInTheDocument()
     // A config-file tool has no editable box of its own.
     expect(
       screen.queryByLabelText("Backend URL for from-file"),
@@ -121,15 +130,16 @@ describe("SearchToolsCard", () => {
 
   it("says the endpoint refuses everything when nothing is configured", async () => {
     mockApi({ tools: { stored: [], config: [] } })
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    renderWithClient(<SearchToolsCard docsHref="https://docs.example/tools" />)
 
     expect(await screen.findByText(/refuses every request/)).toBeInTheDocument()
+    expect(await screen.findByText("0 tools")).toBeInTheDocument()
   })
 
   it("adds a tool with the chosen provider", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    await renderOpened(user)
     await screen.findByText("local")
 
     await user.type(screen.getByLabelText("Search tool name"), "second")
@@ -157,7 +167,7 @@ describe("SearchToolsCard", () => {
   it("will not submit an exa tool without the key exa requires", async () => {
     mockApi()
     const user = userEvent.setup()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    await renderOpened(user)
     await screen.findByText("local")
 
     await user.type(screen.getByLabelText("Search tool name"), "keyless-exa")
@@ -170,7 +180,7 @@ describe("SearchToolsCard", () => {
   it("omits api_key from a save that only changes the backend URL", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    await renderOpened(user)
     await screen.findByText("local")
 
     const input = screen.getByLabelText("Backend URL for local")
@@ -199,7 +209,7 @@ describe("SearchToolsCard", () => {
       writeDetail: "search_tools.local.api_key is required for provider 'exa'.",
     })
     const user = userEvent.setup()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    await renderOpened(user)
     await screen.findByText("local")
 
     const input = screen.getByLabelText("Backend URL for local")
@@ -213,12 +223,12 @@ describe("SearchToolsCard", () => {
   it("removes a tool after the confirm step", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
-    renderWithClient(<SearchToolsCard onSaved={() => {}} />)
+    await renderOpened(user)
     await screen.findByText("local")
 
     // The two steps read differently now: the trigger names the object and the
     // armed confirm names the consequence, which is what the second click does.
-    await user.click(screen.getByRole("button", { name: "Remove tool" }))
+    await user.click(screen.getByRole("button", { name: "Remove" }))
     await user.click(screen.getByRole("button", { name: "Remove permanently" }))
 
     await waitFor(() => {

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -136,6 +136,31 @@ describe("SearchToolsCard", () => {
     expect(await screen.findByText("0 tools")).toBeInTheDocument()
   })
 
+  it("does not read a failed request as an empty deployment", async () => {
+    // `isLoading` goes false with no data behind it, so the fallback would
+    // otherwise claim no tools are configured and that POST /v1/search refuses
+    // every request, on a read that never answered.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes("/v1/search-tools/providers")) {
+        return jsonResponse(PROVIDERS)
+      }
+      if (url.includes("/v1/search-tools")) {
+        return jsonResponse({ detail: "boom" }, 500)
+      }
+      return jsonResponse([])
+    })
+    renderWithClient(<SearchToolsCard docsHref="https://docs.example/tools" />)
+
+    expect(
+      await screen.findByText(
+        "Could not read the tools this deployment serves.",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/refuses every request/)).toBeNull()
+    expect(screen.queryByText("0 tools")).toBeNull()
+  })
+
   it("adds a tool with the chosen provider", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -17,7 +17,6 @@ import { ConfirmButton } from "@/shared/components/actions/ConfirmButton"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { errorMessage } from "@/shared/components/feedback/errorMessage"
 import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
-import { Dot } from "@/shared/components/indicators/Dot"
 import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
 import { DisclosureRow } from "@/shared/components/navigation/DisclosureRow"
 import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
@@ -34,7 +33,7 @@ import { useAutosave } from "@/shared/hooks/useAutosave"
 
 /** The lanes every line in the panel shares, so the columns read down. */
 const NAME_LANE = "w-full shrink-0 font-mono text-xs md:w-[7.5rem]"
-const PROVIDER_LANE = "w-full shrink-0 text-xs text-subtle md:w-[5.5rem]"
+const PROVIDER_LANE = "w-full shrink-0 text-caption text-subtle md:w-[5.5rem]"
 
 // The endpoint a tool with no api_base of its own will actually call, so a blank
 // box reads as "inherits X" rather than as "unconfigured".
@@ -118,7 +117,7 @@ function StoredToolLine({
           isDisabled={busy || !changed}
           onPress={commit}
         >
-          Save
+          {update.isPending ? "Saving…" : "Save"}
         </Button>
         <ConfirmButton
           confirmLabel="Remove permanently"
@@ -129,17 +128,17 @@ function StoredToolLine({
         </ConfirmButton>
       </div>
       {tool.decryptable ? null : (
-        <p className="text-xs text-warning">
+        <p className="text-caption text-warning">
           Key unreadable: check OTARI_SECRET_KEY
         </p>
       )}
       {tool.shadows_config ? (
-        <p className="text-xs text-warning">
+        <p className="text-caption text-warning">
           Overrides the config-file tool of this name
         </p>
       ) : null}
       {save.error ? (
-        <p role="alert" className="break-words text-xs text-danger">
+        <p role="alert" className="break-words text-caption text-danger">
           {save.error}
         </p>
       ) : null}
@@ -154,16 +153,15 @@ function ConfigToolLine({ tool }: { tool: ConfigSearchTool }) {
     <div className="flex flex-col gap-2 px-4 py-3 md:flex-row md:flex-wrap md:items-center">
       <code className={NAME_LANE}>{tool.name}</code>
       <span className={PROVIDER_LANE}>{tool.provider}</span>
-      <span className="min-w-0 flex-1 text-xs text-subtle">
+      <span className="min-w-0 flex-1 text-caption text-subtle">
         {tool.api_base ?? "no api_base declared"} · config file, editable where
         it is defined
       </span>
-      <span className="flex shrink-0 items-center gap-2.5 text-mono-overline text-subtle">
-        <Dot className="bg-text-subtle" />
+      <span className="shrink-0 text-mono-overline text-subtle">
         {tool.has_api_key ? "Key set" : "No key"}
       </span>
       {tool.shadowed ? (
-        <p className="text-xs text-warning">
+        <p className="text-caption text-warning">
           Overridden by the stored tool of this name
         </p>
       ) : null}
@@ -271,12 +269,12 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
           {create.isPending ? "Adding…" : "Add"}
         </Button>
       </div>
-      <p className="text-xs text-subtle">
+      <p className="text-caption text-subtle">
         Storing an API key needs{" "}
         <code className="font-mono">OTARI_SECRET_KEY</code> set on the gateway.
       </p>
       {error ? (
-        <p role="alert" className="break-words text-xs text-danger">
+        <p role="alert" className="break-words text-caption text-danger">
           {error}
         </p>
       ) : null}
@@ -301,6 +299,9 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
   const stored = tools.data?.stored ?? []
   const fromConfig = tools.data?.config ?? []
   const count = stored.length + fromConfig.length
+  // Nothing is known until the read answers, and "0 tools · refuses every
+  // request" is a claim, not a placeholder.
+  const answered = !tools.isLoading
 
   return (
     <SettingsGroup
@@ -312,15 +313,17 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
       <DisclosureRow
         label="Configure search tools"
         help={
-          count === 0
-            ? "None configured, so POST /v1/search refuses every request."
-            : "Callers name one in search_tool_name, or in the /v1/search/{tool} path."
+          !answered
+            ? "Reading the tools this deployment serves."
+            : count === 0
+              ? "None configured, so POST /v1/search refuses every request."
+              : "Callers name one in search_tool_name, or in the /v1/search/{tool} path."
         }
         isOpen={isOpen}
         onToggle={() => setIsOpen((open) => !open)}
         trailing={
           <span className="text-caption text-subtle tabular-nums">
-            {toolCount(count)}
+            {answered ? toolCount(count) : ""}
           </span>
         }
       >

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@heroui/react"
 import { useEffect, useState } from "react"
+
 import type {
   ConfigSearchTool,
   SearchProviderInfo,
@@ -16,15 +17,24 @@ import { ConfirmButton } from "@/shared/components/actions/ConfirmButton"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { errorMessage } from "@/shared/components/feedback/errorMessage"
 import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
-import { Badge } from "@/shared/components/indicators/Badge"
+import { Dot } from "@/shared/components/indicators/Dot"
 import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
+import { DisclosureRow } from "@/shared/components/navigation/DisclosureRow"
 import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
+import { useAutosave } from "@/shared/hooks/useAutosave"
 
 // Search tools are what POST /v1/search dispatches against. They used to be
 // declarable only in a config file, so a deployment configured entirely through
-// the dashboard could not use that endpoint at all. This card is the route in:
+// the dashboard could not use that endpoint at all. This is the route in:
 // stored tools are editable here, config-file tools are shown read-only so the
 // operator can see every tool a caller could name.
+//
+// A drill-in rather than a fifth group of rows, because it is a list of things
+// rather than a set of settings, and it is empty on most deployments.
+
+/** The lanes every line in the panel shares, so the columns read down. */
+const NAME_LANE = "w-full shrink-0 font-mono text-xs md:w-[7.5rem]"
+const PROVIDER_LANE = "w-full shrink-0 text-xs text-subtle md:w-[5.5rem]"
 
 // The endpoint a tool with no api_base of its own will actually call, so a blank
 // box reads as "inherits X" rather than as "unconfigured".
@@ -37,35 +47,35 @@ function inheritedBase(
   )
 }
 
-function StoredToolRow({
+function toolCount(count: number): string {
+  return `${count} ${count === 1 ? "tool" : "tools"}`
+}
+
+function StoredToolLine({
   tool,
   providers,
-  onSaved,
 }: {
   tool: StoredSearchTool
   providers: SearchProviderInfo[]
-  onSaved: (message: string) => void
 }) {
   const update = useUpdateSearchTool()
   const remove = useDeleteSearchTool()
+  const save = useAutosave()
   const [apiBase, setApiBase] = useState(tool.api_base ?? "")
   // Blank means "keep the stored key". The field is write-only, so it never
-  // shows what is stored, only the last four of it in the badge above.
+  // shows what is stored, only the last four of it beside the row.
   const [apiKey, setApiKey] = useState("")
-  const [error, setError] = useState("")
-
-  useEffect(() => {
-    setApiBase(tool.api_base ?? "")
-  }, [tool.api_base])
+  // Re-synced from the server's answer, so a change made elsewhere lands in the
+  // box rather than leaving a stale draft over it.
+  useEffect(() => setApiBase(tool.api_base ?? ""), [tool.api_base])
 
   const inherited = inheritedBase(providers, tool.provider)
   const changed = apiBase.trim() !== (tool.api_base ?? "") || apiKey !== ""
   const busy = update.isPending || remove.isPending
 
-  const save = () => {
-    setError("")
-    update.mutate(
-      {
+  const commit = () =>
+    void save.run(async () => {
+      await update.mutateAsync({
         name: tool.name,
         body: {
           api_base: apiBase.trim() === "" ? null : apiBase.trim(),
@@ -73,33 +83,15 @@ function StoredToolRow({
           ...(apiKey === "" ? {} : { api_key: apiKey }),
           expected_updated_at: tool.updated_at,
         },
-      },
-      {
-        onSuccess: () => {
-          setApiKey("")
-          onSaved(`${tool.name} saved`)
-        },
-        onError: (err) => setError(errorMessage(err)),
-      },
-    )
-  }
+      })
+      setApiKey("")
+    })
 
   return (
-    <div className="flex flex-col gap-2 py-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <code className="font-mono text-body">{tool.name}</code>
-        <Badge tone="muted">{tool.provider}</Badge>
-        {tool.last4 ? (
-          <Badge tone="muted">{`key ····${tool.last4}`}</Badge>
-        ) : null}
-        {tool.decryptable ? null : (
-          <Badge tone="warn">Key unreadable: check OTARI_SECRET_KEY</Badge>
-        )}
-        {tool.shadows_config ? (
-          <Badge tone="warn">Overrides the config-file tool of this name</Badge>
-        ) : null}
-      </div>
-      <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
+        <code className={NAME_LANE}>{tool.name}</code>
+        <span className={PROVIDER_LANE}>{tool.provider}</span>
         <input
           type="text"
           inputMode="url"
@@ -108,7 +100,7 @@ function StoredToolRow({
           disabled={busy}
           placeholder={inherited ? `inherits ${inherited}` : "backend URL"}
           onChange={(event) => setApiBase(event.target.value)}
-          className={`w-full sm:w-72 ${INPUT_CLASS}`}
+          className={`field-machine w-full md:w-[15rem] ${INPUT_CLASS}`}
         />
         <input
           type="password"
@@ -116,65 +108,70 @@ function StoredToolRow({
           aria-label={`New API key for ${tool.name}`}
           value={apiKey}
           disabled={busy}
-          placeholder={tool.last4 ? "replace key" : "add key (optional)"}
+          placeholder={tool.last4 ? `replace key ····${tool.last4}` : "add key"}
           onChange={(event) => setApiKey(event.target.value)}
-          className={`w-full sm:w-52 ${INPUT_CLASS}`}
+          className={`field-machine w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
         <Button
           size="sm"
-          variant="primary"
           aria-label={`Save ${tool.name}`}
           isDisabled={busy || !changed}
-          onPress={save}
+          onPress={commit}
         >
-          {update.isPending ? "Saving…" : "Save"}
+          Save
         </Button>
         <ConfirmButton
           confirmLabel="Remove permanently"
           isPending={busy}
-          onConfirm={() => {
-            setError("")
-            remove.mutate(tool.name, {
-              onSuccess: () => onSaved(`${tool.name} removed`),
-              onError: (err) => setError(errorMessage(err)),
-            })
-          }}
+          onConfirm={() => void save.run(() => remove.mutateAsync(tool.name))}
         >
-          Remove tool
+          Remove
         </ConfirmButton>
       </div>
-      {error ? (
-        <span className="break-words text-caption text-danger">{error}</span>
+      {tool.decryptable ? null : (
+        <p className="text-xs text-warning">
+          Key unreadable: check OTARI_SECRET_KEY
+        </p>
+      )}
+      {tool.shadows_config ? (
+        <p className="text-xs text-warning">
+          Overrides the config-file tool of this name
+        </p>
+      ) : null}
+      {save.error ? (
+        <p role="alert" className="break-words text-xs text-danger">
+          {save.error}
+        </p>
       ) : null}
     </div>
   )
 }
 
-function ConfigToolRow({ tool }: { tool: ConfigSearchTool }) {
+// A config-file tool is a fact, not a control: it is editable only where the
+// file is defined, so it reads as a line of values.
+function ConfigToolLine({ tool }: { tool: ConfigSearchTool }) {
   return (
-    <div className="flex flex-wrap items-center gap-2 py-4">
-      <code className="font-mono text-body">{tool.name}</code>
-      <Badge tone="muted">{tool.provider}</Badge>
-      <Badge tone="muted">Config file</Badge>
-      {tool.has_api_key ? <Badge tone="muted">key set</Badge> : null}
-      {tool.shadowed ? (
-        <Badge tone="warn">Overridden by the stored tool of this name</Badge>
-      ) : null}
-      <span className="text-caption">
-        {tool.api_base ?? "no api_base declared"} · editable only where the
-        config file is defined
+    <div className="flex flex-col gap-2 px-4 py-3 md:flex-row md:flex-wrap md:items-center">
+      <code className={NAME_LANE}>{tool.name}</code>
+      <span className={PROVIDER_LANE}>{tool.provider}</span>
+      <span className="min-w-0 flex-1 text-xs text-subtle">
+        {tool.api_base ?? "no api_base declared"} · config file, editable where
+        it is defined
       </span>
+      <span className="flex shrink-0 items-center gap-2.5 text-mono-overline text-subtle">
+        <Dot className="bg-text-subtle" />
+        {tool.has_api_key ? "Key set" : "No key"}
+      </span>
+      {tool.shadowed ? (
+        <p className="text-xs text-warning">
+          Overridden by the stored tool of this name
+        </p>
+      ) : null}
     </div>
   )
 }
 
-function AddToolForm({
-  providers,
-  onSaved,
-}: {
-  providers: SearchProviderInfo[]
-  onSaved: (message: string) => void
-}) {
+function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
   const create = useCreateSearchTool()
   const [name, setName] = useState("")
   const [provider, setProvider] = useState(providers[0]?.id ?? "")
@@ -197,10 +194,9 @@ function AddToolForm({
 
   const submit = () => {
     setError("")
-    const created = name.trim()
     create.mutate(
       {
-        name: created,
+        name: name.trim(),
         provider,
         api_base: apiBase.trim() === "" ? null : apiBase.trim(),
         api_key: apiKey === "" ? null : apiKey,
@@ -210,25 +206,23 @@ function AddToolForm({
           setName("")
           setApiBase("")
           setApiKey("")
-          onSaved(`${created} added`)
         },
-        onError: (err) => setError(errorMessage(err)),
+        onError: (cause) => setError(errorMessage(cause)),
       },
     )
   }
 
   return (
-    <div className="flex flex-col gap-2 py-4">
-      <span className="text-body">Add a search tool</span>
-      <div className="flex flex-wrap items-end gap-2">
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
         <input
           type="text"
           aria-label="Search tool name"
           value={name}
-          placeholder="name, e.g. local"
+          placeholder="local"
           disabled={create.isPending}
           onChange={(event) => setName(event.target.value)}
-          className={`w-full sm:w-44 ${INPUT_CLASS}`}
+          className={`field-machine w-full md:w-[7.5rem] ${INPUT_CLASS}`}
         />
         <FilterSelect
           ariaLabel="Search provider"
@@ -254,7 +248,7 @@ function AddToolForm({
                 : "backend URL"
           }
           onChange={(event) => setApiBase(event.target.value)}
-          className={`w-full sm:w-72 ${INPUT_CLASS}`}
+          className={`field-machine w-full md:w-[15rem] ${INPUT_CLASS}`}
         />
         <input
           type="password"
@@ -266,7 +260,7 @@ function AddToolForm({
             keyRequired ? "API key (required)" : "API key (optional)"
           }
           onChange={(event) => setApiKey(event.target.value)}
-          className={`w-full sm:w-52 ${INPUT_CLASS}`}
+          className={`field-machine w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
         <Button
           size="sm"
@@ -277,65 +271,70 @@ function AddToolForm({
           {create.isPending ? "Adding…" : "Add"}
         </Button>
       </div>
-      <span className="text-caption">
-        Callers name the tool in{" "}
-        <code className="font-mono">search_tool_name</code>, or in the{" "}
-        <code className="font-mono">POST /v1/search/{"{tool}"}</code> path.
+      <p className="text-xs text-subtle">
         Storing an API key needs{" "}
         <code className="font-mono">OTARI_SECRET_KEY</code> set on the gateway.
-      </span>
+      </p>
       {error ? (
-        <span className="break-words text-caption text-danger">{error}</span>
+        <p role="alert" className="break-words text-xs text-danger">
+          {error}
+        </p>
       ) : null}
     </div>
   )
 }
 
-export function SearchToolsCard({
-  onSaved,
-}: {
-  onSaved: (message: string) => void
-}) {
+/**
+ * The named tools behind `POST /v1/search`, as a row that drills in.
+ *
+ * A searxng tool that declares no backend URL of its own inherits the
+ * deployment's web-search URL, which is why this sits directly under the
+ * backend settings: one entry here exposes the same backend on the direct
+ * endpoint.
+ */
+export function SearchToolsCard({ docsHref }: { docsHref: string }) {
   const tools = useSearchTools()
   const providers = useSearchProviders()
+  const [isOpen, setIsOpen] = useState(false)
+
   const known = providers.data ?? []
   const stored = tools.data?.stored ?? []
   const fromConfig = tools.data?.config ?? []
+  const count = stored.length + fromConfig.length
 
   return (
     <SettingsGroup
+      bounded
       title="Search tools"
-      description={
-        <>
-          The tools <code className="font-mono">POST /v1/search</code>{" "}
-          dispatches against. A searxng tool that declares no backend URL uses
-          the web-search URL above, so one entry here exposes the same backend
-          on the direct endpoint.
-          <ErrorBanner error={tools.error ?? providers.error} />
-        </>
-      }
+      description="Named tools behind the direct endpoint, POST /v1/search. A searxng tool with no URL of its own reuses the backend above."
+      docsHref={docsHref}
     >
-      {stored.map((tool) => (
-        <StoredToolRow
-          key={tool.name}
-          tool={tool}
-          providers={known}
-          onSaved={onSaved}
-        />
-      ))}
-      {fromConfig.map((tool) => (
-        <ConfigToolRow key={tool.name} tool={tool} />
-      ))}
-      {stored.length === 0 && fromConfig.length === 0 && !tools.isLoading ? (
-        <p className="py-4 text-sm text-muted">
-          No search tools configured, so{" "}
-          <code className="font-mono">POST /v1/search</code> refuses every
-          request.
-        </p>
-      ) : null}
-      {known.length > 0 ? (
-        <AddToolForm providers={known} onSaved={onSaved} />
-      ) : null}
+      <DisclosureRow
+        label="Configure search tools"
+        help={
+          count === 0
+            ? "None configured, so POST /v1/search refuses every request."
+            : "Callers name one in search_tool_name, or in the /v1/search/{tool} path."
+        }
+        isOpen={isOpen}
+        onToggle={() => setIsOpen((open) => !open)}
+        trailing={
+          <span className="text-caption text-subtle tabular-nums">
+            {toolCount(count)}
+          </span>
+        }
+      >
+        <div className="flex flex-col divide-y divide-border-subtle">
+          <ErrorBanner error={tools.error ?? providers.error} />
+          {stored.map((tool) => (
+            <StoredToolLine key={tool.name} tool={tool} providers={known} />
+          ))}
+          {fromConfig.map((tool) => (
+            <ConfigToolLine key={tool.name} tool={tool} />
+          ))}
+          {known.length > 0 ? <AddToolForm providers={known} /> : null}
+        </div>
+      </DisclosureRow>
     </SettingsGroup>
   )
 }

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -300,8 +300,10 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
   const fromConfig = tools.data?.config ?? []
   const count = stored.length + fromConfig.length
   // Nothing is known until the read answers, and "0 tools · refuses every
-  // request" is a claim, not a placeholder.
-  const answered = !tools.isLoading
+  // request" is a claim, not a placeholder. A failed read is not an empty
+  // deployment either: `isLoading` goes false with no data behind it.
+  const failed = Boolean(tools.error)
+  const answered = !tools.isLoading && !failed
 
   return (
     <SettingsGroup
@@ -313,11 +315,13 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
       <DisclosureRow
         label="Configure search tools"
         help={
-          !answered
-            ? "Reading the tools this deployment serves."
-            : count === 0
-              ? "None configured, so POST /v1/search refuses every request."
-              : "Callers name one in search_tool_name, or in the /v1/search/{tool} path."
+          failed
+            ? "Could not read the tools this deployment serves."
+            : !answered
+              ? "Reading the tools this deployment serves."
+              : count === 0
+                ? "None configured, so POST /v1/search refuses every request."
+                : "Callers name one in search_tool_name, or in the /v1/search/{tool} path."
         }
         isOpen={isOpen}
         onToggle={() => setIsOpen((open) => !open)}

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -122,7 +122,7 @@ function StoredToolLine({
               write({ api_base: next === "" ? null : next }),
             )
           }}
-          className={`field-machine w-full md:w-[15rem] ${INPUT_CLASS}`}
+          className={`otari-machine-field w-full md:w-[15rem] ${INPUT_CLASS}`}
         />
         <input
           type="password"
@@ -143,7 +143,7 @@ function StoredToolLine({
               setApiKey("")
             })
           }}
-          className={`field-machine w-full md:w-[10rem] ${INPUT_CLASS}`}
+          className={`otari-machine-field w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
         <ConfirmButton
           confirmLabel="Remove permanently"
@@ -248,7 +248,7 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
           placeholder="local"
           disabled={create.isPending}
           onChange={(event) => setName(event.target.value)}
-          className={`field-machine w-full md:w-[7.5rem] ${INPUT_CLASS}`}
+          className={`otari-machine-field w-full md:w-[7.5rem] ${INPUT_CLASS}`}
         />
         <FilterSelect
           ariaLabel="Search provider"
@@ -274,7 +274,7 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
                 : "backend URL"
           }
           onChange={(event) => setApiBase(event.target.value)}
-          className={`field-machine w-full md:w-[15rem] ${INPUT_CLASS}`}
+          className={`otari-machine-field w-full md:w-[15rem] ${INPUT_CLASS}`}
         />
         <input
           type="password"
@@ -286,7 +286,7 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
             keyRequired ? "API key (required)" : "API key (optional)"
           }
           onChange={(event) => setApiKey(event.target.value)}
-          className={`field-machine w-full md:w-[10rem] ${INPUT_CLASS}`}
+          className={`otari-machine-field w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
         <Button
           size="sm"
@@ -340,6 +340,13 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
       description="Named tools behind the direct endpoint, POST /v1/search. A searxng tool with no URL of its own reuses the backend above."
       docsHref={docsHref}
     >
+      {tools.error || providers.error ? (
+        // Outside the disclosure: a read that failed is the thing the operator
+        // most needs to see, and the row is collapsed by default.
+        <div className="px-4 py-3">
+          <ErrorBanner error={tools.error ?? providers.error} />
+        </div>
+      ) : null}
       <DisclosureRow
         label="Configure search tools"
         help={
@@ -360,7 +367,6 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
         }
       >
         <div className="flex flex-col divide-y divide-border-subtle">
-          <ErrorBanner error={tools.error ?? providers.error} />
           {stored.map((tool) => (
             <StoredToolLine key={tool.name} tool={tool} providers={known} />
           ))}

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@heroui/react"
-import { useEffect, useState } from "react"
-
+import { useState } from "react"
 import type {
   ConfigSearchTool,
   SearchProviderInfo,
   StoredSearchTool,
+  UpdateSearchToolRequest,
 } from "@/client"
+import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
 import {
   useCreateSearchTool,
   useDeleteSearchTool,
@@ -20,7 +21,7 @@ import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
 import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
 import { DisclosureRow } from "@/shared/components/navigation/DisclosureRow"
 import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
-import { useAutosave } from "@/shared/hooks/useAutosave"
+import { commitOnEnter, useAutosave } from "@/shared/hooks/useAutosave"
 
 // Search tools are what POST /v1/search dispatches against. They used to be
 // declarable only in a config file, so a deployment configured entirely through
@@ -59,32 +60,45 @@ function StoredToolLine({
 }) {
   const update = useUpdateSearchTool()
   const remove = useDeleteSearchTool()
-  const save = useAutosave()
+  const urlSave = useAutosave()
+  const keySave = useAutosave()
+  const removal = useAutosave()
   const [apiBase, setApiBase] = useState(tool.api_base ?? "")
+  const [syncedBase, setSyncedBase] = useState(tool.api_base ?? "")
   // Blank means "keep the stored key". The field is write-only, so it never
-  // shows what is stored, only the last four of it beside the row.
+  // shows what is stored, only the last four of it in its own placeholder.
   const [apiKey, setApiKey] = useState("")
-  // Re-synced from the server's answer, so a change made elsewhere lands in the
-  // box rather than leaving a stale draft over it.
-  useEffect(() => setApiBase(tool.api_base ?? ""), [tool.api_base])
+
+  const committedBase = tool.api_base ?? ""
+  // Re-synced from the server's answer, in render rather than an effect, which
+  // is the idiom the other autosaving rows use. After one of this row's own
+  // writes the two already agree, so it moves nothing.
+  if (committedBase !== syncedBase) {
+    setSyncedBase(committedBase)
+    setApiBase(committedBase)
+  }
+
+  // The row is one stored tool, and every write carries `expected_updated_at`.
+  // Under a Save button that was one write per click; under autosave, leaving
+  // the URL and then the key fires two, and the second would still carry the
+  // `updated_at` from before the first. The writer takes the fresh one from the
+  // previous write's own response, which is the same job it does for the
+  // workspace policies.
+  const write = usePolicyWriter({
+    server: tool,
+    resetKey: tool.name,
+    // `api_key` is deliberately absent: omitted means "keep the stored key",
+    // so only the commit that changes it puts it on the wire.
+    toBody: (stored: StoredSearchTool): UpdateSearchToolRequest => ({
+      api_base: stored.api_base,
+      expected_updated_at: stored.updated_at,
+    }),
+    put: (body: UpdateSearchToolRequest) =>
+      update.mutateAsync({ name: tool.name, body }),
+  })
 
   const inherited = inheritedBase(providers, tool.provider)
-  const changed = apiBase.trim() !== (tool.api_base ?? "") || apiKey !== ""
-  const busy = update.isPending || remove.isPending
-
-  const commit = () =>
-    void save.run(async () => {
-      await update.mutateAsync({
-        name: tool.name,
-        body: {
-          api_base: apiBase.trim() === "" ? null : apiBase.trim(),
-          // Omitted entirely when blank, so saving a URL never clears the key.
-          ...(apiKey === "" ? {} : { api_key: apiKey }),
-          expected_updated_at: tool.updated_at,
-        },
-      })
-      setApiKey("")
-    })
+  const busy = remove.isPending
 
   return (
     <div className="flex flex-col gap-2 px-4 py-3">
@@ -95,34 +109,48 @@ function StoredToolLine({
           type="text"
           inputMode="url"
           aria-label={`Backend URL for ${tool.name}`}
+          aria-invalid={urlSave.error ? true : undefined}
           value={apiBase}
-          disabled={busy}
+          disabled={busy || urlSave.isSaving}
           placeholder={inherited ? `inherits ${inherited}` : "backend URL"}
           onChange={(event) => setApiBase(event.target.value)}
+          onKeyDown={commitOnEnter}
+          onBlur={() => {
+            const next = apiBase.trim()
+            if (next === committedBase) return
+            void urlSave.run(() =>
+              write({ api_base: next === "" ? null : next }),
+            )
+          }}
           className={`field-machine w-full md:w-[15rem] ${INPUT_CLASS}`}
         />
         <input
           type="password"
           autoComplete="new-password"
           aria-label={`New API key for ${tool.name}`}
+          aria-invalid={keySave.error ? true : undefined}
           value={apiKey}
-          disabled={busy}
+          disabled={busy || keySave.isSaving}
           placeholder={tool.last4 ? `replace key ····${tool.last4}` : "add key"}
           onChange={(event) => setApiKey(event.target.value)}
+          onKeyDown={commitOnEnter}
+          // Blank is not a value here, it is "leave the stored key alone", so
+          // an empty blur writes nothing and a focus-and-leave costs nothing.
+          onBlur={() => {
+            if (apiKey === "") return
+            void keySave.run(async () => {
+              await write({ api_key: apiKey })
+              setApiKey("")
+            })
+          }}
           className={`field-machine w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
-        <Button
-          size="sm"
-          aria-label={`Save ${tool.name}`}
-          isDisabled={busy || !changed}
-          onPress={commit}
-        >
-          {update.isPending ? "Saving…" : "Save"}
-        </Button>
         <ConfirmButton
           confirmLabel="Remove permanently"
           isPending={busy}
-          onConfirm={() => void save.run(() => remove.mutateAsync(tool.name))}
+          onConfirm={() =>
+            void removal.run(() => remove.mutateAsync(tool.name))
+          }
         >
           Remove
         </ConfirmButton>
@@ -137,9 +165,9 @@ function StoredToolLine({
           Overrides the config-file tool of this name
         </p>
       ) : null}
-      {save.error ? (
+      {urlSave.error || keySave.error || removal.error ? (
         <p role="alert" className="break-words text-caption text-danger">
-          {save.error}
+          {urlSave.error || keySave.error || removal.error}
         </p>
       ) : null}
     </div>

--- a/web/src/features/tools/ToolSettingRows.tsx
+++ b/web/src/features/tools/ToolSettingRows.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import { useEffect, useId, useState } from "react"
+import { useId, useState } from "react"
 
 import type { ToolSettingField } from "@/client"
 import { useTestService } from "@/shared/api/tools"
@@ -58,9 +58,14 @@ export interface FieldCopy {
 
 function useDraft(committed: string) {
   const [draft, setDraft] = useState(committed)
+  const [synced, setSynced] = useState(committed)
   // Re-hydrated from the server's answer, so a save or a clear lands in the
-  // field instead of leaving a stale draft over it.
-  useEffect(() => setDraft(committed), [committed])
+  // field instead of leaving a stale draft over it. In render rather than an
+  // effect, which is the idiom `PolicyRow` uses: one rule for the job.
+  if (committed !== synced) {
+    setSynced(committed)
+    setDraft(committed)
+  }
   return [draft, setDraft] as const
 }
 
@@ -92,6 +97,7 @@ function TextRow({
     <SettingRow
       label={copy.label}
       labelId={labelId}
+      controlId={settingInputId(field.key)}
       configKey={configKey}
       help={copy.help}
       note={note}
@@ -159,6 +165,7 @@ function NumberRow({
     <SettingRow
       label={copy.label}
       labelId={labelId}
+      controlId={settingInputId(field.key)}
       configKey={configKey}
       help={copy.help}
       error={message}
@@ -289,7 +296,7 @@ function UrlRow({
         <p
           role="status"
           aria-live="polite"
-          className={`text-xs ${test.data?.ok ? "text-success" : "text-danger"}`}
+          className={`text-caption ${test.data?.ok ? "text-success" : "text-danger"}`}
         >
           {settled &&
             (test.error ? errorMessage(test.error) : test.data?.reason)}
@@ -416,9 +423,15 @@ export function ToolPriceRow({
   const errorId = useId()
 
   const trimmed = draft.trim()
-  const parsed = Number(trimmed)
-  const valid = trimmed !== "" && Number.isFinite(parsed) && parsed >= 0
-  const message = loadError || save.error
+  // Digits with an optional decimal part, spelled out rather than left to
+  // `Number`, which reads "1e3" as 1000 and "0x10" as 16. The other numeric
+  // rows refuse those; this one is money, so it admits a decimal point.
+  const parsed = /^\d+(\.\d+)?$/.test(trimmed) ? Number(trimmed) : Number.NaN
+  const invalid =
+    trimmed !== "" && !(Number.isFinite(parsed) && parsed >= 0)
+      ? "An amount in dollars, such as 0.01."
+      : ""
+  const message = loadError || save.error || invalid
 
   return (
     <SettingRow
@@ -442,8 +455,18 @@ export function ToolPriceRow({
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={commitOnEnter}
             onBlur={() => {
-              if (!valid || trimmed === committed) return
-              void save.run(() => commit(parsed * PER_MILLION))
+              if (invalid || trimmed === committed) return
+              // Blank cannot be sent: `/v1/pricing` only writes a rate, so
+              // there is no way to make a priced tool unpriced again from
+              // here. Putting the stored value back says that without a
+              // message that would nag on every pass through the field.
+              if (trimmed === "") {
+                setDraft(committed)
+                return
+              }
+              // Rounded, because the wire value is per million: 0.07 * 1e6 is
+              // 70000.00000000001 in binary floating point.
+              void save.run(() => commit(Math.round(parsed * PER_MILLION)))
             }}
             className={`field-machine w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS} ${
               message ? "border-danger" : ""

--- a/web/src/features/tools/ToolSettingRows.tsx
+++ b/web/src/features/tools/ToolSettingRows.tsx
@@ -13,8 +13,8 @@ import { commitOnEnter, useAutosave } from "@/shared/hooks/useAutosave"
 // so a jump from the tool panel lands the field in the page rather than under
 // the 56px top bar.
 const TEXT_INPUT = `w-full scroll-mt-16 md:w-[13.75rem] ${INPUT_CLASS}`
-const MACHINE_INPUT = `field-machine ${TEXT_INPUT}`
-const NUMBER_INPUT = `field-machine w-full scroll-mt-16 text-right tabular-nums md:w-[5.5rem] ${INPUT_CLASS}`
+const MACHINE_INPUT = `otari-machine-field ${TEXT_INPUT}`
+const NUMBER_INPUT = `otari-machine-field w-full scroll-mt-16 text-right tabular-nums md:w-[5.5rem] ${INPUT_CLASS}`
 
 /**
  * The mono caption beside a row's label, if the key is not already the label.
@@ -466,7 +466,7 @@ export function ToolPriceRow({
               // 70000.00000000001 in binary floating point.
               void save.run(() => commit(Math.round(parsed * PER_MILLION)))
             }}
-            className={`field-machine w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS}`}
+            className={`otari-machine-field w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS}`}
           />
         </div>
       }

--- a/web/src/features/tools/ToolSettingRows.tsx
+++ b/web/src/features/tools/ToolSettingRows.tsx
@@ -125,9 +125,7 @@ function TextRow({
               if (next === committed) return
               void save.run(() => commit(field.key, next === "" ? null : next))
             }}
-            className={`${copy.machine ? MACHINE_INPUT : TEXT_INPUT} ${
-              save.error ? "border-danger" : ""
-            }`}
+            className={`${copy.machine ? MACHINE_INPUT : TEXT_INPUT}`}
           />
           {trailing}
         </div>
@@ -189,7 +187,7 @@ function NumberRow({
               commit(field.key, trimmed === "" ? null : parsed),
             )
           }}
-          className={`${NUMBER_INPUT} ${message ? "border-danger" : ""}`}
+          className={`${NUMBER_INPUT}`}
         />
       }
     />
@@ -468,9 +466,7 @@ export function ToolPriceRow({
               // 70000.00000000001 in binary floating point.
               void save.run(() => commit(Math.round(parsed * PER_MILLION)))
             }}
-            className={`field-machine w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS} ${
-              message ? "border-danger" : ""
-            }`}
+            className={`field-machine w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS}`}
           />
         </div>
       }

--- a/web/src/features/tools/ToolSettingRows.tsx
+++ b/web/src/features/tools/ToolSettingRows.tsx
@@ -1,0 +1,456 @@
+import { Button } from "@heroui/react"
+import { useEffect, useId, useState } from "react"
+
+import type { ToolSettingField } from "@/client"
+import { useTestService } from "@/shared/api/tools"
+import { errorMessage } from "@/shared/components/feedback/errorMessage"
+import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
+import { SettingRow } from "@/shared/components/layout/SettingRow"
+import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
+import { commitOnEnter, useAutosave } from "@/shared/hooks/useAutosave"
+
+// The control lane, one width for text and one for a number, and `scroll-mt-16`
+// so a jump from the tool panel lands the field in the page rather than under
+// the 56px top bar.
+const TEXT_INPUT = `w-full scroll-mt-16 md:w-[13.75rem] ${INPUT_CLASS}`
+const MACHINE_INPUT = `field-machine ${TEXT_INPUT}`
+const NUMBER_INPUT = `field-machine w-full scroll-mt-16 text-right tabular-nums md:w-[5.5rem] ${INPUT_CLASS}`
+
+/**
+ * The mono caption beside a row's label, if the key is not already the label.
+ *
+ * A key with no copy entry falls back to using itself as the label, and showing
+ * it twice would read "web_search_url web_search_url".
+ */
+function keyCaption(copy: FieldCopy, field: ToolSettingField) {
+  return copy.label === field.key ? undefined : field.key
+}
+
+/**
+ * The ids a row's control names itself by: the label, and the key caption when
+ * there is one. "Backend URL" alone is not unique on a page configuring three
+ * services, and an accessible name has to contain the visible label.
+ */
+function namedBy(labelId: string, caption: string | undefined) {
+  return caption ? `${labelId} ${labelId}-key` : labelId
+}
+
+/** The field a "jump to this setting" link scrolls to and focuses. */
+export function settingInputId(key: string) {
+  return `tool-setting-${key}`
+}
+
+/** What a row writes, and what the page does with it. */
+export type CommitField = (
+  key: string,
+  value: boolean | number | string | null,
+) => Promise<unknown>
+
+/** The label, help line and placeholder a key wears in the dashboard. */
+export interface FieldCopy {
+  label: string
+  help: string
+  /** A representative value, never the word "default": blank already means that. */
+  placeholder: string
+  /** Mono, for a value a machine reads. Off for a sentence a model reads. */
+  machine?: boolean
+}
+
+function useDraft(committed: string) {
+  const [draft, setDraft] = useState(committed)
+  // Re-hydrated from the server's answer, so a save or a clear lands in the
+  // field instead of leaving a stale draft over it.
+  useEffect(() => setDraft(committed), [committed])
+  return [draft, setDraft] as const
+}
+
+function TextRow({
+  field,
+  copy,
+  commit,
+  disabled,
+  trailing,
+  note,
+  onDraftChange,
+}: {
+  field: ToolSettingField
+  copy: FieldCopy
+  commit: CommitField
+  disabled: boolean
+  trailing?: React.ReactNode
+  note?: React.ReactNode
+  onDraftChange?: (value: string) => void
+}) {
+  const committed = typeof field.value === "string" ? field.value : ""
+  const [draft, setDraft] = useDraft(committed)
+  const save = useAutosave()
+  const errorId = useId()
+  const labelId = useId()
+  const configKey = keyCaption(copy, field)
+
+  return (
+    <SettingRow
+      label={copy.label}
+      labelId={labelId}
+      configKey={configKey}
+      help={copy.help}
+      note={note}
+      error={save.error}
+      errorId={errorId}
+      control={
+        <div className="flex items-center gap-1.5">
+          <input
+            id={settingInputId(field.key)}
+            type="text"
+            inputMode={field.type === "url" ? "url" : "text"}
+            aria-labelledby={namedBy(labelId, configKey)}
+            aria-invalid={save.error ? true : undefined}
+            aria-describedby={save.error ? errorId : undefined}
+            value={draft}
+            disabled={disabled || save.isSaving}
+            placeholder={copy.placeholder}
+            onChange={(event) => {
+              setDraft(event.target.value)
+              onDraftChange?.(event.target.value)
+            }}
+            onKeyDown={commitOnEnter}
+            onBlur={() => {
+              const next = draft.trim()
+              if (next === committed) return
+              void save.run(() => commit(field.key, next === "" ? null : next))
+            }}
+            className={`${copy.machine ? MACHINE_INPUT : TEXT_INPUT} ${
+              save.error ? "border-danger" : ""
+            }`}
+          />
+          {trailing}
+        </div>
+      }
+    />
+  )
+}
+
+function NumberRow({
+  field,
+  copy,
+  commit,
+  disabled,
+}: {
+  field: ToolSettingField
+  copy: FieldCopy
+  commit: CommitField
+  disabled: boolean
+}) {
+  const committed = typeof field.value === "number" ? String(field.value) : ""
+  const [draft, setDraft] = useDraft(committed)
+  const save = useAutosave()
+  const errorId = useId()
+  const labelId = useId()
+  const configKey = keyCaption(copy, field)
+
+  const trimmed = draft.trim()
+  // Digits only. `Number` would read "0x10" as 16 and "1e1" as 10, and the
+  // server's floor is 1, so both are refused here rather than sent.
+  const parsed = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN
+  const valid = trimmed === "" || (Number.isSafeInteger(parsed) && parsed >= 1)
+  const message = save.error || (valid ? "" : "A whole number, 1 or more.")
+
+  return (
+    <SettingRow
+      label={copy.label}
+      labelId={labelId}
+      configKey={configKey}
+      help={copy.help}
+      error={message}
+      errorId={errorId}
+      control={
+        <input
+          id={settingInputId(field.key)}
+          type="text"
+          inputMode="numeric"
+          aria-labelledby={namedBy(labelId, configKey)}
+          aria-invalid={message ? true : undefined}
+          aria-describedby={message ? errorId : undefined}
+          value={draft}
+          disabled={disabled || save.isSaving}
+          placeholder={copy.placeholder}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={commitOnEnter}
+          onBlur={() => {
+            if (!valid || trimmed === committed) return
+            void save.run(() =>
+              commit(field.key, trimmed === "" ? null : parsed),
+            )
+          }}
+          className={`${NUMBER_INPUT} ${message ? "border-danger" : ""}`}
+        />
+      }
+    />
+  )
+}
+
+// A nullable boolean has three meaningful states, so a select rather than a
+// toggle: "Default" is what the backend decides, and a two-state control cannot
+// say it. Discrete, so it saves on change with nothing typed to lose.
+function BoolRow({
+  field,
+  copy,
+  commit,
+  disabled,
+  defaultLabel,
+}: {
+  field: ToolSettingField
+  copy: FieldCopy
+  commit: CommitField
+  disabled: boolean
+  defaultLabel: string
+}) {
+  const save = useAutosave()
+  const errorId = useId()
+  const configKey = keyCaption(copy, field)
+  const current =
+    field.value === true ? "on" : field.value === false ? "off" : "default"
+
+  return (
+    <SettingRow
+      label={copy.label}
+      configKey={configKey}
+      help={copy.help}
+      error={save.error}
+      errorId={errorId}
+      control={
+        <FilterSelect
+          ariaLabel={configKey ? `${copy.label} ${configKey}` : copy.label}
+          value={current}
+          onChange={(next) =>
+            void save.run(() =>
+              commit(field.key, next === "default" ? null : next === "on"),
+            )
+          }
+          options={[
+            { value: "default", label: defaultLabel },
+            { value: "on", label: "On" },
+            { value: "off", label: "Off" },
+          ]}
+          disabled={disabled || save.isSaving}
+        />
+      }
+    />
+  )
+}
+
+// The URL row carries Test, which probes the *typed* value so an operator can
+// check an endpoint before leaving the field. The result is pinned to the URL
+// it was asked about, so a late answer never lands beside a different one.
+function UrlRow({
+  field,
+  copy,
+  commit,
+  disabled,
+}: {
+  field: ToolSettingField
+  copy: FieldCopy
+  commit: CommitField
+  disabled: boolean
+}) {
+  const committed = typeof field.value === "string" ? field.value : ""
+  const [typed, setTyped] = useState(committed)
+  const [seen, setSeen] = useState(committed)
+  const [testedUrl, setTestedUrl] = useState<string | null>(null)
+  const test = useTestService()
+
+  // A refetch can re-seed the field with no keystroke, which the `onChange`
+  // reset below never sees. Following it here is what stops a result for the
+  // old URL from sitting beside the new one.
+  if (committed !== seen) {
+    setSeen(committed)
+    setTyped(committed)
+  }
+
+  const trimmed = typed.trim()
+  // A result belongs to the URL it was asked about, so a late answer never
+  // lands beside a different one.
+  const settled = testedUrl === trimmed && !test.isPending
+
+  return (
+    <TextRow
+      field={field}
+      copy={copy}
+      commit={commit}
+      disabled={disabled}
+      onDraftChange={(value) => {
+        setTyped(value)
+        // A result for the old URL must not sit beside a newly typed one.
+        test.reset()
+      }}
+      note={
+        // Always rendered so the outcome is announced when it arrives, not just
+        // shown. Empty until there is one for the URL currently in the field.
+        <p
+          role="status"
+          aria-live="polite"
+          className={`text-xs ${test.data?.ok ? "text-success" : "text-danger"}`}
+        >
+          {settled &&
+            (test.error ? errorMessage(test.error) : test.data?.reason)}
+        </p>
+      }
+      trailing={
+        <Button
+          size="sm"
+          aria-label={`Test ${field.service}`}
+          isDisabled={trimmed === "" || test.isPending}
+          onPress={() => {
+            setTestedUrl(trimmed)
+            test.mutate({ service: field.service, url: trimmed })
+          }}
+        >
+          {test.isPending ? "Testing…" : "Test"}
+        </Button>
+      }
+    />
+  )
+}
+
+/**
+ * One editable tool setting, as the row grammar the whole page is built from.
+ *
+ * `readOnly` renders the value rather than a disabled control: a member does
+ * not set this, and a dimmed field reads as a form that is briefly unavailable.
+ */
+export function ToolSettingRow({
+  field,
+  copy,
+  commit,
+  disabled,
+  readOnly,
+  defaultLabel = "Default",
+}: {
+  field: ToolSettingField
+  copy: FieldCopy
+  commit: CommitField
+  disabled: boolean
+  readOnly: boolean
+  /** Names what the backend does when nothing is set ("Default (on)"). */
+  defaultLabel?: string
+}) {
+  const configKey = keyCaption(copy, field)
+
+  if (readOnly) {
+    const shown =
+      field.value === null || field.value === ""
+        ? "Default"
+        : field.value === true
+          ? "On"
+          : field.value === false
+            ? "Off"
+            : String(field.value)
+    return (
+      <SettingRow
+        label={copy.label}
+        configKey={configKey}
+        help={copy.help}
+        control={
+          <span className="break-words text-caption text-foreground">
+            {shown}
+          </span>
+        }
+      />
+    )
+  }
+  if (field.type === "url") {
+    return (
+      <UrlRow field={field} copy={copy} commit={commit} disabled={disabled} />
+    )
+  }
+  if (field.type === "int") {
+    return (
+      <NumberRow
+        field={field}
+        copy={copy}
+        commit={commit}
+        disabled={disabled}
+      />
+    )
+  }
+  if (field.type === "bool") {
+    return (
+      <BoolRow
+        field={field}
+        copy={copy}
+        commit={commit}
+        disabled={disabled}
+        defaultLabel={defaultLabel}
+      />
+    )
+  }
+  return (
+    <TextRow field={field} copy={copy} commit={commit} disabled={disabled} />
+  )
+}
+
+// The stored column is `input_price_per_million`, and `flat_request_cost` reads
+// it as USD per *million* calls, so a cent a search is stored as 10000. Right
+// for the wire, hostile at a keyboard: this row speaks dollars per call and
+// does the conversion itself.
+const PER_MILLION = 1_000_000
+
+/** Per-call price for a tool Otari runs itself, in the same row grammar. */
+export function ToolPriceRow({
+  pricingKey,
+  configured,
+  commit,
+  disabled,
+  loadError,
+}: {
+  pricingKey: string
+  configured: number | null
+  commit: (perMillion: number) => Promise<unknown>
+  disabled: boolean
+  /** Set when the current rate could not be read, so nothing may overwrite it. */
+  loadError?: string
+}) {
+  const committed = configured === null ? "" : String(configured / PER_MILLION)
+  const [draft, setDraft] = useDraft(committed)
+  const save = useAutosave()
+  const errorId = useId()
+
+  const trimmed = draft.trim()
+  const parsed = Number(trimmed)
+  const valid = trimmed !== "" && Number.isFinite(parsed) && parsed >= 0
+  const message = loadError || save.error
+
+  return (
+    <SettingRow
+      label="Price per call"
+      configKey={pricingKey}
+      help="Unpriced calls are recorded and billed nothing; refused when require_pricing is on."
+      error={message}
+      errorId={errorId}
+      control={
+        <div className="flex items-center gap-1.5">
+          <span className="text-mono-overline text-subtle">USD</span>
+          <input
+            type="text"
+            inputMode="decimal"
+            aria-label={`Price per call for ${pricingKey}`}
+            aria-invalid={message ? true : undefined}
+            aria-describedby={message ? errorId : undefined}
+            value={draft}
+            disabled={disabled || save.isSaving}
+            placeholder="0.00"
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={commitOnEnter}
+            onBlur={() => {
+              if (!valid || trimmed === committed) return
+              void save.run(() => commit(parsed * PER_MILLION))
+            }}
+            className={`field-machine w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS} ${
+              message ? "border-danger" : ""
+            }`}
+          />
+        </div>
+      }
+    />
+  )
+}

--- a/web/src/features/tools/ToolStatusGroup.tsx
+++ b/web/src/features/tools/ToolStatusGroup.tsx
@@ -95,7 +95,10 @@ export function ToolStatusGroup({
                       })
                       input?.focus({ preventScroll: true })
                     }}
-                    className="text-caption text-link transition-colors duration-150 ease-out hover:text-link-hover focus-visible:otari-focus-ring motion-reduce:transition-none"
+                    // The only control in this row's lane, so it carries the
+                    // 44px floor itself; a bare `<button>` also keeps Tailwind's
+                    // reset cursor without this.
+                    className="inline-flex min-h-11 cursor-pointer items-center text-caption text-link transition-colors duration-150 ease-out hover:text-link-hover focus-visible:otari-focus-ring motion-reduce:transition-none"
                   >
                     Set backend URL ↓
                   </button>

--- a/web/src/features/tools/ToolStatusGroup.tsx
+++ b/web/src/features/tools/ToolStatusGroup.tsx
@@ -65,7 +65,7 @@ export function ToolStatusGroup({
         onToggle={() => setIsOpen((open) => !open)}
         trailing={
           <span className="flex items-center gap-2.5 text-mono-overline text-subtle">
-            <Dot className={tool.available ? "bg-accent" : "bg-text-subtle"} />
+            <Dot className={tool.available ? "bg-success" : "bg-text-subtle"} />
             {tool.available ? "Available" : "Unavailable · no backend"}
           </span>
         }

--- a/web/src/features/tools/ToolStatusGroup.tsx
+++ b/web/src/features/tools/ToolStatusGroup.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react"
+
+import type { ManagedTool } from "@/client"
+import { settingInputId } from "@/features/tools/ToolSettingRows"
+import { CopyableValue } from "@/shared/components/actions/CopyField"
+import { Dot } from "@/shared/components/indicators/Dot"
+import { SettingRow } from "@/shared/components/layout/SettingRow"
+import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
+import { DisclosureRow } from "@/shared/components/navigation/DisclosureRow"
+import { DocsLink } from "@/shared/components/navigation/DocsLink"
+
+/**
+ * The declaration a client sends, as a value to take.
+ *
+ * Sized to its content rather than to the lane, which is what a full-width
+ * readonly field got wrong: the value is 28 characters and the field was 800.
+ * A frame rather than bare text, because it holds something to be copied
+ * verbatim; the value inside it is real selectable text, since the Clipboard
+ * API does not exist on the plain-HTTP origins this dashboard is served from.
+ */
+function DeclarationChip({ tool }: { tool: ManagedTool }) {
+  return (
+    <span className="inline-flex h-8 items-center border border-control-border bg-surface-alt pl-2.5">
+      <CopyableValue
+        value={`"type": "${tool.id}"`}
+        label={`tools[].type for ${tool.id}`}
+        className="font-mono text-xs text-foreground"
+      />
+    </span>
+  )
+}
+
+/**
+ * What the tool is, whether this deployment can run it, and how to ask for it.
+ *
+ * At the head of the page because it is the question an operator arrives with:
+ * the settings below say how a search runs, and this says whether one runs at
+ * all. Collapsed, because the answer is the row and the reasoning is the panel.
+ *
+ * The panel is the same `SettingRow` grammar as the settings below it, indented
+ * to say these rows belong to the tool row that opened them. Eyebrowed
+ * paragraphs read as a second system on a page that is otherwise all rows.
+ */
+export function ToolStatusGroup({
+  tool,
+  docsHref,
+  urlFieldKey,
+}: {
+  tool: ManagedTool
+  docsHref: string
+  /** The setting the "no backend" case sends the operator to, when there is one. */
+  urlFieldKey?: string
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  // The provider-named keywords interception adds. Absent when it is off, which
+  // is the only thing on this page that changes the list.
+  const alsoAccepted = tool.accepted_types.filter((type) => type !== tool.id)
+
+  return (
+    <SettingsGroup bounded>
+      <DisclosureRow
+        label={<code className="text-mono-caption">{tool.id}</code>}
+        help={tool.description}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen((open) => !open)}
+        trailing={
+          <span className="flex items-center gap-2.5 text-mono-overline text-subtle">
+            <Dot className={tool.available ? "bg-accent" : "bg-text-subtle"} />
+            {tool.available ? "Available" : "Unavailable · no backend"}
+          </span>
+        }
+      >
+        <div className="flex flex-col divide-y divide-border-subtle">
+          {/* Absent rather than empty when the tool is available: there is no
+              reason to give. */}
+          {tool.available ? null : (
+            <SettingRow
+              nested
+              label="Why unavailable"
+              help="No backend URL is set, so every call is rejected with 400."
+              control={
+                urlFieldKey ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      // The field's own `scroll-mt-16` keeps it clear of the
+                      // top bar; focus moves separately so the smooth scroll is
+                      // not cut short by the browser's own scroll-into-view.
+                      const input = document.getElementById(
+                        settingInputId(urlFieldKey),
+                      )
+                      input?.scrollIntoView({
+                        behavior: "smooth",
+                        block: "start",
+                      })
+                      input?.focus({ preventScroll: true })
+                    }}
+                    className="text-caption text-link transition-colors duration-150 ease-out hover:text-link-hover focus-visible:otari-focus-ring motion-reduce:transition-none"
+                  >
+                    Set backend URL ↓
+                  </button>
+                ) : null
+              }
+            />
+          )}
+          <SettingRow
+            nested
+            label="Declare in a request"
+            help={
+              <>
+                Goes in <code className="font-mono">tools[].type</code>.{" "}
+                {alsoAccepted.length > 0 ? (
+                  <>
+                    This deployment also routes{" "}
+                    <code className="font-mono">{alsoAccepted.join(", ")}</code>{" "}
+                    to it.{" "}
+                  </>
+                ) : null}
+                <DocsLink href={docsHref}>Developer docs</DocsLink>
+              </>
+            }
+            control={<DeclarationChip tool={tool} />}
+          />
+        </div>
+      </DisclosureRow>
+    </SettingsGroup>
+  )
+}

--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -335,6 +335,64 @@ describe("ToolsGuardrailsPage", () => {
     expect(lastPatch(fetchMock)).toBeUndefined()
   })
 
+  it.each(["1e3", "0x10", "abc"])(
+    "refuses %s as a price rather than letting Number read it",
+    async (raw) => {
+      // The other numeric rows guard against this; the money row is the one
+      // that admits a decimal, so its guard is a different regex, not none.
+      const fetchMock = mockApi()
+      const user = userEvent.setup()
+      renderWithClient(<ToolsGuardrailsPage only="web_search" />)
+      const price = await screen.findByLabelText(
+        "Price per call for otari:web_search",
+      )
+
+      // The row is disabled until /v1/pricing answers, so a rate is never
+      // typed over one nobody can see.
+      await waitFor(() => expect(price).toBeEnabled())
+      await user.type(price, raw)
+      await user.tab()
+
+      expect(
+        await screen.findByText("An amount in dollars, such as 0.01."),
+      ).toBeInTheDocument()
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).includes("/v1/pricing"),
+        ) &&
+          fetchMock.mock.calls.some(
+            ([, init]) => (init?.method ?? "") === "POST",
+          ),
+      ).toBe(false)
+    },
+  )
+
+  it("rounds a price onto the wire rather than shipping float noise", async () => {
+    // The stored column is per million, so 0.07 * 1e6 is 70000.00000000001.
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage only="web_search" />)
+    const price = await screen.findByLabelText(
+      "Price per call for otari:web_search",
+    )
+
+    await waitFor(() => expect(price).toBeEnabled())
+    await user.type(price, "0.07")
+    await user.tab()
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          String(url).includes("/v1/pricing") &&
+          (init?.method ?? "") === "POST",
+      )
+      expect(call).toBeDefined()
+      expect(JSON.parse(String(call?.[1]?.body)).input_price_per_million).toBe(
+        70000,
+      )
+    })
+  })
+
   it("tests a URL for reachability and announces the result", async () => {
     mockApi({ testBody: { ok: true, reason: "reachable (HTTP 200)" } })
     const user = userEvent.setup()

--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -194,73 +194,152 @@ function mockApi(opts: MockOpts = {}) {
     })
 }
 
+// The label a control now carries: the visible label and the config key beside
+// it, which is what makes "Backend URL" unique on a page configuring three
+// services.
+const named = (label: string, key: string) => `${label} ${key}`
+const WEB_SEARCH_URL = named("Backend URL", "web_search_url")
+const ENGINES = named("Engines", "web_search_engines")
+const MAX_RESULTS = named("Max results", "web_search_max_results")
+const EXTRACT = named("Extract page content", "web_search_extract")
+const INTERCEPT = named("Intercept provider web search", "web_search_intercept")
+const SANDBOX_URL = named("Backend URL", "sandbox_url")
+const GUARDRAILS_URL = named("Backend URL", "guardrails_url")
+
+/** The last PATCH body the page sent, parsed. */
+function lastPatch(fetchMock: ReturnType<typeof mockApi>) {
+  const call = fetchMock.mock.calls
+    .filter(([, init]) => (init?.method ?? "") === "PATCH")
+    .at(-1)
+  return call ? (JSON.parse(String(call[1]?.body)) as unknown) : undefined
+}
+
 describe("ToolsGuardrailsPage", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it("renders the three service sections and effective values", async () => {
+  it("renders every service's groups and effective values", async () => {
     mockApi()
     renderWithClient(<ToolsGuardrailsPage />)
 
-    expect(await screen.findByText("Web search")).toBeInTheDocument()
-    expect(screen.getByText("Code execution")).toBeInTheDocument()
-    expect(screen.getByText("Guardrails")).toBeInTheDocument()
-    expect(screen.getByLabelText("web_search_url")).toHaveValue(
+    // The combined page names the service in each group heading, since three
+    // groups called "Backend" would not say which one they configure.
+    expect(
+      await screen.findByRole("heading", { name: "Web search · Backend" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Code execution · Backend" }),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole("heading", { name: "Guardrails · Backend" }),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(WEB_SEARCH_URL)).toHaveValue(
       "http://searxng:8080",
     )
-    expect(screen.getByLabelText("guardrails_url")).toHaveValue(
+    expect(screen.getByLabelText(GUARDRAILS_URL)).toHaveValue(
       "http://guardrails:8000",
     )
   })
 
-  it("saves a URL change with a PATCH", async () => {
+  it("saves a URL change on blur, with no Save button on the page", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
-    const input = screen.getByLabelText("web_search_url")
+    const input = screen.getByLabelText(WEB_SEARCH_URL)
     await user.clear(input)
     await user.type(input, "http://new-searxng:9000")
-    await user.click(
-      screen.getByRole("button", { name: "Save web_search_url" }),
-    )
+    await user.tab()
 
-    const call = fetchMock.mock.calls.find(
-      ([, init]) => (init?.method ?? "") === "PATCH",
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({
+        web_search_url: "http://new-searxng:9000",
+      }),
     )
-    expect(call).toBeDefined()
-    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
-      web_search_url: "http://new-searxng:9000",
-    })
+    expect(screen.queryByRole("button", { name: /^Save/ })).toBeNull()
   })
 
-  it("clears a URL to null when emptied and saved", async () => {
+  it("commits a field on Enter without leaving it by hand", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(ENGINES)
 
-    const input = screen.getByLabelText("web_search_url")
+    await user.type(screen.getByLabelText(ENGINES), "google,bing{Enter}")
+
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({
+        web_search_engines: "google,bing",
+      }),
+    )
+  })
+
+  it("does not save a field that was focused and left unchanged", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(WEB_SEARCH_URL)
+
+    await user.click(screen.getByLabelText(WEB_SEARCH_URL))
+    await user.tab()
+
+    expect(lastPatch(fetchMock)).toBeUndefined()
+  })
+
+  it("clears a URL to null when emptied", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(WEB_SEARCH_URL)
+
+    await user.clear(screen.getByLabelText(WEB_SEARCH_URL))
+    await user.tab()
+
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({ web_search_url: null }),
+    )
+  })
+
+  it("trims surrounding whitespace when saving a text field", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(ENGINES)
+
+    await user.type(screen.getByLabelText(ENGINES), "  google,bing  ")
+    await user.tab()
+
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({
+        web_search_engines: "google,bing",
+      }),
+    )
+  })
+
+  it("refuses a ceiling that is not a whole number without asking the server", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(MAX_RESULTS)
+
+    const input = screen.getByLabelText(MAX_RESULTS)
     await user.clear(input)
-    await user.click(
-      screen.getByRole("button", { name: "Save web_search_url" }),
-    )
+    await user.type(input, "1e1")
+    await user.tab()
 
-    const call = fetchMock.mock.calls.find(
-      ([, init]) => (init?.method ?? "") === "PATCH",
-    )
-    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
-      web_search_url: null,
-    })
+    expect(
+      await screen.findByText("A whole number, 1 or more."),
+    ).toBeInTheDocument()
+    expect(lastPatch(fetchMock)).toBeUndefined()
   })
 
   it("tests a URL for reachability and announces the result", async () => {
     mockApi({ testBody: { ok: true, reason: "reachable (HTTP 200)" } })
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
     await user.click(screen.getByRole("button", { name: "Test web_search" }))
     expect(await screen.findByText("reachable (HTTP 200)")).toBeInTheDocument()
@@ -269,8 +348,8 @@ describe("ToolsGuardrailsPage", () => {
   it("does not keep a test result against a URL that changed underneath it", async () => {
     // Editing the field already drops a stale result (the onChange reset). This
     // covers the path that reset does not: the committed URL changing from a
-    // refetch (e.g. a background refresh, or saving a sibling field) re-seeds the
-    // input with no keystroke, so a result must be gated on the URL it tested.
+    // refetch re-seeds the input with no keystroke, so a result must be gated on
+    // the URL it tested.
     const user = userEvent.setup()
     let searxngUrl = "http://searxng:8080"
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -295,64 +374,85 @@ describe("ToolsGuardrailsPage", () => {
       return jsonResponse([])
     })
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
-    // Test the URL; its result shows while the field still holds the tested URL.
     await user.click(screen.getByRole("button", { name: "Test web_search" }))
     expect(await screen.findByText("reachable (HTTP 200)")).toBeInTheDocument()
 
-    // Save a sibling field; the refetch re-seeds web_search_url to a new value.
-    await user.type(screen.getByLabelText("web_search_engines"), "google")
-    await user.click(
-      screen.getByRole("button", { name: "Save web_search_engines" }),
-    )
+    await user.type(screen.getByLabelText(ENGINES), "google")
+    await user.tab()
 
     await waitFor(() =>
-      expect(screen.getByLabelText("web_search_url")).toHaveValue(
+      expect(screen.getByLabelText(WEB_SEARCH_URL)).toHaveValue(
         "http://searxng:9999",
       ),
     )
-    // The result belonged to the old URL, so it must no longer be shown.
     expect(screen.queryByText("reachable (HTTP 200)")).not.toBeInTheDocument()
   })
 
-  it("shows an inline error under the field when a save is rejected", async () => {
+  it("shows a rejected save in the row it came from, keeping the typed value", async () => {
     mockApi({
       patchStatus: 422,
       patchDetail: "URL must use http or https, got no scheme.",
     })
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(SANDBOX_URL)
 
-    const input = screen.getByLabelText("sandbox_url")
+    const input = screen.getByLabelText(SANDBOX_URL)
     await user.type(input, "ftp://bad")
-    await user.click(screen.getByRole("button", { name: "Save sandbox_url" }))
+    await user.tab()
 
     expect(
       await screen.findByText(/must use http or https/),
     ).toBeInTheDocument()
+    expect(input).toHaveValue("ftp://bad")
+    expect(input).toHaveAttribute("aria-invalid", "true")
   })
 
   it("sends web_search_extract=false when the tri-state select is set to Off", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
-    await pickOption(user, "web_search_extract", "Off")
+    await pickOption(user, EXTRACT, "Off")
 
-    const call = fetchMock.mock.calls.find(
-      ([, init]) => (init?.method ?? "") === "PATCH",
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({ web_search_extract: false }),
     )
-    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
-      web_search_extract: false,
-    })
   })
 
-  it("renders a backend field not in the frontend's ordered list (fallback)", async () => {
-    // A field the backend reports for a service but the frontend hasn't listed in
-    // SERVICES[*].order must still render, so a backend addition is not hidden.
+  it("saves web_search_intercept from the tri-state select", async () => {
+    const fetchMock = mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(WEB_SEARCH_URL)
+
+    await pickOption(user, INTERCEPT, "On")
+
+    await waitFor(() =>
+      expect(lastPatch(fetchMock)).toEqual({ web_search_intercept: true }),
+    )
+  })
+
+  it("surfaces a failed boolean save inline (not silently)", async () => {
+    mockApi({
+      patchStatus: 422,
+      patchDetail: "web_search_extract must be a boolean.",
+    })
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage />)
+    await screen.findByLabelText(WEB_SEARCH_URL)
+
+    await pickOption(user, EXTRACT, "Off")
+
+    expect(await screen.findByText(/must be a boolean/)).toBeInTheDocument()
+  })
+
+  it("renders a backend field no group lists (fallback)", async () => {
+    // A field the backend reports for a service that no group in SERVICES names
+    // must still render, so a backend addition is not hidden.
     const withExtra: ToolSettingsResponse = {
       fields: [
         ...FIELDS,
@@ -371,106 +471,83 @@ describe("ToolsGuardrailsPage", () => {
         : jsonResponse(withExtra),
     )
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+
     expect(
       await screen.findByLabelText("web_search_timeout_s"),
     ).toBeInTheDocument()
   })
 
-  it("surfaces a failed boolean save inline (not silently)", async () => {
-    mockApi({
-      patchStatus: 422,
-      patchDetail: "web_search_extract must be a boolean.",
-    })
-    const user = userEvent.setup()
-    renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
-
-    await pickOption(user, "web_search_extract", "Off")
-
-    expect(await screen.findByText(/must be a boolean/)).toBeInTheDocument()
-  })
-
-  it("aligns fields on one grid: every row shares the same fixed input/action columns", async () => {
-    // The alignment fix (issue #355) lays each field out as a grid row with
-    // fixed-width input and action tracks, so the boxes and Save buttons line up
-    // in columns regardless of a row's type or whether it also has a Test button.
-    // Before the fix, rows were flex with per-type input widths (w-64 vs w-28)
-    // and a Test button that shoved Save off the shared right edge.
+  it("lays every row out with the label left and the control in a shared lane", async () => {
+    // One row shape for every field type, which is what keeps the controls in a
+    // column down a group whether or not a row also carries a Test button.
     mockApi()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
-    const rowOf = (labeledBy: string) =>
-      screen.getByLabelText(labeledBy).closest("div.grid") as HTMLElement | null
-
-    const urlRow = rowOf("web_search_url") // has Save + Test
-    const textRow = rowOf("web_search_engines") // has Save only
-    const numberRow = rowOf("web_search_max_results") // narrower numeric input
-
-    for (const row of [urlRow, textRow, numberRow]) {
-      expect(row).not.toBeNull()
-      // Same three-track template on every row keeps the columns aligned.
-      expect(row?.className).toContain(
-        "sm:grid-cols-[minmax(0,1fr)_16rem_10rem]",
-      )
+    for (const label of [WEB_SEARCH_URL, ENGINES, MAX_RESULTS]) {
+      expect(screen.getByLabelText(label).className).toContain("w-full")
     }
-
-    // The URL and text inputs fill the shared input column (no more w-64 vs w-28
-    // mismatch); the numeric input is pinned to that column's right edge.
-    expect(screen.getByLabelText("web_search_url").className).toContain(
-      "w-full",
+    // Only the numeric field narrows, and it does so in the same lane.
+    expect(screen.getByLabelText(MAX_RESULTS).className).toContain(
+      "md:w-[5.5rem]",
     )
-    expect(screen.getByLabelText("web_search_engines").className).toContain(
-      "w-full",
+    expect(screen.getByLabelText(ENGINES).className).toContain(
+      "md:w-[13.75rem]",
     )
-    expect(screen.getByLabelText("web_search_max_results").className).toContain(
-      "sm:justify-self-end",
-    )
-  })
-
-  it("trims surrounding whitespace when saving a text field", async () => {
-    const fetchMock = mockApi()
-    const user = userEvent.setup()
-    renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
-
-    const input = screen.getByLabelText("web_search_engines")
-    await user.type(input, "  google,bing  ")
-    await user.click(
-      screen.getByRole("button", { name: "Save web_search_engines" }),
-    )
-
-    const call = fetchMock.mock.calls.find(
-      ([, init]) => (init?.method ?? "") === "PATCH",
-    )
-    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
-      web_search_engines: "google,bing",
-    })
   })
 })
 
-describe("ToolsGuardrailsPage how-to-call card", () => {
+describe("ToolsGuardrailsPage tool status", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it("shows the accepted declaration types and a runnable example per tool", async () => {
+  it("heads each tool's settings with whether the deployment can run it", async () => {
     mockApi()
     renderWithClient(<ToolsGuardrailsPage />)
 
-    // One card per gateway-run tool; guardrails has none (it is not declared in
-    // `tools[]` at all).
-    await screen.findByText("Web search")
-    await waitFor(() =>
-      expect(screen.getAllByText("Accepted tools[].type")).toHaveLength(2),
-    )
-    // The type to declare is the thing an operator cannot guess from the settings.
-    expect(screen.getAllByText("otari_web_search").length).toBeGreaterThan(0)
-    expect(screen.getAllByText(/POST \/v1\/chat\/completions/)).toHaveLength(2)
+    // One row per gateway-run tool; guardrails declares none, so it has no row.
+    expect(
+      await screen.findByRole("button", { name: /otari_web_search/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /otari_code_execution/ }),
+    ).toBeInTheDocument()
+    // The code-execution fixture has available: false.
+    expect(
+      screen.getByRole("button", { name: /Unavailable · no backend/ }),
+    ).toBeInTheDocument()
   })
 
-  it("advertises the provider-named keywords when interception is on", async () => {
+  it("opens to the type a client declares and the reason a tool is unavailable", async () => {
+    mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage only="sandbox" />)
+
+    const row = await screen.findByRole("button", {
+      name: /otari_code_execution/,
+    })
+    expect(row).toHaveAttribute("aria-expanded", "false")
+    await user.click(row)
+
+    expect(row).toHaveAttribute("aria-expanded", "true")
+    // Two rows in the page's own grammar, not a pair of eyebrowed paragraphs.
+    expect(screen.getByText("Why unavailable")).toBeInTheDocument()
+    expect(screen.getByText("Declare in a request")).toBeInTheDocument()
+    // The value is selectable text beside a copy button, sized to its content:
+    // the Clipboard API is absent on plain-HTTP origins, so the manual path is
+    // the one that always works.
+    expect(
+      screen.getByText('"type": "otari_code_execution"'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "Copy tools[].type for otari_code_execution",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("names the provider keywords interception adds", async () => {
     mockApi({
       tools: {
         object: "list",
@@ -486,65 +563,41 @@ describe("ToolsGuardrailsPage how-to-call card", () => {
         ],
       },
     })
-    renderWithClient(<ToolsGuardrailsPage />)
+    const user = userEvent.setup()
+    renderWithClient(<ToolsGuardrailsPage only="web_search" />)
 
-    expect(await screen.findByText("web_search_<date>")).toBeInTheDocument()
-    expect(screen.getByText("web_search")).toBeInTheDocument()
-  })
-
-  it("flags a tool whose backend is not configured", async () => {
-    mockApi()
-    renderWithClient(<ToolsGuardrailsPage />)
-
-    // The code-execution fixture has available: false. The flag is a subtle dot
-    // and a mono fact now: unavailable, not broken.
+    await user.click(
+      await screen.findByRole("button", { name: /otari_web_search/ }),
+    )
     expect(
-      await screen.findByText("Unavailable — no backend"),
+      screen.getByText("web_search, web_search_<date>"),
     ).toBeInTheDocument()
   })
 
   it("keeps the editable settings usable when /v1/tools fails", async () => {
-    // The card is reference material; a failed discovery fetch must not take the
-    // settings form down with it.
+    // The status row is reference material; a failed discovery fetch must not
+    // take the settings form down with it.
     mockApi({ toolsStatus: 500 })
-    renderWithClient(<ToolsGuardrailsPage />)
+    renderWithClient(<ToolsGuardrailsPage only="web_search" />)
 
-    expect(await screen.findByLabelText("web_search_url")).toHaveValue(
+    expect(await screen.findByLabelText(WEB_SEARCH_URL)).toHaveValue(
       "http://searxng:8080",
     )
     await waitFor(() =>
       expect(
-        screen.queryByText("Accepted tools[].type", { exact: false }),
+        screen.queryByRole("button", { name: /otari_web_search/ }),
       ).not.toBeInTheDocument(),
     )
-  })
-
-  it("saves web_search_intercept from the tri-state select", async () => {
-    const fetchMock = mockApi()
-    const user = userEvent.setup()
-    renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
-
-    await pickOption(user, "web_search_intercept", "On")
-
-    const call = fetchMock.mock.calls.find(
-      ([, init]) => (init?.method ?? "") === "PATCH",
-    )
-    expect(JSON.parse(String(call?.[1]?.body))).toEqual({
-      web_search_intercept: true,
-    })
   })
 
   it("re-reads the search providers after the web-search URL is saved", async () => {
     // A searxng search tool with no api_base inherits web_search_url, so the
     // catalogue that tells the Search tools card what a blank box resolves to
-    // (and whether one is required at all) changes with this very PATCH. Without
-    // the invalidation the card keeps offering the old inherited URL, or keeps
-    // demanding one the gateway would now supply.
+    // (and whether one is required at all) changes with this very PATCH.
     const fetchMock = mockApi()
     const user = userEvent.setup()
     renderWithClient(<ToolsGuardrailsPage />)
-    await screen.findByText("Web search")
+    await screen.findByLabelText(WEB_SEARCH_URL)
 
     const providerFetches = () =>
       fetchMock.mock.calls.filter(([url]) =>
@@ -553,20 +606,17 @@ describe("ToolsGuardrailsPage how-to-call card", () => {
     await waitFor(() => expect(providerFetches()).toBeGreaterThan(0))
     const before = providerFetches()
 
-    const input = screen.getByLabelText("web_search_url")
+    const input = screen.getByLabelText(WEB_SEARCH_URL)
     await user.clear(input)
     await user.type(input, "http://new-searxng:9000")
-    await user.click(
-      screen.getByRole("button", { name: "Save web_search_url" }),
-    )
+    await user.tab()
 
     await waitFor(() => expect(providerFetches()).toBeGreaterThan(before))
   })
+
   it("carries the MCP servers section on the combined page and no narrowed one", async () => {
     // The card has no service above it to be filtered with, so the `only` guard
-    // is the only thing keeping it off the per-service views. Asserted on the
-    // heading, which renders in every state of the card including the one a
-    // test harness with no selected workspace lands in.
+    // is the only thing keeping it off the per-service views.
     mockApi()
     const { unmount } = renderWithClient(<ToolsGuardrailsPage />)
     expect(
@@ -575,7 +625,7 @@ describe("ToolsGuardrailsPage how-to-call card", () => {
     unmount()
 
     renderWithClient(<ToolsGuardrailsPage only="sandbox" />)
-    await screen.findByText(/Backend for otari_code_execution tools/)
+    await screen.findByLabelText(SANDBOX_URL)
     expect(
       screen.queryByRole("heading", { name: "MCP servers" }),
     ).not.toBeInTheDocument()
@@ -610,7 +660,7 @@ describe("ToolsGuardrailsPage by caller role", () => {
       screen.getByText(/Per-workspace code execution is set on a workspace/),
     ).toBeInTheDocument()
 
-    // No deployment search-tools card, whose read is still operator-only.
+    // No deployment search-tools group, whose read is still operator-only.
     expect(
       screen.queryByRole("heading", { name: "Search tools" }),
     ).not.toBeInTheDocument()
@@ -633,19 +683,12 @@ describe("ToolsGuardrailsPage by caller role", () => {
     expect(
       await screen.findByText("web_search_max_results"),
     ).toBeInTheDocument()
-    expect(
-      screen.queryByLabelText("web_search_max_results"),
-    ).not.toBeInTheDocument()
-    // Deliberately not "no Save button on the page": the workspace cards below
-    // are a member's to edit and have their own.
-    expect(
-      screen.queryByLabelText("web_search_purpose_hint"),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(MAX_RESULTS)).not.toBeInTheDocument()
     // The service endpoints never arrive, so nothing renders them either.
     expect(screen.queryByText("web_search_url")).not.toBeInTheDocument()
     expect(screen.queryByText("guardrails_url")).not.toBeInTheDocument()
     // Nor the per-call rate: `/v1/pricing` is still operator-only, so this row
-    // would show a member an editable "Not priced" field that only fails on save.
+    // would show a member an editable "unpriced" field that only fails on save.
     expect(screen.queryByText("Price per call")).not.toBeInTheDocument()
   })
 
@@ -665,7 +708,7 @@ describe("ToolsGuardrailsPage by caller role", () => {
         /Per-workspace code execution is set on a workspace/,
       ),
     ).toBeInTheDocument()
-    expect(screen.queryByLabelText("sandbox_url")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(SANDBOX_URL)).not.toBeInTheDocument()
   })
 
   it("still renders the operator forms alongside the workspace cards for an operator", async () => {
@@ -674,7 +717,7 @@ describe("ToolsGuardrailsPage by caller role", () => {
     mockApi()
     renderWithClient(<ToolsGuardrailsPage only="web_search" />)
 
-    expect(await screen.findByLabelText("web_search_url")).toBeInTheDocument()
+    expect(await screen.findByLabelText(WEB_SEARCH_URL)).toBeInTheDocument()
     expect(
       screen.getByRole("heading", { name: "Search tools" }),
     ).toBeInTheDocument()

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -1,8 +1,7 @@
-import { Button } from "@heroui/react"
 import { Fragment, useEffect, useRef, useState } from "react"
 import { FiCheck } from "react-icons/fi"
+
 import type {
-  ManagedTool,
   ToolServiceName,
   ToolSettingField,
   UpdateToolSettingsRequest,
@@ -10,25 +9,23 @@ import type {
 import { isDeploymentOperator } from "@/features/organization/roles"
 import { OrganizationGuardrailsCard } from "@/features/tools/OrganizationGuardrailsCard"
 import { SearchToolsCard } from "@/features/tools/SearchToolsCard"
+import type { FieldCopy } from "@/features/tools/ToolSettingRows"
+import { ToolPriceRow, ToolSettingRow } from "@/features/tools/ToolSettingRows"
+import { ToolStatusGroup } from "@/features/tools/ToolStatusGroup"
 import { WorkspaceCodeExecutionPolicyCard } from "@/features/tools/WorkspaceCodeExecutionPolicyCard"
 import { WorkspaceMcpServersCard } from "@/features/tools/WorkspaceMcpServersCard"
 import { WorkspaceWebSearchCard } from "@/features/tools/WorkspaceWebSearchCard"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import { usePricing, useSetPricing } from "@/shared/api/pricing"
 import {
-  useTestService,
   useToolSettings,
   useTools,
   useUpdateToolSettings,
 } from "@/shared/api/tools"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
-import { errorMessage } from "@/shared/components/feedback/errorMessage"
-import { PageLoading } from "@/shared/components/feedback/PageLoading"
-import { INPUT_CLASS } from "@/shared/components/forms/inputClass"
-import { Dot } from "@/shared/components/indicators/Dot"
 import { PageIntro } from "@/shared/components/layout/PageIntro"
 import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
-import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
+import { docsSourceHref } from "@/shared/helpers/docs"
 
 // One settable field maps onto one key of the update request; cast at this one
 // boundary (the keys come from the backend's field list).
@@ -39,67 +36,208 @@ function oneField(
   return { [key]: value } as UpdateToolSettingsRequest
 }
 
-// The services, in display order, with the fields each owns (url first). Fields
-// not listed for a service are still rendered under it via the fallback, but
-// this fixes the order and lets us give each service a short blurb.
-const SERVICES: {
+/**
+ * What each key is called in the dashboard, and the one line under it.
+ *
+ * The backend's own `description` is written for an API reference: it names the
+ * env var's semantics in full, at two or three lines. A row's help line has to
+ * fit under a label, so the page carries its own copy and falls back to the
+ * backend's for a key it has not been told about yet.
+ */
+const FIELD_COPY: Record<string, FieldCopy & { defaultLabel?: string }> = {
+  web_search_url: {
+    label: "Backend URL",
+    help: "While unset, otari_web_search requests are rejected with 400.",
+    placeholder: "http://searxng:8080",
+    machine: true,
+  },
+  web_search_engines: {
+    label: "Engines",
+    help: "Comma-separated SearXNG engines. Blank uses the backend's defaults.",
+    placeholder: "google,bing,duckduckgo",
+    machine: true,
+  },
+  web_search_max_results: {
+    label: "Max results",
+    help: "Cap on hits per call. A per-tool max_results still overrides it.",
+    placeholder: "10",
+  },
+  web_search_extract: {
+    label: "Extract page content",
+    help: "On: page text is extracted in-process. Off: snippet-only results.",
+    placeholder: "",
+    defaultLabel: "Default (on)",
+  },
+  web_search_intercept: {
+    label: "Intercept provider web search",
+    help: "Run a bare web_search declaration here instead of at the provider. Needs a backend URL.",
+    placeholder: "",
+    defaultLabel: "Default (off)",
+  },
+  web_search_purpose_hint: {
+    label: "Purpose hint",
+    help: "Sent to the backend when a tool entry has none of its own.",
+    placeholder: "Answer from official docs",
+  },
+  sandbox_url: {
+    label: "Backend URL",
+    help: "While unset, otari_code_execution requests are rejected with 400.",
+    placeholder: "http://sandbox:8080",
+    machine: true,
+  },
+  sandbox_session_image: {
+    label: "Session image",
+    help: "The image a leased session runs. Blank lets the backend choose.",
+    placeholder: "mzdotai/otari-sandbox-container:latest",
+    machine: true,
+  },
+  sandbox_purpose_hint: {
+    label: "Purpose hint",
+    help: "Sent to the backend when a tool entry has none of its own.",
+    placeholder: "Run untrusted analysis code",
+  },
+  guardrails_url: {
+    label: "Backend URL",
+    help: "Used when a request does not pass a guardrail URL of its own.",
+    placeholder: "http://guardrails:8000",
+    machine: true,
+  },
+}
+
+function copyFor(field: ToolSettingField): FieldCopy & {
+  defaultLabel?: string
+} {
+  return (
+    FIELD_COPY[field.key] ?? {
+      label: field.key,
+      help: field.description ?? "",
+      placeholder: "",
+      machine: true,
+    }
+  )
+}
+
+interface GroupSpec {
+  title: string
+  blurb: string
+  /** A heading in `docs/tools.md`. */
+  docsAnchor: string
+  keys: string[]
+  /** The group the tool's own per-call price belongs in. */
+  priced?: boolean
+  /** Where a key the backend added but this page has not been told about goes. */
+  catchAll?: boolean
+}
+
+interface ServiceSpec {
   key: ToolServiceName
   label: string
-  blurb: string
-  order: string[]
-  // The pricing key for a tool Otari runs itself. Present only for the two
-  // gateway-run tools: guardrails is a check, not billable work.
+  intro: string
+  docsAnchor: string
+  /** The pricing key for a tool Otari runs itself. Guardrails is a check, not billable work. */
   pricingKey?: string
-  // The /v1/tools id whose calling convention is shown under this service.
-  // Absent for guardrails, which is not declared in `tools[]` at all.
+  /** The `/v1/tools` id whose status heads the page. Guardrails declares none. */
   toolId?: string
-}[] = [
+  groups: GroupSpec[]
+}
+
+const SERVICES: ServiceSpec[] = [
   {
     key: "web_search",
     label: "Web search",
-    blurb:
-      "Backend for otari_web_search tools. A SearXNG-shaped service at the URL below, or a licensed API (web_search_provider), which needs no URL.",
+    intro:
+      "Give models a live search tool and decide which workspaces may use it. Changes apply immediately.",
+    docsAnchor: "web-search",
     pricingKey: "otari:web_search",
     toolId: "otari_web_search",
-    order: [
-      "web_search_url",
-      "web_search_engines",
-      "web_search_max_results",
-      "web_search_extract",
-      "web_search_intercept",
-      "web_search_purpose_hint",
+    groups: [
+      {
+        title: "Backend",
+        blurb:
+          "A SearXNG-shaped service at the URL below, or a licensed API (web_search_provider), which needs no URL.",
+        docsAnchor: "web-search",
+        keys: [
+          "web_search_url",
+          "web_search_engines",
+          "web_search_max_results",
+        ],
+        priced: true,
+      },
+      {
+        title: "Behavior",
+        blurb:
+          "How a search runs once the backend answers. Each default applies unless a request says otherwise.",
+        docsAnchor: "web-search-interception",
+        keys: [
+          "web_search_extract",
+          "web_search_intercept",
+          "web_search_purpose_hint",
+        ],
+        catchAll: true,
+      },
     ],
   },
   {
     key: "sandbox",
     label: "Code execution",
-    blurb:
-      "Backend for otari_code_execution tools (the sandbox that runs generated code).",
+    intro:
+      "Give models a sandbox to run generated code in, and decide which workspaces may use it. Changes apply immediately.",
+    docsAnchor: "code-execution",
     pricingKey: "otari:code_execution",
     toolId: "otari_code_execution",
-    order: ["sandbox_url", "sandbox_session_image", "sandbox_purpose_hint"],
+    groups: [
+      {
+        title: "Backend",
+        blurb: "The sandbox that runs generated code for otari_code_execution.",
+        docsAnchor: "code-execution",
+        keys: ["sandbox_url", "sandbox_session_image"],
+        priced: true,
+      },
+      {
+        title: "Behavior",
+        blurb: "What the gateway sends the sandbox when a request does not.",
+        docsAnchor: "code-execution",
+        keys: ["sandbox_purpose_hint"],
+        catchAll: true,
+      },
+    ],
   },
   {
     key: "guardrails",
     label: "Guardrails",
-    blurb:
-      "Default input-guardrails service used when a request does not pass its own guardrail URL.",
-    order: ["guardrails_url"],
+    intro:
+      "The input-guardrails service this deployment checks requests against, and what your organization mandates.",
+    docsAnchor: "who-runs-a-tool",
+    groups: [
+      {
+        title: "Backend",
+        blurb:
+          "Used when a request does not pass a guardrail URL of its own. Guardrails are a check, so they are never priced.",
+        docsAnchor: "who-runs-a-tool",
+        keys: ["guardrails_url"],
+        catchAll: true,
+      },
+    ],
   },
 ]
 
-// A short-lived confirmation toast, styled to match the app's ConnectionStatus
-// toast (bottom-right), so a save gives visible feedback without a page-level banner.
+const toolsDocs = (anchor?: string) => docsSourceHref("tools.md", anchor)
+
+// Two sibling cards still submit with a Save button of their own and have no
+// row to report into, so they keep the page-level acknowledgement. The setting
+// rows do not use it: each says what happened where it happened.
 function useSaveToast(): [string | null, (message: string) => void] {
   const [message, setMessage] = useState<string | null>(null)
   const timer = useRef<number | undefined>(undefined)
-  const show = (next: string) => {
-    setMessage(next)
-    window.clearTimeout(timer.current)
-    timer.current = window.setTimeout(() => setMessage(null), 2500)
-  }
   useEffect(() => () => window.clearTimeout(timer.current), [])
-  return [message, show]
+  return [
+    message,
+    (next: string) => {
+      setMessage(next)
+      window.clearTimeout(timer.current)
+      timer.current = window.setTimeout(() => setMessage(null), 2500)
+    },
+  ]
 }
 
 function SaveToast({ message }: { message: string | null }) {
@@ -116,533 +254,38 @@ function SaveToast({ message }: { message: string | null }) {
   )
 }
 
-// Every field renders as one grid row with three fixed-width tracks:
-// label | input (16rem) | actions (10rem). Because the input and action tracks
-// have the same width on every row, the boxes and the Save buttons line up in
-// columns down a card regardless of which rows also carry a Test button, an
-// extra help line, or a narrower numeric input. Below `sm` the grid collapses
-// to a single column and the pieces stack.
-//
-// The actions track is sized for the Save button so Save stays column-aligned
-// across every row; on URL rows the trailing Test button is intentionally left
-// to overflow the track's right edge (grid tracks don't clip) rather than
-// widening the track, which would push Save inward and break that alignment.
-const ROW_CLASS =
-  "grid gap-x-4 gap-y-1.5 py-4 sm:grid-cols-[minmax(0,1fr)_16rem_10rem] sm:items-start"
-const INPUT_CELL = `w-full sm:col-start-2 ${INPUT_CLASS}`
-const ACTIONS_CELL = "flex items-center gap-2 sm:col-start-3"
-const MESSAGE_CELL = "flex flex-col gap-1 sm:col-span-2 sm:col-start-2"
-
-function SaveError({ message }: { message?: string }) {
-  if (!message) return null
-  return <span className="break-words text-caption text-danger">{message}</span>
-}
-
-function FieldLabel({
-  field,
-  help,
-}: {
-  field: ToolSettingField
-  help?: string
-}) {
+// A box at the size of what is coming. Drawn here rather than shared: this is
+// the only place in the product holding a settings row's shape open.
+function Placeholder({ className }: { className: string }) {
   return (
-    <div className="min-w-0 sm:col-start-1">
-      <code className="font-mono text-body">{field.key}</code>
-      {field.description ? (
-        // Capped for the reason every full-bleed row's prose is: the row
-        // spans the page, the sentence does not.
-        <p className="mt-1 max-w-prose text-caption">{field.description}</p>
-      ) : null}
-      {help ? <p className="mt-1 text-caption">{help}</p> : null}
-    </div>
-  )
-}
-
-// A URL row: a shared draft that Test probes and Save commits. Test runs against
-// the typed (possibly unsaved) value, so an operator can verify before saving.
-function UrlRow({
-  field,
-  onSave,
-  saveError,
-  disabled,
-}: {
-  field: ToolSettingField
-  onSave: (value: string | null) => void
-  saveError?: string
-  disabled: boolean
-}) {
-  const committed = typeof field.value === "string" ? field.value : ""
-  const [draft, setDraft] = useState(committed)
-  // The URL a still-relevant test result belongs to. A pending request for the old
-  // URL can resolve after the field is edited; only render a result whose URL still
-  // matches the field, so an outcome is never shown against a different URL.
-  const [testedUrl, setTestedUrl] = useState<string | null>(null)
-  const test = useTestService()
-
-  useEffect(() => {
-    setDraft(committed)
-  }, [committed])
-
-  const changed = draft.trim() !== committed
-  const trimmed = draft.trim()
-  const resultMatches = testedUrl !== null && testedUrl === trimmed
-
-  return (
-    <div className={ROW_CLASS}>
-      <FieldLabel
-        field={field}
-        help="Leave blank and Save to fall back to the configured default."
-      />
-      <input
-        type="text"
-        inputMode="url"
-        aria-label={field.key}
-        value={draft}
-        disabled={disabled}
-        placeholder="unset"
-        onChange={(event) => {
-          setDraft(event.target.value)
-          // Drop any prior reachability result so a result for the old URL
-          // never sits beside a newly-typed, untested one. The result render is
-          // also gated on `resultMatches`, which covers a late-resolving request.
-          test.reset()
-        }}
-        className={INPUT_CELL}
-      />
-      <div className={ACTIONS_CELL}>
-        <Button
-          size="sm"
-          variant="primary"
-          aria-label={`Save ${field.key}`}
-          isDisabled={disabled || !changed}
-          onPress={() => onSave(trimmed === "" ? null : trimmed)}
-        >
-          Save
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          aria-label={`Test ${field.service}`}
-          isDisabled={trimmed === "" || test.isPending}
-          onPress={() => {
-            setTestedUrl(trimmed)
-            test.mutate({ service: field.service, url: trimmed })
-          }}
-        >
-          {test.isPending ? "Testing…" : "Test"}
-        </Button>
-      </div>
-      <div className={MESSAGE_CELL}>
-        {/* aria-live so the reachability outcome is announced, not just shown. */}
-        <span
-          role="status"
-          aria-live="polite"
-          className="block break-words text-xs"
-        >
-          {test.isPending || !resultMatches ? null : test.error ? (
-            <span className="text-danger">{errorMessage(test.error)}</span>
-          ) : test.data ? (
-            <span
-              className={
-                test.data.ok ? "font-medium text-success" : "text-danger"
-              }
-            >
-              {test.data.reason}
-            </span>
-          ) : null}
-        </span>
-        <SaveError message={saveError} />
-      </div>
-    </div>
-  )
-}
-
-// A nullable free-text row (engines, purpose hints). Empty clears to the default.
-function TextRow({
-  field,
-  onSave,
-  saveError,
-  disabled,
-}: {
-  field: ToolSettingField
-  onSave: (value: string | null) => void
-  saveError?: string
-  disabled: boolean
-}) {
-  const committed = typeof field.value === "string" ? field.value : ""
-  const [draft, setDraft] = useState(committed)
-
-  useEffect(() => {
-    setDraft(committed)
-  }, [committed])
-
-  const changed = draft !== committed
-
-  return (
-    <div className={ROW_CLASS}>
-      <FieldLabel field={field} />
-      <input
-        type="text"
-        aria-label={field.key}
-        value={draft}
-        disabled={disabled}
-        placeholder="default"
-        onChange={(event) => setDraft(event.target.value)}
-        className={INPUT_CELL}
-      />
-      <div className={ACTIONS_CELL}>
-        <Button
-          size="sm"
-          variant="primary"
-          aria-label={`Save ${field.key}`}
-          isDisabled={disabled || !changed}
-          onPress={() => onSave(draft.trim() === "" ? null : draft.trim())}
-        >
-          Save
-        </Button>
-      </div>
-      {saveError ? (
-        <div className={MESSAGE_CELL}>
-          <SaveError message={saveError} />
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-// A nullable integer row (max_results). Empty clears to the backend default.
-function NumberRow({
-  field,
-  onSave,
-  saveError,
-  disabled,
-}: {
-  field: ToolSettingField
-  onSave: (value: number | null) => void
-  saveError?: string
-  disabled: boolean
-}) {
-  const committed = typeof field.value === "number" ? String(field.value) : ""
-  const [draft, setDraft] = useState(committed)
-
-  useEffect(() => {
-    setDraft(committed)
-  }, [committed])
-
-  const trimmed = draft.trim()
-  const parsed = Number(trimmed)
-  const valid = trimmed === "" || (Number.isInteger(parsed) && parsed >= 1)
-  const changed = valid && trimmed !== committed
-
-  return (
-    <div className={ROW_CLASS}>
-      <FieldLabel
-        field={field}
-        help="Leave blank to use the backend default."
-      />
-      <input
-        type="number"
-        min="1"
-        step="1"
-        inputMode="numeric"
-        aria-label={field.key}
-        value={draft}
-        disabled={disabled}
-        placeholder="default"
-        onChange={(event) => setDraft(event.target.value)}
-        // Narrower than the text inputs but right-aligned in the same column, so
-        // its right edge (and the Save button beside it) still lines up with them.
-        className={`w-full text-right tabular-nums sm:col-start-2 sm:w-28 sm:justify-self-end ${INPUT_CLASS}`}
-      />
-      <div className={ACTIONS_CELL}>
-        <Button
-          size="sm"
-          variant="primary"
-          aria-label={`Save ${field.key}`}
-          isDisabled={disabled || !changed}
-          onPress={() => onSave(trimmed === "" ? null : parsed)}
-        >
-          Save
-        </Button>
-      </div>
-      {saveError ? (
-        <div className={MESSAGE_CELL}>
-          <SaveError message={saveError} />
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-// Per-call price for a tool Otari runs itself.
-//
-// The stored column is `input_price_per_million`, and `flat_request_cost` reads it
-// as USD per *million* calls, so charging a cent a search means storing 10000. That
-// convention is right for the wire and hostile at a keyboard, so this row speaks in
-// dollars per call and does the 1e6 conversion itself. Same reason it lives here
-// rather than on the Models page: a tool is not a model, and the Models editor is
-// labeled per million tokens throughout.
-const PER_MILLION = 1_000_000
-
-function ToolPriceRow({
-  pricingKey,
-  configured,
-  onSave,
-  saving,
-  saveError,
-  disabled,
-}: {
-  pricingKey: string
-  configured: number | null
-  onSave: (perCall: number) => void
-  saving: boolean
-  saveError?: string
-  disabled: boolean
-}) {
-  const committed = configured === null ? "" : String(configured / PER_MILLION)
-  const [draft, setDraft] = useState(committed)
-
-  useEffect(() => {
-    setDraft(committed)
-  }, [committed])
-
-  const trimmed = draft.trim()
-  const parsed = Number(trimmed)
-  const valid = trimmed !== "" && Number.isFinite(parsed) && parsed >= 0
-  const changed = valid && trimmed !== committed
-
-  return (
-    <div className={ROW_CLASS}>
-      <div className="flex flex-col gap-0.5">
-        <span className="text-body">Price per call</span>
-        <span className="text-caption">
-          {configured === null ? (
-            <>
-              Not priced. Calls are recorded but billed nothing, and with{" "}
-              <code className="font-mono">require_pricing</code> on they are
-              refused. Stored as <code className="font-mono">{pricingKey}</code>
-              .
-            </>
-          ) : (
-            <>
-              Charged per call and added to the request that ran it. Stored as{" "}
-              <code className="font-mono">{pricingKey}</code>.
-            </>
-          )}
-        </span>
-      </div>
-      <div className="flex items-center gap-1.5 sm:col-start-2 sm:justify-self-end">
-        <span className="text-caption">USD</span>
-        <input
-          type="number"
-          min="0"
-          step="0.0001"
-          inputMode="decimal"
-          aria-label={`Price per call for ${pricingKey}`}
-          value={draft}
-          disabled={disabled}
-          placeholder="0.00"
-          onChange={(event) => setDraft(event.target.value)}
-          className={`w-full text-right tabular-nums sm:w-28 ${INPUT_CLASS}`}
-        />
-      </div>
-      <div className={ACTIONS_CELL}>
-        <Button
-          size="sm"
-          variant="primary"
-          aria-label={`Save price for ${pricingKey}`}
-          isDisabled={disabled || !changed || saving}
-          onPress={() => onSave(parsed)}
-        >
-          {saving ? "Saving…" : "Save"}
-        </Button>
-      </div>
-      {saveError ? (
-        <div className={MESSAGE_CELL}>
-          <SaveError message={saveError} />
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-// A nullable boolean (web_search_extract) has three meaningful states: default
-// (backend decides, currently on), on, or off. A tri-state select is honest
-// about "default" in a way a two-state toggle cannot be.
-function BoolRow({
-  field,
-  onSave,
-  saveError,
-  disabled,
-}: {
-  field: ToolSettingField
-  onSave: (value: boolean | null) => void
-  saveError?: string
-  disabled: boolean
-}) {
-  // A tri-state select applies on change (like the toggles on the Settings page),
-  // so a discrete choice needs no separate Save; text/number/url rows keep an
-  // explicit Save because they have intermediate, typed-but-unsaved states.
-  const current =
-    field.value === true ? "on" : field.value === false ? "off" : "default"
-  return (
-    <div className={ROW_CLASS}>
-      <FieldLabel field={field} />
-      <div className="sm:col-start-2 sm:justify-self-start">
-        <FilterSelect
-          ariaLabel={field.key}
-          value={current}
-          onChange={(next) => onSave(next === "default" ? null : next === "on")}
-          options={[
-            { value: "default", label: "Default" },
-            { value: "on", label: "On" },
-            { value: "off", label: "Off" },
-          ]}
-          disabled={disabled}
-        />
-      </div>
-      {saveError ? (
-        <div className={MESSAGE_CELL}>
-          <SaveError message={saveError} />
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-// What a client has to send to make the gateway run a tool. This exists because
-// the contract is otherwise invisible: nothing on the page told an operator that
-// `otari_web_search` is the type to declare, or that turning interception on also
-// makes `web_search_20250305` work. Rendered from GET /v1/tools, so it reports
-// what this deployment currently honors rather than a static example.
-function HowToCallCard({ tool }: { tool: ManagedTool }) {
-  const request = {
-    model: "anthropic:claude-sonnet-4-6",
-    messages: [{ role: "user", content: "..." }],
-    tools: [tool.example],
-  }
-  return (
-    <div className="flex flex-col gap-3 py-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <code className="font-mono text-body">{tool.id}</code>
-        {tool.available ? null : (
-          // The reason, stated: a subtle dot and a mono fact, because a tool
-          // with no backend is unavailable rather than broken.
-          <span className="flex items-center gap-2 text-mono-overline text-subtle">
-            <Dot className="bg-text-subtle" />
-            Unavailable — no backend
-          </span>
-        )}
-      </div>
-      <p className="max-w-prose text-sm text-muted">{tool.description}</p>
-      <div className="flex flex-col gap-1">
-        <span className="text-xs font-medium text-foreground">
-          Accepted tools[].type
-        </span>
-        <div className="flex flex-wrap items-center gap-x-1.5">
-          {tool.accepted_types.map((type, index) => (
-            // Mono on the page ground with a separator between entries, not a
-            // boxed chip: these are values to read, and the box was the only
-            // thing making a list of type names look like a set of controls.
-            <span key={type} className="flex items-center gap-1.5">
-              {index > 0 ? (
-                <span aria-hidden className="text-subtle">
-                  ·
-                </span>
-              ) : null}
-              <code className="font-mono text-xs text-foreground">{type}</code>
-            </span>
-          ))}
-        </div>
-      </div>
-      {/* Bounded by rules, not by a border. `border-control-border bg-surface`
-          is the floating-surface recipe, which belongs to things that sit above
-          the page (a popover, a menu); applied to a block that is part of the
-          page it makes a card of it, which is the shape this whole direction
-          removes. The rules say where the example starts and stops, and the
-          block scrolls inside them. */}
-      <pre className="overflow-x-auto border-y border-border py-3 text-xs">
-        <code>{`POST /v1/chat/completions\n${JSON.stringify(request, null, 2)}`}</code>
-      </pre>
-    </div>
-  )
-}
-
-// What a member is shown: the same field, as a value rather than as a control.
-// A disabled input would be the cheaper change and the worse one, since it reads
-// as a form that is briefly unavailable rather than as something this caller
-// does not set. The service-endpoint fields never reach here at all: the server
-// withholds them from a non-operator (otari-ai#1969).
-function ReadOnlyRow({ field }: { field: ToolSettingField }) {
-  const shown =
-    field.value === null || field.value === ""
-      ? "Default"
-      : field.value === true
-        ? "On"
-        : field.value === false
-          ? "Off"
-          : String(field.value)
-  return (
-    <div className={ROW_CLASS}>
-      <FieldLabel field={field} />
-      <span className="break-words text-body sm:col-start-2">{shown}</span>
-    </div>
-  )
-}
-
-function ServiceRow({
-  field,
-  onSave,
-  saveError,
-  disabled,
-  readOnly,
-}: {
-  field: ToolSettingField
-  onSave: (value: boolean | number | string | null) => void
-  saveError?: string
-  disabled: boolean
-  readOnly: boolean
-}) {
-  if (readOnly) {
-    return <ReadOnlyRow field={field} />
-  }
-  if (field.type === "url") {
-    return (
-      <UrlRow
-        field={field}
-        onSave={onSave}
-        saveError={saveError}
-        disabled={disabled}
-      />
-    )
-  }
-  if (field.type === "int") {
-    return (
-      <NumberRow
-        field={field}
-        onSave={onSave}
-        saveError={saveError}
-        disabled={disabled}
-      />
-    )
-  }
-  if (field.type === "bool") {
-    return (
-      <BoolRow
-        field={field}
-        onSave={onSave}
-        saveError={saveError}
-        disabled={disabled}
-      />
-    )
-  }
-  return (
-    <TextRow
-      field={field}
-      onSave={onSave}
-      saveError={saveError}
-      disabled={disabled}
+    <span
+      aria-hidden
+      className={`block animate-pulse bg-surface-subtle motion-reduce:animate-none ${className}`}
     />
+  )
+}
+
+/** The frames, at the real row height, so settings arriving does not move the page. */
+function LoadingGroups() {
+  return (
+    <>
+      {[0, 1].map((group) => (
+        <SettingsGroup bounded key={group}>
+          {[0, 1, 2].map((row) => (
+            <div
+              key={row}
+              className="flex min-h-11 items-center gap-6 px-4 py-3"
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                <Placeholder className="h-4 w-40" />
+                <Placeholder className="h-3.5 w-64" />
+              </div>
+              <Placeholder className="h-8 w-[13.75rem] shrink-0" />
+            </div>
+          ))}
+        </SettingsGroup>
+      ))}
+    </>
   )
 }
 
@@ -653,218 +296,192 @@ function ServiceRow({
  * this page filtered to its own service rather than scrolling one long page.
  * Omitted, every service renders, which is the /tools route the group's parent
  * still points at.
+ *
+ * Every control on the page saves itself: text on blur or Enter, selects on
+ * change, each row reporting its own outcome where it happened. There is no
+ * Save button and no page-level toast, because a page of independent settings
+ * has nothing for one button to be about.
  */
 export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
   // The Tools group is member-visible for the workspace and organization cards
   // below. Of the deployment-wide reads above them, only the tool settings now
   // answer a tenant, without the service endpoints in them (otari-ai#1969), so
-  // that one is asked unconditionally and rendered read-only. The pricing row
-  // and the /v1/search tools stay operator-only on the server, so they are still
-  // gated on the same answer the sidebar uses rather than fired into a 403.
+  // that one is asked unconditionally and rendered read-only. The pricing rows
+  // and the /v1/search tools stay operator-only on the server, so they are
+  // still gated on the same answer the sidebar uses rather than fired into a 403.
   const organization = useOrganizationContext()
   const isOperator = isDeploymentOperator(organization.data)
   const query = useToolSettings()
   const tools = useTools(isOperator)
   const pricing = usePricing(isOperator)
   const setPricing = useSetPricing()
-  const [pricedTool, setPricedTool] = useState<string | null>(null)
-  const [priceErrors, setPriceErrors] = useState<Record<string, string>>({})
-
-  // Latest rate per key. /v1/pricing is history-shaped (one row per effective_at),
-  // and the newest row is the one in force.
-  const currentRates = new Map<string, number>()
-  for (const row of pricing.data ?? []) {
-    const seen = currentRates.get(row.model_key)
-    if (seen === undefined)
-      currentRates.set(row.model_key, row.input_price_per_million)
-  }
-
-  const savePrice = (key: string, perCall: number) => {
-    setPricedTool(key)
-    setPriceErrors((prev) => ({ ...prev, [key]: "" }))
-    setPricing.mutate(
-      {
-        model_key: key,
-        // The stored convention is USD per million calls; the row above collects
-        // dollars per call, so scale here and nowhere else.
-        input_price_per_million: perCall * PER_MILLION,
-        output_price_per_million: 0,
-      },
-      {
-        onSuccess: () => {
-          setPricedTool(null)
-          showToast("Price saved")
-        },
-        onError: (error: unknown) => {
-          setPricedTool(null)
-          setPriceErrors((prev) => ({
-            ...prev,
-            [key]:
-              error instanceof Error
-                ? error.message
-                : "Could not save the price",
-          }))
-        },
-      },
-    )
-  }
   const update = useUpdateToolSettings()
   const [toast, showToast] = useSaveToast()
-  const [errors, setErrors] = useState<Record<string, string>>({})
 
-  const data = query.data
-  const disabled = !data || update.isPending
-
-  const byKey = new Map((data?.fields ?? []).map((field) => [field.key, field]))
-
-  const save = (
-    field: ToolSettingField,
-    value: boolean | number | string | null,
-  ) => {
-    setErrors((prev) => {
-      const { [field.key]: _removed, ...rest } = prev
-      return rest
-    })
-    update.mutate(oneField(field.key, value), {
-      onSuccess: () => showToast(`${field.key} saved`),
-      onError: (error) =>
-        setErrors((prev) => ({ ...prev, [field.key]: errorMessage(error) })),
-    })
+  // Latest rate per key. /v1/pricing is history-shaped (one row per
+  // effective_at), and the newest row is the one in force.
+  const currentRates = new Map<string, number>()
+  for (const row of pricing.data ?? []) {
+    if (!currentRates.has(row.model_key)) {
+      currentRates.set(row.model_key, row.input_price_per_million)
+    }
   }
 
+  const data = query.data
+  const disabled = !data
+  const byKey = new Map((data?.fields ?? []).map((field) => [field.key, field]))
+  const shown = SERVICES.filter((service) => !only || service.key === only)
+  const narrowed = only ? shown[0] : undefined
+
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex max-w-[56rem] flex-col gap-10 pb-10">
       <PageIntro
-        title={
-          only
-            ? (SERVICES.find((service) => service.key === only)?.label ??
-              "Tools & Guardrails")
-            : "Tools & Guardrails"
-        }
+        title={narrowed?.label ?? "Tools & Guardrails"}
+        docsHref={toolsDocs(narrowed?.docsAnchor)}
       >
         {/* Two readings: an operator configures the service endpoints, and a
             caller who does not is told what the deployment's tools do to their
             requests instead of how to configure a backend they cannot reach. */}
         {isOperator
-          ? "Configure the built-in tool and guardrail service endpoints without a restart. Changes apply immediately and persist. URLs are validated for shape (http/https) and can be tested for reachability before saving; the network-safety gates for these services live on the Settings page."
-          : "How this deployment's built-in tools behave on your requests, what your workspace may use of them, and what your organization mandates. The service backends themselves are a deployment operator's to configure."}
+          ? (narrowed?.intro ??
+            "Configure the built-in tool and guardrail service endpoints without a restart. Changes apply immediately and persist.")
+          : "How this deployment's built-in tools behave on your requests, what your workspace may use of them, and what your organization mandates."}
       </PageIntro>
 
       <ErrorBanner error={query.error} />
 
-      {query.isLoading ? <PageLoading /> : null}
+      {query.isLoading ? <LoadingGroups /> : null}
 
-      {SERVICES.filter((service) => !only || service.key === only).map(
-        (service) => {
-          const ordered = service.order
-            .map((key) => byKey.get(key))
-            .filter((f): f is ToolSettingField => f !== undefined)
-          // Any field the backend reports for this service that isn't in `order`
-          // (e.g. a newly added key) still renders, after the ordered ones, so a
-          // backend addition is visible without a frontend change.
-          const extra = (data?.fields ?? []).filter(
-            (f) => f.service === service.key && !service.order.includes(f.key),
-          )
-          const fields = [...ordered, ...extra]
-          // Absent while /v1/tools is still loading, or if it failed: the card is
-          // reference material, so its absence must not hide the editable settings.
-          const managed = service.toolId
-            ? (tools.data?.data ?? []).find(
-                (tool) => tool.id === service.toolId,
-              )
-            : undefined
-          return (
-            <Fragment key={service.key}>
-              {/* The deployment-wide settings list exists only once the
-                  operator-gated read produced this service's fields. The
-                  workspace and organization cards below sit outside this
-                  branch, because their audience is wider than the operator's
-                  and they must not disappear with a read their viewer may not
-                  make. */}
-              {fields.length === 0 ? null : (
-                <section className="flex flex-col gap-2">
-                  {/* The shared settings list rather than a hand-rolled one, so
-                      this cannot pick a separator tier of its own. The heading
-                      is dropped on a filtered view, where the page title
-                      already names the service and repeating it reads as two
-                      headings for the same thing. */}
-                  <SettingsGroup
-                    title={only ? undefined : service.label}
-                    description={service.blurb}
-                  >
-                    {/* Operator-only inside a list a member now also sees: the
-                        rate comes from `/v1/pricing`, whose read is still
-                        operator-gated, so a member would get an editable "Not
-                        priced" row that can only fail on save. */}
-                    {isOperator && service.pricingKey ? (
-                      <ToolPriceRow
-                        pricingKey={service.pricingKey}
-                        configured={
-                          currentRates.get(service.pricingKey) ?? null
-                        }
-                        onSave={(perCall) =>
-                          savePrice(service.pricingKey as string, perCall)
-                        }
-                        saving={pricedTool === service.pricingKey}
-                        saveError={
-                          priceErrors[service.pricingKey] ||
-                          (pricing.error
-                            ? "Could not load the current price. Reload before editing."
-                            : undefined)
-                        }
-                        // Also disabled when the load failed: an errored query leaves
-                        // `configured` null, which renders as "Not priced" and would
-                        // invite an operator to overwrite a rate they cannot see.
-                        disabled={pricing.isLoading || Boolean(pricing.error)}
-                      />
-                    ) : null}
-                    {fields.map((field) => (
-                      <ServiceRow
+      {shown.map((service) => {
+        const managed = service.toolId
+          ? (tools.data?.data ?? []).find((tool) => tool.id === service.toolId)
+          : undefined
+        // Where the "no backend" case sends the operator. Found by type rather
+        // than by position, so it survives a group's keys being reordered.
+        const urlField = (data?.fields ?? []).find(
+          (field) => field.service === service.key && field.type === "url",
+        )
+        const known = new Set(service.groups.flatMap((group) => group.keys))
+        // A key the backend reports for this service that no group lists still
+        // renders, so a backend addition is visible without a frontend change.
+        const unlisted = (data?.fields ?? []).filter(
+          (field) => field.service === service.key && !known.has(field.key),
+        )
+
+        return (
+          <Fragment key={service.key}>
+            {/* The question an operator arrives with, above the settings that
+                answer it: can this deployment run the tool at all. */}
+            {managed ? (
+              <ToolStatusGroup
+                tool={managed}
+                docsHref={toolsDocs(service.docsAnchor)}
+                urlFieldKey={urlField?.key}
+              />
+            ) : null}
+
+            {service.groups.map((group) => {
+              const fields = [
+                ...group.keys
+                  .map((key) => byKey.get(key))
+                  .filter((field): field is ToolSettingField => Boolean(field)),
+                ...(group.catchAll ? unlisted : []),
+              ]
+              // Operator-only inside a group a member also sees: the rate
+              // comes from /v1/pricing, whose read is still operator-gated, so
+              // a member would get an editable "unpriced" row that can only
+              // fail on save.
+              const pricingKey =
+                group.priced && isOperator ? service.pricingKey : undefined
+              if (fields.length === 0 && pricingKey === undefined) return null
+              return (
+                <SettingsGroup
+                  bounded
+                  key={group.title}
+                  // On the combined page the service is not otherwise named,
+                  // and three groups called "Backend" say nothing about which
+                  // service each one configures.
+                  title={
+                    only ? group.title : `${service.label} · ${group.title}`
+                  }
+                  description={group.blurb}
+                  docsHref={toolsDocs(group.docsAnchor)}
+                >
+                  {fields.map((field) => {
+                    const copy = copyFor(field)
+                    return (
+                      <ToolSettingRow
                         key={field.key}
                         field={field}
-                        onSave={(value) => save(field, value)}
-                        saveError={errors[field.key]}
+                        copy={copy}
+                        defaultLabel={copy.defaultLabel}
+                        commit={(key, value) =>
+                          update.mutateAsync(oneField(key, value))
+                        }
                         disabled={disabled}
                         readOnly={!isOperator}
                       />
-                    ))}
-                    {managed ? <HowToCallCard tool={managed} /> : null}
-                  </SettingsGroup>
-                </section>
-              )}
-              {/* Directly below the in-loop web-search settings, because a searxng
+                    )
+                  })}
+                  {pricingKey ? (
+                    <ToolPriceRow
+                      pricingKey={pricingKey}
+                      configured={currentRates.get(pricingKey) ?? null}
+                      commit={(perMillion) =>
+                        setPricing.mutateAsync({
+                          model_key: pricingKey,
+                          input_price_per_million: perMillion,
+                          // A tool call is one unit; there is no output side
+                          // of it to price.
+                          output_price_per_million: 0,
+                        })
+                      }
+                      // Also disabled when the load failed: an errored query
+                      // leaves the rate unknown, and a blur would overwrite a
+                      // price nobody can see.
+                      disabled={pricing.isLoading || Boolean(pricing.error)}
+                      loadError={
+                        pricing.error
+                          ? "Could not read the current price. Reload before editing."
+                          : undefined
+                      }
+                    />
+                  ) : null}
+                </SettingsGroup>
+              )
+            })}
+
+            {/* Directly below the in-loop web-search settings, because a searxng
                 search tool that declares no backend URL of its own inherits the
-                one set just above it. Operator-only, like the settings above:
-                its rows are the deployment's own /v1/search credentials. */}
-              {/* The workspace card goes below both, because it narrows the
-                backend set above it and the /v1/search tools beside it: a
-                workspace switched off may use neither. */}
-              {service.key === "web_search" ? (
-                <>
-                  {isOperator ? <SearchToolsCard onSaved={showToast} /> : null}
-                  <WorkspaceWebSearchCard onSaved={showToast} />
-                </>
-              ) : null}
-              {/* And directly below the sandbox settings, for the same reason:
-                the workspace policy narrows the deployment-wide sandbox set
-                just above it, and reads as nonsense apart from it. */}
-              {service.key === "sandbox" ? (
-                <WorkspaceCodeExecutionPolicyCard onSaved={showToast} />
-              ) : null}
-              {/* And directly below the guardrail settings, which are the
-                deployment-wide half of the same feature: an entry with no
-                endpoint of its own is sent to the URL set just above it. */}
-              {service.key === "guardrails" ? (
-                <OrganizationGuardrailsCard onSaved={showToast} />
-              ) : null}
-            </Fragment>
-          )
-        },
-      )}
+                one set just above it. Operator-only, like those settings: its
+                rows are the deployment's own /v1/search credentials. The
+                workspace group goes below both, because it narrows the backend
+                above it and the /v1/search tools beside it. */}
+            {service.key === "web_search" ? (
+              <>
+                {isOperator ? (
+                  <SearchToolsCard docsHref={toolsDocs("direct-search")} />
+                ) : null}
+                <WorkspaceWebSearchCard
+                  docsHref={toolsDocs("per-workspace-search-policy")}
+                />
+              </>
+            ) : null}
+            {service.key === "sandbox" ? (
+              <WorkspaceCodeExecutionPolicyCard
+                docsHref={toolsDocs("per-workspace-code-policy")}
+              />
+            ) : null}
+            {service.key === "guardrails" ? (
+              <OrganizationGuardrailsCard onSaved={showToast} />
+            ) : null}
+          </Fragment>
+        )
+      })}
 
       {/* Beside the services rather than under one of them, and left out of
-        every narrowed view, each of which is one service. `/tools/mcp-servers`
-        renders the same card. */}
+          every narrowed view, each of which is one service. `/tools/mcp-servers`
+          renders the same card. */}
       {only ? null : <WorkspaceMcpServersCard />}
 
       <SaveToast message={toast} />

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.test.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.test.tsx
@@ -18,6 +18,8 @@ import {
 import { pickOption, selectTrigger } from "@/tests/select"
 
 const ALPHA = "11111111-1111-1111-1111-111111111111"
+const STANCE = "Code execution for this workspace"
+const IMAGE = "Sandbox image for this workspace"
 
 function mockApi({
   memberships = [{ workspace_id: ALPHA, name: "Alpha", role: "admin" }],
@@ -46,14 +48,20 @@ function mockApi({
   return calls
 }
 
-// The form hydrates from the policy once it arrives, so a test that types
-// before then would have its input overwritten by the load. The Save button is
-// disabled while the query is in flight, which is the signal to wait on.
+// Every control is disabled until the policy has arrived, so a save cannot race
+// the load that would overwrite the field under it. That is the signal to wait
+// on before typing.
 async function renderLoaded() {
   renderCard()
+  await waitFor(() => expect(selectTrigger(STANCE)).toBeEnabled())
+}
+
+/** The one PUT body, once the write has gone out. */
+async function putBody(calls: { method: string; body: unknown }[]) {
   await waitFor(() =>
-    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
+    expect(calls.some((call) => call.method === "PUT")).toBe(true),
   )
+  return calls.filter((call) => call.method === "PUT").at(-1)?.body
 }
 
 function renderCard() {
@@ -63,7 +71,7 @@ function renderCard() {
   return render(
     <QueryClientProvider client={client}>
       <SelectedWorkspaceProvider>
-        <WorkspaceCodeExecutionPolicyCard onSaved={() => {}} />
+        <WorkspaceCodeExecutionPolicyCard docsHref="https://docs.example/tools" />
       </SelectedWorkspaceProvider>
     </QueryClientProvider>,
   )
@@ -75,14 +83,14 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     window.localStorage.clear()
   })
 
-  it("reads an unconfigured workspace as using the deployment default", async () => {
+  it("reads an unconfigured workspace as the deployment default, with nothing to narrow", async () => {
     mockApi()
-    renderCard()
+    await renderLoaded()
 
-    expect(await screen.findByText("NO POLICY SET")).toBeInTheDocument()
-    expect(selectTrigger("Code execution")).toHaveTextContent(
-      "Deployment default",
-    )
+    expect(selectTrigger(STANCE)).toHaveTextContent("Deployment default")
+    // There is no stored policy, so the rows below have nothing to write.
+    expect(screen.getByLabelText("Max tool-loop iterations")).toBeDisabled()
+    expect(screen.getByLabelText("Prompt hint")).toBeDisabled()
   })
 
   it("shows a stored policy's stance and limits", async () => {
@@ -97,44 +105,58 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     })
     await renderLoaded()
 
-    expect(selectTrigger("Code execution")).toHaveTextContent("Blocked")
+    expect(selectTrigger(STANCE)).toHaveTextContent("Blocked")
     expect(screen.getByLabelText("Max tool-loop iterations")).toHaveValue("3")
-    expect(screen.getByLabelText("Execution timeout (seconds)")).toHaveValue(
-      "12",
-    )
-    expect(screen.queryByText("No policy set")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Execution timeout")).toHaveValue("12")
   })
 
-  it("saves the stance and the limits the operator typed", async () => {
+  it("saves the stance the moment it changes, with no Save button anywhere", async () => {
     const calls = mockApi()
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Code execution", "Allowed")
-    await user.type(screen.getByLabelText("Max tool-loop iterations"), "4")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await pickOption(user, STANCE, "Allowed")
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toEqual({
+    expect(await putBody(calls)).toEqual({
       enabled: true,
       default_purpose_hint: null,
-      max_iterations: 4,
+      max_iterations: null,
       exec_timeout_s: null,
       image: null,
       tools: null,
     })
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull()
+  })
+
+  it("saves a limit when the field is left", async () => {
+    const calls = mockApi({
+      policy: workspaceCodeExecutionPolicy({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
+    const user = userEvent.setup()
+    await renderLoaded()
+
+    await user.type(screen.getByLabelText("Max tool-loop iterations"), "4")
+    await user.tab()
+
+    expect(await putBody(calls)).toMatchObject({ max_iterations: 4 })
   })
 
   it("offers only the images the operator approved, plus the deployment default", async () => {
     mockApi({
       policy: workspaceCodeExecutionPolicy({
         workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
         allowed_images: ["mzdotai/otari-sandbox-container:latest"],
       }),
     })
     await renderLoaded()
 
-    await userEvent.setup().click(selectTrigger("Sandbox image"))
+    await userEvent.setup().click(selectTrigger(IMAGE))
     expect(
       screen.getAllByRole("option").map((option) => option.textContent),
     ).toEqual(["Deployment default", "mzdotai/otari-sandbox-container:latest"])
@@ -145,31 +167,28 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     await renderLoaded()
 
     expect(
-      screen.queryByRole("button", { name: /Sandbox image$/ }),
+      screen.queryByRole("button", { name: IMAGE }),
     ).not.toBeInTheDocument()
-    expect(screen.getByText(/approved no sandbox images/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/runs whatever the sandbox runs/i),
+    ).toBeInTheDocument()
   })
 
   it("saves the image the operator chose", async () => {
     const calls = mockApi({
       policy: workspaceCodeExecutionPolicy({
         workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
         allowed_images: ["mzdotai/otari-sandbox-container:latest"],
       }),
     })
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Code execution", "Allowed")
-    await pickOption(
-      user,
-      "Sandbox image",
-      "mzdotai/otari-sandbox-container:latest",
-    )
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await pickOption(user, IMAGE, "mzdotai/otari-sandbox-container:latest")
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({
+    expect(await putBody(calls)).toMatchObject({
       image: "mzdotai/otari-sandbox-container:latest",
       tools: null,
     })
@@ -183,7 +202,7 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     await renderLoaded()
 
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
-    expect(screen.getByText(/serves code_execution/i)).toBeInTheDocument()
+    expect(screen.getByText("code_execution only")).toBeInTheDocument()
   })
 
   it("offers a checkbox per tool once the sandbox serves more than one", async () => {
@@ -224,10 +243,8 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     await user.click(
       screen.getByRole("checkbox", { name: "bash_code_execution" }),
     )
-    await user.click(screen.getByRole("button", { name: "Save" }))
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({ tools: null })
+    expect(await putBody(calls)).toMatchObject({ tools: null })
   })
 
   it("preserves a stored tool policy this deployment no longer serves", async () => {
@@ -249,10 +266,9 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
 
     // The operator came here to change something else entirely.
     await user.type(screen.getByLabelText("Max tool-loop iterations"), "4")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.tab()
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({
+    expect(await putBody(calls)).toMatchObject({
       max_iterations: 4,
       tools: ["bash_code_execution"],
     })
@@ -302,11 +318,9 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
         name: "bash_code_execution (no longer served)",
       }),
     )
-    await user.click(screen.getByRole("button", { name: "Save" }))
 
     // Everything served, nothing else: narrows nothing, so no list is stored.
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({ tools: null })
+    expect(await putBody(calls)).toMatchObject({ tools: null })
   })
 
   it("names a withdrawn pin instead of showing it bare", async () => {
@@ -325,7 +339,7 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     })
     await renderLoaded()
 
-    expect(selectTrigger("Sandbox image")).toHaveTextContent(
+    expect(selectTrigger(IMAGE)).toHaveTextContent(
       "ghcr.io/acme/withdrawn:1 (no longer approved)",
     )
     expect(
@@ -345,7 +359,7 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     })
     await renderLoaded()
 
-    expect(selectTrigger("Sandbox image")).toHaveTextContent(
+    expect(selectTrigger(IMAGE)).toHaveTextContent(
       "ghcr.io/acme/withdrawn:1 (no longer approved)",
     )
   })
@@ -363,11 +377,9 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Sandbox image", "Deployment default")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await pickOption(user, IMAGE, "Deployment default")
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({ image: null })
+    expect(await putBody(calls)).toMatchObject({ image: null })
   })
 
   it("shows a stored image", async () => {
@@ -382,9 +394,7 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     })
     await renderLoaded()
 
-    expect(selectTrigger("Sandbox image")).toHaveTextContent(
-      "ghcr.io/acme/sandbox:2",
-    )
+    expect(selectTrigger(IMAGE)).toHaveTextContent("ghcr.io/acme/sandbox:2")
   })
 
   it("clears the policy rather than storing one when set back to the deployment default", async () => {
@@ -398,25 +408,33 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Code execution", "Deployment default")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await pickOption(user, STANCE, "Deployment default")
 
-    expect(calls.some((call) => call.method === "DELETE")).toBe(true)
+    await waitFor(() =>
+      expect(calls.some((call) => call.method === "DELETE")).toBe(true),
+    )
     expect(calls.some((call) => call.method === "PUT")).toBe(false)
   })
 
   it("refuses a limit the deployment could never honor without asking the server", async () => {
-    const calls = mockApi()
+    const calls = mockApi({
+      policy: workspaceCodeExecutionPolicy({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Code execution", "Allowed")
-    await user.type(screen.getByLabelText("Execution timeout (seconds)"), "600")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.type(screen.getByLabelText("Execution timeout"), "600")
+    await user.tab()
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Execution timeout must be a whole number of seconds from 1 to 60.",
-    )
+    expect(
+      await screen.findByText(
+        `A whole number of seconds from 1 to ${MAX_EXEC_TIMEOUT_S}.`,
+      ),
+    ).toBeInTheDocument()
     expect(calls.some((call) => call.method === "PUT")).toBe(false)
   })
 
@@ -460,9 +478,7 @@ describe("WorkspaceCodeExecutionPolicyCard", () => {
     expect(
       await screen.findByText(/set by an owner or admin/i),
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: "Save" }),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Max tool-loop iterations")).toBeNull()
     expect(policyRequests).toEqual([])
   })
 

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
@@ -5,6 +5,7 @@ import {
   PolicyRow,
   parsePhrase,
 } from "@/features/tools/PolicyRow"
+import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import {
   useClearWorkspaceCodeExecutionPolicy,
@@ -74,6 +75,25 @@ export function WorkspaceCodeExecutionPolicyCard({
   const stanceSave = useAutosave()
   const imageSave = useAutosave()
   const toolsSave = useAutosave()
+  // One writer for the group: a PUT replaces the whole policy, so two rows
+  // saving at once would each carry the other's pre-save value.
+  const write = usePolicyWriter({
+    server: query.data,
+    resetKey: selected?.workspace_id ?? "",
+    toBody: (stored) => ({
+      enabled: stored.enabled,
+      default_purpose_hint: stored.default_purpose_hint,
+      max_iterations: stored.max_iterations,
+      exec_timeout_s: stored.exec_timeout_s,
+      image: stored.image,
+      tools: stored.tools,
+    }),
+    put: (body: UpdateWorkspaceCodeExecutionPolicyRequest) =>
+      setPolicy.mutateAsync({
+        workspaceId: selected?.workspace_id as string,
+        body,
+      }),
+  })
 
   if (!selected) {
     return (
@@ -131,22 +151,11 @@ export function WorkspaceCodeExecutionPolicyCard({
   const listedTools = [...availableTools, ...staleTools]
   const storedTools = policy?.tools
 
-  // A PUT replaces the policy, so one field's save carries the rest of it.
+  // `enabled` is the one field a patch always restates: the stance select is
+  // the only control that changes it, and every other row must not flip it.
   const commitField = (
     patch: Partial<UpdateWorkspaceCodeExecutionPolicyRequest>,
-  ) =>
-    setPolicy.mutateAsync({
-      workspaceId: selected.workspace_id,
-      body: {
-        enabled: stance !== "blocked",
-        default_purpose_hint: policy?.default_purpose_hint ?? null,
-        max_iterations: policy?.max_iterations ?? null,
-        exec_timeout_s: policy?.exec_timeout_s ?? null,
-        image: policy?.image ?? null,
-        tools: policy?.tools ?? null,
-        ...patch,
-      },
-    })
+  ) => write({ enabled: stance !== "blocked", ...patch })
 
   // An unset list ticks every box, because that is what it means: the workspace
   // gets whatever the backend serves. Unticking one is therefore a narrowing
@@ -264,7 +273,7 @@ export function WorkspaceCodeExecutionPolicyCard({
         error={imageSave.error}
         note={
           withdrawnImage ? (
-            <p className="text-xs text-warning">
+            <p className="text-caption text-warning">
               This workspace is pinned to an image the operator no longer
               approves, so its requests are refused. Pick another, or ask an
               operator to restore it.
@@ -301,7 +310,7 @@ export function WorkspaceCodeExecutionPolicyCard({
               disabled={narrowingDisabled || imageSave.isSaving}
             />
           ) : (
-            <span className="text-xs text-subtle">
+            <span className="text-caption text-subtle">
               None approved, so this workspace runs whatever the sandbox runs
             </span>
           )
@@ -314,7 +323,7 @@ export function WorkspaceCodeExecutionPolicyCard({
         error={toolsSave.error}
         note={
           staleTools.length > 0 ? (
-            <p className="text-xs text-warning">
+            <p className="text-caption text-warning">
               This workspace's policy names {staleTools.join(", ")}, which this
               deployment's sandbox no longer serves, so its requests are
               refused. Untick it and pick what should be allowed, or set the
@@ -344,7 +353,7 @@ export function WorkspaceCodeExecutionPolicyCard({
               ))}
             </fieldset>
           ) : (
-            <span className="text-xs text-subtle">
+            <span className="text-caption text-subtle">
               {availableTools.length === 1
                 ? `${availableTools[0]} only`
                 : "None served"}

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
@@ -1,7 +1,10 @@
-import { Button } from "@heroui/react"
-import { useEffect, useState } from "react"
-
+import type { UpdateWorkspaceCodeExecutionPolicyRequest } from "@/client"
 import { canManageWorkspace } from "@/features/organization/roles"
+import {
+  ceilingParser,
+  PolicyRow,
+  parsePhrase,
+} from "@/features/tools/PolicyRow"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import {
   useClearWorkspaceCodeExecutionPolicy,
@@ -9,32 +12,30 @@ import {
   useWorkspaceCodeExecutionPolicy,
 } from "@/shared/api/tools"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
-import { errorMessage } from "@/shared/components/feedback/errorMessage"
 import { InfoBanner } from "@/shared/components/feedback/InfoBanner"
 import { Checkbox } from "@/shared/components/forms/Checkbox"
-import { Field } from "@/shared/components/forms/Field"
-import { Dot } from "@/shared/components/indicators/Dot"
-import { Section } from "@/shared/components/layout/Section"
+import { SettingRow } from "@/shared/components/layout/SettingRow"
+import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
 import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
 import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
+import { useAutosave } from "@/shared/hooks/useAutosave"
 
-// The layer above the deployment-wide sandbox settings this card sits under: the
-// settings above say where code runs, this says which workspaces may ask for it
-// and how far. A policy can only narrow, so there is no control here that turns
-// anything on that the deployment has not configured; when it has configured
-// nothing, the banner says so rather than letting the form imply otherwise.
+// The layer above the deployment-wide sandbox settings this group sits under:
+// the settings above say where code runs, this says which workspaces may ask
+// for it and how far. A policy can only narrow, so there is no control here
+// that turns anything on the deployment has not configured.
 //
 // Three states, not two, which is why the first control is a select rather than
 // a toggle: a workspace can be allowed, blocked, or carry no policy at all.
 // "Deployment default" is the last of those and is a delete, not a saved
-// `enabled: true`.
+// `enabled: true`. While it is chosen there is no policy to narrow, so the rows
+// below it have nothing to write and are disabled.
 //
 // The image and tool controls are built from `allowed_images` and
 // `available_tools` on the policy itself rather than from constants here. The
 // image list is the operator's supply-chain allow-list and the server refuses
 // anything outside it, so a free-text field would be offering what the write
-// rejects; when the operator has curated nothing, the picker is replaced by a
-// line saying so.
+// rejects.
 
 type Stance = "default" | "allowed" | "blocked"
 
@@ -47,26 +48,17 @@ const DEPLOYMENT_IMAGE = ""
 export const MAX_ITERATIONS = 25
 export const MAX_EXEC_TIMEOUT_S = 60
 
-function parseCeiling(
-  raw: string,
-  max: number,
-): { value: number | null; valid: boolean } {
-  const trimmed = raw.trim()
-  if (trimmed === "") return { value: null, valid: true }
-  // Digits only, so `0x10` and `1e1` are refused rather than silently read as
-  // 16 and 10 by `Number`.
-  if (!/^\d+$/.test(trimmed)) return { value: null, valid: false }
-  const parsed = Number(trimmed)
-  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > max) {
-    return { value: null, valid: false }
-  }
-  return { value: parsed, valid: true }
-}
-
+/**
+ * Whether requests billed to this workspace may run generated code, and the
+ * limits they run under.
+ *
+ * A policy can only narrow what the deployment above allows; it never grants a
+ * sandbox the deployment has not configured.
+ */
 export function WorkspaceCodeExecutionPolicyCard({
-  onSaved,
+  docsHref,
 }: {
-  onSaved: (message: string) => void
+  docsHref: string
 }) {
   const { selected, isLoading: workspaceLoading } = useSelectedWorkspace()
   const context = useOrganizationContext()
@@ -79,36 +71,9 @@ export function WorkspaceCodeExecutionPolicyCard({
   const query = useWorkspaceCodeExecutionPolicy(workspaceId)
   const setPolicy = useSetWorkspaceCodeExecutionPolicy()
   const clearPolicy = useClearWorkspaceCodeExecutionPolicy()
-
-  const [stance, setStance] = useState<Stance>("default")
-  const [hint, setHint] = useState("")
-  const [maxIterations, setMaxIterations] = useState("")
-  const [execTimeout, setExecTimeout] = useState("")
-  const [image, setImage] = useState(DEPLOYMENT_IMAGE)
-  // `null` is "narrow nothing", which is not the same as an empty selection:
-  // the server refuses an empty list, so unticking the last tool restores the
-  // unnarrowed state rather than saving one nothing can run.
-  const [tools, setTools] = useState<string[] | null>(null)
-  const [error, setError] = useState("")
-
-  const policy = query.data
-  // Hydrate from whatever the server last said, including after a save or a
-  // clear, so the form never drifts from the stored policy.
-  useEffect(() => {
-    if (!policy) return
-    setStance(
-      !policy.configured ? "default" : policy.enabled ? "allowed" : "blocked",
-    )
-    setHint(policy.default_purpose_hint ?? "")
-    setMaxIterations(
-      policy.max_iterations !== null ? String(policy.max_iterations) : "",
-    )
-    setExecTimeout(
-      policy.exec_timeout_s !== null ? String(policy.exec_timeout_s) : "",
-    )
-    setImage(policy.image ?? DEPLOYMENT_IMAGE)
-    setTools(policy.tools)
-  }, [policy])
+  const stanceSave = useAutosave()
+  const imageSave = useAutosave()
+  const toolsSave = useAutosave()
 
   if (!selected) {
     return (
@@ -129,9 +94,19 @@ export function WorkspaceCodeExecutionPolicyCard({
     )
   }
 
-  // Disabled while the policy is in flight, so a save cannot race the load that
-  // would overwrite the form under it.
-  const busy = setPolicy.isPending || clearPolicy.isPending || query.isLoading
+  const policy = query.data
+  const stance: Stance = !policy?.configured
+    ? "default"
+    : policy.enabled
+      ? "allowed"
+      : "blocked"
+
+  // Disabled until the read has succeeded. Without that the rows sit at
+  // "Deployment default" over a workspace that may well have a stored policy,
+  // and one change issues the write that drops it.
+  const unreadable = query.isLoading || query.isError || !policy
+  const narrowingDisabled = unreadable || stance === "default"
+
   const allowedImages = policy?.allowed_images ?? []
   const availableTools = policy?.available_tools ?? []
   // A pin the operator has since withdrawn is still stored, and the server
@@ -154,251 +129,229 @@ export function WorkspaceCodeExecutionPolicyCard({
   // What the checkboxes cover: what is served, plus whatever stale kinds the
   // policy still names, so unticking one is how an operator retires it.
   const listedTools = [...availableTools, ...staleTools]
+  const storedTools = policy?.tools
+
+  // A PUT replaces the policy, so one field's save carries the rest of it.
+  const commitField = (
+    patch: Partial<UpdateWorkspaceCodeExecutionPolicyRequest>,
+  ) =>
+    setPolicy.mutateAsync({
+      workspaceId: selected.workspace_id,
+      body: {
+        enabled: stance !== "blocked",
+        default_purpose_hint: policy?.default_purpose_hint ?? null,
+        max_iterations: policy?.max_iterations ?? null,
+        exec_timeout_s: policy?.exec_timeout_s ?? null,
+        image: policy?.image ?? null,
+        tools: policy?.tools ?? null,
+        ...patch,
+      },
+    })
 
   // An unset list ticks every box, because that is what it means: the workspace
   // gets whatever the backend serves. Unticking one is therefore a narrowing
   // from the full set, not from nothing, and unticking the last leaves nothing
   // to store, which the server refuses, so that end returns to unset.
-  const toggleTool = (tool: string, isSelected: boolean) => {
-    const current = tools ?? availableTools
-    const next = isSelected
-      ? listedTools.filter((name) => current.includes(name) || name === tool)
-      : current.filter((name) => name !== tool)
-    setTools(next.length === 0 ? null : next)
-  }
-
+  //
   // A stored list narrows nothing only when it covers everything served *and*
   // names nothing else. Comparing lengths instead would read a stale
   // `["bash_code_execution"]` against a served `["code_execution"]` as the full
   // set, and save `null` over a policy admission is currently refusing, which
-  // would grant code execution to a workspace whose row denies it, from a save
-  // that meant to change the timeout.
-  const toolsForSave = (): string[] | null => {
-    if (tools === null || tools.length === 0) return null
-    const coversEverythingServed = availableTools.every((name) =>
-      tools.includes(name),
-    )
-    const namesNothingElse = tools.every((name) =>
-      availableTools.includes(name),
-    )
-    return coversEverythingServed && namesNothingElse ? null : tools
-  }
-
-  const save = () => {
-    setError("")
-    if (stance === "default") {
-      clearPolicy.mutate(
-        { workspaceId: selected.workspace_id },
-        {
-          onSuccess: () =>
-            onSaved(`${selected.name} uses the deployment default`),
-          onError: (err) => setError(errorMessage(err)),
-        },
-      )
-      return
-    }
-    const iterations = parseCeiling(maxIterations, MAX_ITERATIONS)
-    const timeout = parseCeiling(execTimeout, MAX_EXEC_TIMEOUT_S)
-    if (!iterations.valid) {
-      setError(
-        `Max iterations must be a whole number from 1 to ${MAX_ITERATIONS}.`,
-      )
-      return
-    }
-    if (!timeout.valid) {
-      setError(
-        `Execution timeout must be a whole number of seconds from 1 to ${MAX_EXEC_TIMEOUT_S}.`,
-      )
-      return
-    }
-    setPolicy.mutate(
-      {
-        workspaceId: selected.workspace_id,
-        body: {
-          enabled: stance === "allowed",
-          default_purpose_hint: hint.trim() === "" ? null : hint.trim(),
-          max_iterations: iterations.value,
-          exec_timeout_s: timeout.value,
-          image: image === DEPLOYMENT_IMAGE ? null : image,
-          tools: toolsForSave(),
-        },
-      },
-      {
-        onSuccess: () =>
-          onSaved(`Code execution policy saved for ${selected.name}`),
-        onError: (err) => setError(errorMessage(err)),
-      },
+  // would grant code execution to a workspace whose row denies it.
+  const toggleTool = (tool: string, isSelected: boolean) => {
+    const current = storedTools ?? availableTools
+    const next = isSelected
+      ? listedTools.filter((name) => current.includes(name) || name === tool)
+      : current.filter((name) => name !== tool)
+    const narrowsNothing =
+      next.length === 0 ||
+      (availableTools.every((name) => next.includes(name)) &&
+        next.every((name) => availableTools.includes(name)))
+    void toolsSave.run(() =>
+      commitField({ tools: narrowsNothing ? null : next }),
     )
   }
 
   return (
-    <Section
-      aria-label={`This workspace (${selected.name})`}
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <SettingsGroup
+      bounded
+      title="This workspace"
+      description={`Narrows what the deployment allows for requests billed to ${selected.name}. Never widens it, and grants no sandbox the deployment has not configured.`}
+      docsHref={docsHref}
     >
-      <div className="flex flex-col gap-2">
-        <h2 className="text-title">This workspace ({selected.name})</h2>
-        <p className="max-w-prose text-sm text-muted">
-          Whether requests billed to this workspace may use
-          otari_code_execution, and the limits they run under. A workspace
-          policy can only narrow what the deployment above allows; it never
-          grants a sandbox the deployment has not configured.
-        </p>
-      </div>
-      <ErrorBanner error={query.error} />
-      {/* A ceiling, not a caution: nothing is broken and nothing on this
-              page can change it, so it reads on the subtle dot. The danger
-              dot is for the things worth acting on. */}
+      {query.error ? (
+        <div className="px-4 py-3">
+          <ErrorBanner error={query.error} />
+        </div>
+      ) : null}
       {policy && !policy.sandbox_configured ? (
-        <InfoBanner>
-          This deployment has no sandbox configured, so code execution is
-          unavailable here whatever this workspace's policy says. The sandbox
-          URL is set above.
-        </InfoBanner>
+        <div className="px-4 py-3">
+          <InfoBanner>
+            This deployment has no sandbox configured, so code execution is
+            unavailable here whatever this workspace's policy says. The sandbox
+            URL is set above.
+          </InfoBanner>
+        </div>
       ) : null}
 
-      <div className="flex flex-wrap items-center gap-3">
-        <FilterSelect
-          label="Code execution"
-          value={stance}
-          onChange={(next) => setStance(next as Stance)}
-          options={[
-            { value: "default", label: "Deployment default" },
-            { value: "allowed", label: "Allowed" },
-            { value: "blocked", label: "Blocked" },
-          ]}
-          disabled={busy}
-        />
-        {policy?.configured === false ? (
-          // The absence of a stored row, stated rather than boxed: this
-          // workspace has not departed from the deployment default.
-          <span className="flex items-center gap-2 text-mono-caption text-subtle">
-            <Dot className="bg-text-subtle" />
-            NO POLICY SET
-          </span>
-        ) : null}
-      </div>
-
-      <Field
-        label="Default prompt hint"
-        value={hint}
-        onChange={setHint}
-        placeholder="Leave blank to use the deployment's hint"
-        description="Used only when a request declares otari_code_execution without a hint of its own."
-      />
-      <Field
-        label="Max tool-loop iterations"
-        value={maxIterations}
-        onChange={setMaxIterations}
-        placeholder={`Blank for the request's own limit (max ${MAX_ITERATIONS})`}
-        description="Lowers the number of model-to-tool rounds. It never raises one."
-      />
-      <Field
-        label="Execution timeout (seconds)"
-        value={execTimeout}
-        onChange={setExecTimeout}
-        placeholder={`Blank for the deployment's ${MAX_EXEC_TIMEOUT_S}s`}
-        description="Lowers how long one execution may run. It never raises it."
-      />
-
-      {allowedImages.length > 0 || withdrawnImage ? (
-        <div className="flex flex-col gap-1">
+      <SettingRow
+        label="Code execution"
+        help="Allow or block the otari_code_execution tool for requests billed here."
+        error={stanceSave.error}
+        control={
           <FilterSelect
-            label="Sandbox image"
-            value={image}
-            onChange={setImage}
+            ariaLabel="Code execution for this workspace"
+            value={stance}
+            onChange={(next) =>
+              void stanceSave.run(() =>
+                next === "default"
+                  ? clearPolicy.mutateAsync({
+                      workspaceId: selected.workspace_id,
+                    })
+                  : commitField({ enabled: next === "allowed" }),
+              )
+            }
             options={[
-              { value: DEPLOYMENT_IMAGE, label: "Deployment default" },
-              ...allowedImages.map((allowed) => ({
-                value: allowed,
-                label: allowed,
-              })),
-              ...(withdrawnImage
-                ? [
-                    {
-                      value: withdrawnImage,
-                      label: `${withdrawnImage} (no longer approved)`,
-                    },
-                  ]
-                : []),
+              { value: "default", label: "Deployment default" },
+              { value: "allowed", label: "Allowed" },
+              { value: "blocked", label: "Blocked" },
             ]}
-            disabled={busy}
+            disabled={unreadable || stanceSave.isSaving}
           />
-          {withdrawnImage ? (
-            <p className="text-caption text-warning">
+        }
+      />
+
+      <PolicyRow
+        key={`hint-${selected.workspace_id}`}
+        label="Prompt hint"
+        help="Used when a request declares otari_code_execution without a hint of its own."
+        placeholder="Show your working"
+        committed={policy?.default_purpose_hint ?? ""}
+        parse={parsePhrase}
+        commit={(default_purpose_hint) => commitField({ default_purpose_hint })}
+        disabled={narrowingDisabled}
+      />
+      <PolicyRow
+        key={`iterations-${selected.workspace_id}`}
+        label="Max tool-loop iterations"
+        help="Lowers the number of model-to-tool rounds. It never raises one."
+        placeholder="10"
+        numeric
+        committed={
+          policy?.max_iterations == null ? "" : String(policy.max_iterations)
+        }
+        parse={ceilingParser(MAX_ITERATIONS, "rounds")}
+        commit={(max_iterations) => commitField({ max_iterations })}
+        disabled={narrowingDisabled}
+      />
+      <PolicyRow
+        key={`timeout-${selected.workspace_id}`}
+        label="Execution timeout"
+        help="Lowers how long one execution may run, in seconds. It never raises it."
+        placeholder="30"
+        numeric
+        committed={
+          policy?.exec_timeout_s == null ? "" : String(policy.exec_timeout_s)
+        }
+        parse={ceilingParser(MAX_EXEC_TIMEOUT_S, "seconds")}
+        commit={(exec_timeout_s) => commitField({ exec_timeout_s })}
+        disabled={narrowingDisabled}
+      />
+
+      <SettingRow
+        label="Sandbox image"
+        help="The image this workspace's code runs in, from the list the operator has approved."
+        error={imageSave.error}
+        note={
+          withdrawnImage ? (
+            <p className="text-xs text-warning">
               This workspace is pinned to an image the operator no longer
               approves, so its requests are refused. Pick another, or ask an
               operator to restore it.
             </p>
+          ) : null
+        }
+        control={
+          allowedImages.length > 0 || withdrawnImage ? (
+            <FilterSelect
+              ariaLabel="Sandbox image for this workspace"
+              value={policy?.image ?? DEPLOYMENT_IMAGE}
+              onChange={(next) =>
+                void imageSave.run(() =>
+                  commitField({
+                    image: next === DEPLOYMENT_IMAGE ? null : next,
+                  }),
+                )
+              }
+              options={[
+                { value: DEPLOYMENT_IMAGE, label: "Deployment default" },
+                ...allowedImages.map((allowed) => ({
+                  value: allowed,
+                  label: allowed,
+                })),
+                ...(withdrawnImage
+                  ? [
+                      {
+                        value: withdrawnImage,
+                        label: `${withdrawnImage} (no longer approved)`,
+                      },
+                    ]
+                  : []),
+              ]}
+              disabled={narrowingDisabled || imageSave.isSaving}
+            />
           ) : (
-            <p className="text-caption">
-              The image this workspace's code runs in, from the list the
-              operator has approved.
-            </p>
-          )}
-        </div>
-      ) : (
-        <p className="text-caption">
-          This deployment has approved no sandbox images, so this workspace runs
-          whatever the sandbox runs. An operator adds them with
-          sandbox_allowed_session_images.
-        </p>
-      )}
+            <span className="text-xs text-subtle">
+              None approved, so this workspace runs whatever the sandbox runs
+            </span>
+          )
+        }
+      />
 
-      {availableTools.length > 1 || staleTools.length > 0 ? (
-        <fieldset className="flex flex-col gap-2">
-          <legend className="text-xs font-medium text-muted">
-            Code-execution tools
-          </legend>
-          <p className="text-caption">
-            Which of the tools this deployment's sandbox serves the workspace
-            may use. Leaving them all ticked narrows nothing; use Blocked above
-            to refuse code execution outright.
-          </p>
-          {listedTools.map((tool) => (
-            <Checkbox
-              key={tool}
-              isSelected={tools === null || tools.includes(tool)}
-              isDisabled={busy}
-              onChange={(isSelected) => toggleTool(tool, isSelected)}
-            >
-              {staleTools.includes(tool) ? `${tool} (no longer served)` : tool}
-            </Checkbox>
-          ))}
-          {staleTools.length > 0 ? (
-            <p className="text-caption text-warning">
+      <SettingRow
+        label="Code-execution tools"
+        help="Which of the tools this deployment's sandbox serves the workspace may use. All ticked narrows nothing."
+        error={toolsSave.error}
+        note={
+          staleTools.length > 0 ? (
+            <p className="text-xs text-warning">
               This workspace's policy names {staleTools.join(", ")}, which this
               deployment's sandbox no longer serves, so its requests are
               refused. Untick it and pick what should be allowed, or set the
               stance to Deployment default to drop the policy.
             </p>
-          ) : null}
-        </fieldset>
-      ) : (
-        // With one tool served there is no subset to choose: ticking and
-        // unticking the single box would both mean "narrow nothing", and a
-        // control that cannot express anything is worse than a sentence
-        // saying so. The checkboxes appear on their own the day a backend
-        // serves a second kind.
-        <p className="text-caption">
-          This deployment's sandbox serves{" "}
-          {availableTools.length === 1 ? availableTools[0] : "no tools"}, so
-          there is no tool subset to choose. Use Blocked above to refuse code
-          execution for this workspace.
-        </p>
-      )}
-
-      {error ? (
-        <p role="alert" className="text-caption text-danger">
-          {error}
-        </p>
-      ) : null}
-      <div className="flex justify-end">
-        <Button size="sm" isDisabled={busy} onPress={save}>
-          Save
-        </Button>
-      </div>
-    </Section>
+          ) : null
+        }
+        control={
+          // With one tool served there is no subset to choose: ticking and
+          // unticking the single box would both mean "narrow nothing", and a
+          // control that cannot express anything is worse than a sentence
+          // saying so. The checkboxes appear the day a backend serves a second.
+          listedTools.length > 1 ? (
+            <fieldset className="flex flex-col gap-1.5">
+              <legend className="sr-only">Code-execution tools</legend>
+              {listedTools.map((tool) => (
+                <Checkbox
+                  key={tool}
+                  isSelected={storedTools == null || storedTools.includes(tool)}
+                  isDisabled={narrowingDisabled || toolsSave.isSaving}
+                  onChange={(isSelected) => toggleTool(tool, isSelected)}
+                >
+                  {staleTools.includes(tool)
+                    ? `${tool} (no longer served)`
+                    : tool}
+                </Checkbox>
+              ))}
+            </fieldset>
+          ) : (
+            <span className="text-xs text-subtle">
+              {availableTools.length === 1
+                ? `${availableTools[0]} only`
+                : "None served"}
+            </span>
+          )
+        }
+      />
+    </SettingsGroup>
   )
 }

--- a/web/src/features/tools/WorkspaceWebSearchCard.test.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.test.tsx
@@ -64,6 +64,14 @@ async function renderLoaded() {
   await waitFor(() => expect(selectTrigger(STANCE)).toBeEnabled())
 }
 
+/** The one PUT body, once the write has gone out. */
+async function putBody(calls: { method: string; body: unknown }[]) {
+  await waitFor(() =>
+    expect(calls.some((call) => call.method === "PUT")).toBe(true),
+  )
+  return calls.filter((call) => call.method === "PUT").at(-1)?.body
+}
+
 describe("WorkspaceWebSearchCard", () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -342,6 +350,94 @@ describe("WorkspaceWebSearchCard", () => {
     ).toBeInTheDocument()
     expect(screen.queryByLabelText("Max results")).toBeNull()
     expect(configRequests).toEqual([])
+  })
+
+  it("does not let a second row's save revert the first", async () => {
+    // Autosave is what opens this: every control has its own save state, so two
+    // rows can be in flight at once, and a PUT body built from the last value
+    // the *query* returned still holds the pre-first-write state.
+    const bodies: Record<string, unknown>[] = []
+    let releaseFirst: (() => void) | undefined
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (!url.includes("/web-search")) {
+        return Response.json(
+          organizationContext({
+            workspace_memberships: [
+              { workspace_id: ALPHA, name: "Alpha", role: "admin" },
+            ],
+          }),
+        )
+      }
+      if ((init?.method ?? "GET") !== "PUT") {
+        return Response.json(
+          workspaceWebSearchConfig({
+            workspace_id: ALPHA,
+            configured: true,
+            enabled: true,
+          }),
+        )
+      }
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      bodies.push(body)
+      if (bodies.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+      }
+      return Response.json(
+        workspaceWebSearchConfig({
+          workspace_id: ALPHA,
+          configured: true,
+          enabled: true,
+          ...body,
+        }),
+      )
+    })
+    const user = userEvent.setup()
+    await renderLoaded()
+
+    await user.type(screen.getByLabelText("Allowed domains"), "arxiv.org")
+    await user.tab()
+    await waitFor(() => expect(bodies).toHaveLength(1))
+
+    // The first write has not answered yet, so the query still holds the row
+    // without the allowed list on it.
+    await user.type(screen.getByLabelText("Blocked domains"), "evil.example")
+    await user.tab()
+    releaseFirst?.()
+
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies[1]).toMatchObject({
+      allowed_domains: ["arxiv.org"],
+      blocked_domains: ["evil.example"],
+    })
+  })
+
+  it("sends only the writable half of the row", async () => {
+    // The stored shape also carries workspace_id, configured, the server's own
+    // web_search_configured and two timestamps. None of them belongs in a PUT.
+    const calls = mockApi({
+      config: workspaceWebSearchConfig({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
+    const user = userEvent.setup()
+    await renderLoaded()
+
+    await user.type(screen.getByLabelText("Max results"), "4")
+    await user.tab()
+
+    expect(Object.keys((await putBody(calls)) as object).sort()).toEqual([
+      "allowed_domains",
+      "blocked_domains",
+      "enabled",
+      "max_results",
+      "provider_options",
+      "purpose_hint",
+    ])
   })
 
   it("keeps its ceiling equal to the one the server enforces", () => {

--- a/web/src/features/tools/WorkspaceWebSearchCard.test.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.test.tsx
@@ -14,6 +14,7 @@ import { organizationContext, workspaceWebSearchConfig } from "@/tests/fixtures"
 import { pickOption, selectTrigger } from "@/tests/select"
 
 const ALPHA = "11111111-1111-1111-1111-111111111111"
+const STANCE = "Web search for this workspace"
 
 function mockApi({
   memberships = [{ workspace_id: ALPHA, name: "Alpha", role: "admin" }],
@@ -42,16 +43,6 @@ function mockApi({
   return calls
 }
 
-// The form hydrates from the row once it arrives, so a test that types before
-// then would have its input overwritten by the load. The Save button is
-// disabled while the query is in flight, which is the signal to wait on.
-async function renderLoaded() {
-  renderCard()
-  await waitFor(() =>
-    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled(),
-  )
-}
-
 function renderCard() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -59,10 +50,18 @@ function renderCard() {
   return render(
     <QueryClientProvider client={client}>
       <SelectedWorkspaceProvider>
-        <WorkspaceWebSearchCard onSaved={() => {}} />
+        <WorkspaceWebSearchCard docsHref="https://docs.example/tools" />
       </SelectedWorkspaceProvider>
     </QueryClientProvider>,
   )
+}
+
+// Every control is disabled until the row has arrived, so a save cannot race
+// the load that would overwrite the field under it. That is the signal to wait
+// on before typing.
+async function renderLoaded() {
+  renderCard()
+  await waitFor(() => expect(selectTrigger(STANCE)).toBeEnabled())
 }
 
 describe("WorkspaceWebSearchCard", () => {
@@ -71,12 +70,14 @@ describe("WorkspaceWebSearchCard", () => {
     window.localStorage.clear()
   })
 
-  it("reads an unconfigured workspace as using the deployment default", async () => {
+  it("reads an unconfigured workspace as the deployment default, with nothing to narrow", async () => {
     mockApi()
-    renderCard()
+    await renderLoaded()
 
-    expect(await screen.findByText("NOTHING SET")).toBeInTheDocument()
-    expect(selectTrigger("Web search")).toHaveTextContent("Deployment default")
+    expect(selectTrigger(STANCE)).toHaveTextContent("Deployment default")
+    // There is no stored row, so the four rows below have nothing to write.
+    expect(screen.getByLabelText("Max results")).toBeDisabled()
+    expect(screen.getByLabelText("Allowed domains")).toBeDisabled()
   })
 
   it("shows a stored row's stance, ceiling and domain lists", async () => {
@@ -92,7 +93,7 @@ describe("WorkspaceWebSearchCard", () => {
     })
     await renderLoaded()
 
-    expect(selectTrigger("Web search")).toHaveTextContent(
+    expect(selectTrigger(STANCE)).toHaveTextContent(
       "Blocked (tool and /v1/search)",
     )
     expect(screen.getByLabelText("Max results")).toHaveValue("3")
@@ -102,33 +103,78 @@ describe("WorkspaceWebSearchCard", () => {
     expect(screen.getByLabelText("Blocked domains")).toHaveValue(
       "example.invalid",
     )
-    expect(screen.queryByText("Nothing set")).not.toBeInTheDocument()
   })
 
-  it("saves the stance, the ceiling and the domains the operator typed", async () => {
+  it("saves the stance the moment it changes, with no Save button anywhere", async () => {
     const calls = mockApi()
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Web search", "Allowed")
+    await pickOption(user, STANCE, "Allowed")
+
+    await waitFor(() =>
+      expect(calls.some((call) => call.method === "PUT")).toBe(true),
+    )
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull()
+  })
+
+  it("saves a ceiling and a domain list when the field is left", async () => {
+    const calls = mockApi({
+      config: workspaceWebSearchConfig({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
+    const user = userEvent.setup()
+    await renderLoaded()
+
     await user.type(screen.getByLabelText("Max results"), "4")
+    await user.tab()
+    await waitFor(() =>
+      expect(calls.find((call) => call.method === "PUT")?.body).toMatchObject({
+        max_results: 4,
+      }),
+    )
+
     await user.type(
       screen.getByLabelText("Blocked domains"),
       "Bad.Example, , other.example",
     )
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.tab()
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toEqual({
-      enabled: true,
-      max_results: 4,
-      purpose_hint: null,
-      allowed_domains: null,
-      // Normalized and de-blanked here so the server is not asked to store a
-      // domain named "".
-      blocked_domains: ["bad.example", "other.example"],
-      provider_options: null,
+    await waitFor(() =>
+      expect(
+        calls.filter((call) => call.method === "PUT").at(-1)?.body,
+      ).toMatchObject({
+        // Normalized and de-blanked here so the server is not asked to store a
+        // domain named "".
+        blocked_domains: ["bad.example", "other.example"],
+      }),
+    )
+  })
+
+  it("commits on Enter without leaving the field by hand", async () => {
+    const calls = mockApi({
+      config: workspaceWebSearchConfig({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
     })
+    const user = userEvent.setup()
+    await renderLoaded()
+
+    await user.type(
+      screen.getByLabelText("Prompt hint"),
+      "Official docs{Enter}",
+    )
+
+    await waitFor(() =>
+      expect(calls.find((call) => call.method === "PUT")?.body).toMatchObject({
+        purpose_hint: "Official docs",
+      }),
+    )
   })
 
   it("preserves provider options it has no form for", async () => {
@@ -145,12 +191,14 @@ describe("WorkspaceWebSearchCard", () => {
     const user = userEvent.setup()
     await renderLoaded()
 
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.type(screen.getByLabelText("Max results"), "4")
+    await user.tab()
 
-    const put = calls.find((call) => call.method === "PUT")
-    expect(put?.body).toMatchObject({
-      provider_options: { search_depth: "advanced" },
-    })
+    await waitFor(() =>
+      expect(calls.find((call) => call.method === "PUT")?.body).toMatchObject({
+        provider_options: { search_depth: "advanced" },
+      }),
+    )
   })
 
   it("clears the row rather than storing one when set back to the deployment default", async () => {
@@ -164,25 +212,33 @@ describe("WorkspaceWebSearchCard", () => {
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Web search", "Deployment default")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await pickOption(user, STANCE, "Deployment default")
 
-    expect(calls.some((call) => call.method === "DELETE")).toBe(true)
+    await waitFor(() =>
+      expect(calls.some((call) => call.method === "DELETE")).toBe(true),
+    )
     expect(calls.some((call) => call.method === "PUT")).toBe(false)
   })
 
   it("refuses a ceiling the backend could never honor without asking the server", async () => {
-    const calls = mockApi()
+    const calls = mockApi({
+      config: workspaceWebSearchConfig({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Web search", "Allowed")
     await user.type(screen.getByLabelText("Max results"), "500")
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.tab()
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Max results must be a whole number from 1 to 20.",
-    )
+    expect(
+      await screen.findByText(
+        `A whole number of results from 1 to ${MAX_RESULTS}.`,
+      ),
+    ).toBeInTheDocument()
     expect(calls.some((call) => call.method === "PUT")).toBe(false)
   })
 
@@ -190,27 +246,32 @@ describe("WorkspaceWebSearchCard", () => {
     // The server matches an entry against a result URL's hostname, so a scheme
     // or a path matches nothing: on a block-list that is a guardrail that reads
     // as set and blocks nothing.
-    const calls = mockApi()
+    const calls = mockApi({
+      config: workspaceWebSearchConfig({
+        workspace_id: ALPHA,
+        configured: true,
+        enabled: true,
+      }),
+    })
     const user = userEvent.setup()
     await renderLoaded()
 
-    await pickOption(user, "Web search", "Allowed")
     await user.type(
       screen.getByLabelText("Blocked domains"),
       "https://evil.example",
     )
-    await user.click(screen.getByRole("button", { name: "Save" }))
+    await user.tab()
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "is not a bare hostname",
-    )
+    expect(
+      await screen.findByText(/is not a bare hostname/),
+    ).toBeInTheDocument()
     expect(calls.some((call) => call.method === "PUT")).toBe(false)
   })
 
-  it("keeps Save disabled when the initial read failed, so a click cannot drop a stored row", async () => {
-    // A failed GET leaves isLoading false and config undefined, so the form sits
-    // at its initial "Deployment default" stance over a workspace that may have
-    // a row. Saving from there would DELETE it.
+  it("keeps every control disabled when the initial read failed, so a change cannot drop a stored row", async () => {
+    // A failed GET leaves isLoading false and config undefined, so the rows sit
+    // at "Deployment default" over a workspace that may have a row, and one
+    // change would DELETE it.
     const calls: { url: string; method: string }[] = []
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input)
@@ -228,9 +289,8 @@ describe("WorkspaceWebSearchCard", () => {
     })
     renderCard()
 
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
-    )
+    await waitFor(() => expect(selectTrigger(STANCE)).toBeDisabled())
+    expect(screen.getByLabelText("Max results")).toBeDisabled()
     expect(calls.some((call) => call.method === "DELETE")).toBe(false)
   })
 
@@ -280,9 +340,7 @@ describe("WorkspaceWebSearchCard", () => {
     expect(
       await screen.findByText(/set by an owner or admin/i),
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: "Save" }),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("Max results")).toBeNull()
     expect(configRequests).toEqual([])
   })
 

--- a/web/src/features/tools/WorkspaceWebSearchCard.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.tsx
@@ -6,6 +6,7 @@ import {
   PolicyRow,
   parsePhrase,
 } from "@/features/tools/PolicyRow"
+import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import {
   useClearWorkspaceWebSearchConfig,
@@ -89,6 +90,28 @@ export function WorkspaceWebSearchCard({ docsHref }: { docsHref: string }) {
   const setConfig = useSetWorkspaceWebSearchConfig()
   const clearConfig = useClearWorkspaceWebSearchConfig()
   const stanceSave = useAutosave()
+  // One writer for the group: a PUT replaces the whole row, so two rows saving
+  // at once would each carry the other's pre-save value.
+  const write = usePolicyWriter({
+    server: query.data,
+    resetKey: selected?.workspace_id ?? "",
+    toBody: (stored) => ({
+      enabled: stored.enabled,
+      max_results: stored.max_results,
+      purpose_hint: stored.purpose_hint,
+      allowed_domains: stored.allowed_domains,
+      blocked_domains: stored.blocked_domains,
+      // Not editable here: an opaque per-backend bag with no form that could
+      // validate it, preserved so a save from the dashboard never clears a
+      // value set over the API.
+      provider_options: stored.provider_options,
+    }),
+    put: (body: UpdateWorkspaceWebSearchConfigRequest) =>
+      setConfig.mutateAsync({
+        workspaceId: selected?.workspace_id as string,
+        body,
+      }),
+  })
 
   if (!selected) {
     return (
@@ -122,23 +145,10 @@ export function WorkspaceWebSearchCard({ docsHref }: { docsHref: string }) {
   const unreadable = query.isLoading || query.isError || !config
   const narrowingDisabled = unreadable || stance === "default"
 
-  // A PUT replaces the row, so one field's save carries the rest of it, and
-  // `provider_options` with them: it is a per-backend bag with no form that
-  // could validate it, and omitting it would silently drop a value set over the
-  // API.
+  // `enabled` is the one field a patch always restates: the stance select is
+  // the only control that changes it, and every other row must not flip it.
   const commitField = (patch: Partial<UpdateWorkspaceWebSearchConfigRequest>) =>
-    setConfig.mutateAsync({
-      workspaceId: selected.workspace_id,
-      body: {
-        enabled: stance !== "blocked",
-        max_results: config?.max_results ?? null,
-        purpose_hint: config?.purpose_hint ?? null,
-        allowed_domains: config?.allowed_domains ?? null,
-        blocked_domains: config?.blocked_domains ?? null,
-        provider_options: config?.provider_options ?? null,
-        ...patch,
-      },
-    })
+    write({ enabled: stance !== "blocked", ...patch })
 
   const setStance = (next: Stance) =>
     void stanceSave.run(() =>

--- a/web/src/features/tools/WorkspaceWebSearchCard.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.tsx
@@ -1,34 +1,35 @@
-import { Button } from "@heroui/react"
-import { useEffect, useState } from "react"
-
+import type { UpdateWorkspaceWebSearchConfigRequest } from "@/client"
 import { canManageWorkspace } from "@/features/organization/roles"
+import {
+  ceilingParser,
+  type Parse,
+  PolicyRow,
+  parsePhrase,
+} from "@/features/tools/PolicyRow"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import {
   useClearWorkspaceWebSearchConfig,
   useSetWorkspaceWebSearchConfig,
   useWorkspaceWebSearchConfig,
 } from "@/shared/api/tools"
-import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
-import { errorMessage } from "@/shared/components/feedback/errorMessage"
 import { InfoBanner } from "@/shared/components/feedback/InfoBanner"
-import { Field } from "@/shared/components/forms/Field"
-import { Dot } from "@/shared/components/indicators/Dot"
-import { Section } from "@/shared/components/layout/Section"
+import { SettingRow } from "@/shared/components/layout/SettingRow"
+import { SettingsGroup } from "@/shared/components/layout/SettingsGroup"
 import { FilterSelect } from "@/shared/components/navigation/FilterSelect"
 import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
+import { useAutosave } from "@/shared/hooks/useAutosave"
 
-// The layer above the deployment-wide web-search settings this card sits under:
-// the settings above say which backend runs a search, this says which
+// The layer above the deployment-wide web-search settings this group sits
+// under: the settings above say which backend runs a search, this says which
 // workspaces may ask for one and how far it may reach. A row can only narrow,
 // so there is no control here that turns anything on the deployment has not
-// configured; when it has configured nothing, the banner says so rather than
-// letting the form imply otherwise.
+// configured.
 //
 // Three states, not two, which is why the first control is a select rather than
 // a toggle: a workspace can be allowed, blocked, or carry no row at all.
 // "Deployment default" is the last of those and is a delete, not a saved
-// `enabled: true`. Same shape as `WorkspaceCodeExecutionPolicyCard`, which is
-// the sibling plane.
+// `enabled: true`. While it is chosen there is no row to narrow, so the four
+// rows below it have nothing to write and are disabled.
 
 type Stance = "default" | "allowed" | "blocked"
 
@@ -36,23 +37,7 @@ type Stance = "default" | "allowed" | "blocked"
 // what the backend honors could never take effect, and the list bound stops one
 // workspace's row growing without limit.
 export const MAX_RESULTS = 20
-export const MAX_DOMAINS = 100
-
-function parseCeiling(
-  raw: string,
-  max: number,
-): { value: number | null; valid: boolean } {
-  const trimmed = raw.trim()
-  if (trimmed === "") return { value: null, valid: true }
-  // Digits only, so `0x10` and `1e1` are refused rather than silently read as
-  // 16 and 10 by `Number`.
-  if (!/^\d+$/.test(trimmed)) return { value: null, valid: false }
-  const parsed = Number(trimmed)
-  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > max) {
-    return { value: null, valid: false }
-  }
-  return { value: parsed, valid: true }
-}
+const MAX_DOMAINS = 100
 
 // Anything that means the entry is not a bare host. The server compares each
 // entry against a result URL's hostname, so a scheme, port or path matches
@@ -65,28 +50,33 @@ const NOT_IN_A_HOSTNAME = /[/:@?#*\\\s]/
 // rather than sent, so a trailing comma is not a domain named "". A leading dot
 // is stripped, matching the server: an entry already covers its subdomains, so
 // `.example.com` is the same rule in cookie syntax.
-function parseDomains(raw: string): {
-  value: string[] | null
-  invalid: string | null
-  tooMany: boolean
-} {
+const parseDomains: Parse<string[] | null> = (raw) => {
   const hosts = raw
     .split(",")
     .map((host) => host.trim().toLowerCase().replace(/^\.+/, ""))
     .filter((host) => host !== "")
-  const invalid = hosts.find((host) => NOT_IN_A_HOSTNAME.test(host)) ?? null
-  return {
-    value: hosts.length > 0 ? hosts : null,
-    invalid,
-    tooMany: hosts.length > MAX_DOMAINS,
+  const malformed = hosts.find((host) => NOT_IN_A_HOSTNAME.test(host))
+  if (malformed !== undefined) {
+    return {
+      value: null,
+      error: `"${malformed}" is not a bare hostname. Give a domain such as example.com, with no scheme, port or path.`,
+    }
   }
+  if (hosts.length > MAX_DOMAINS) {
+    return { value: null, error: `At most ${MAX_DOMAINS} domains.` }
+  }
+  return { value: hosts.length > 0 ? hosts : null, error: "" }
 }
 
-export function WorkspaceWebSearchCard({
-  onSaved,
-}: {
-  onSaved: (message: string) => void
-}) {
+/**
+ * Whether requests billed to this workspace may search the web, and how far a
+ * search may reach.
+ *
+ * Blocking covers both doors: the `otari_web_search` tool and `POST /v1/search`.
+ * The rest narrows the in-loop tool only. Nothing here grants a backend the
+ * deployment has not configured, and nothing here holds a credential.
+ */
+export function WorkspaceWebSearchCard({ docsHref }: { docsHref: string }) {
   const { selected, isLoading: workspaceLoading } = useSelectedWorkspace()
   const context = useOrganizationContext()
   // The client half of the gate the service enforces, and it gates the *read*
@@ -98,27 +88,7 @@ export function WorkspaceWebSearchCard({
   const query = useWorkspaceWebSearchConfig(workspaceId)
   const setConfig = useSetWorkspaceWebSearchConfig()
   const clearConfig = useClearWorkspaceWebSearchConfig()
-
-  const [stance, setStance] = useState<Stance>("default")
-  const [maxResults, setMaxResults] = useState("")
-  const [hint, setHint] = useState("")
-  const [allowedDomains, setAllowedDomains] = useState("")
-  const [blockedDomains, setBlockedDomains] = useState("")
-  const [error, setError] = useState("")
-
-  const config = query.data
-  // Hydrate from whatever the server last said, including after a save or a
-  // clear, so the form never drifts from the stored row.
-  useEffect(() => {
-    if (!config) return
-    setStance(
-      !config.configured ? "default" : config.enabled ? "allowed" : "blocked",
-    )
-    setMaxResults(config.max_results !== null ? String(config.max_results) : "")
-    setHint(config.purpose_hint ?? "")
-    setAllowedDomains((config.allowed_domains ?? []).join(", "))
-    setBlockedDomains((config.blocked_domains ?? []).join(", "))
-  }, [config])
+  const stanceSave = useAutosave()
 
   if (!selected) {
     return (
@@ -139,168 +109,133 @@ export function WorkspaceWebSearchCard({
     )
   }
 
-  // Disabled while the row is in flight, so a save cannot race the load that
-  // would overwrite the form under it, and disabled outright until the read has
-  // succeeded. Without that last part a failed GET leaves `isLoading` false and
-  // `config` undefined, so the form sits at its initial "Deployment default"
-  // stance over a workspace that may well have a stored row, and one click on
-  // an apparently harmless Save issues the DELETE that drops it.
-  const busy =
-    setConfig.isPending ||
-    clearConfig.isPending ||
-    query.isLoading ||
-    query.isError ||
-    !config
+  const config = query.data
+  const stance: Stance = !config?.configured
+    ? "default"
+    : config.enabled
+      ? "allowed"
+      : "blocked"
 
-  const save = () => {
-    setError("")
-    if (stance === "default") {
-      clearConfig.mutate(
-        { workspaceId: selected.workspace_id },
-        {
-          onSuccess: () =>
-            onSaved(`${selected.name} uses the deployment default`),
-          onError: (err) => setError(errorMessage(err)),
-        },
-      )
-      return
-    }
-    const results = parseCeiling(maxResults, MAX_RESULTS)
-    if (!results.valid) {
-      setError(`Max results must be a whole number from 1 to ${MAX_RESULTS}.`)
-      return
-    }
-    const allowed = parseDomains(allowedDomains)
-    const blocked = parseDomains(blockedDomains)
-    if (allowed.tooMany || blocked.tooMany) {
-      setError(`A domain list may name at most ${MAX_DOMAINS} domains.`)
-      return
-    }
-    const malformed = allowed.invalid ?? blocked.invalid
-    if (malformed !== null) {
-      setError(
-        `"${malformed}" is not a bare hostname. Give a domain such as example.com, with no scheme, port or path.`,
-      )
-      return
-    }
-    setConfig.mutate(
-      {
-        workspaceId: selected.workspace_id,
-        body: {
-          enabled: stance === "allowed",
-          max_results: results.value,
-          purpose_hint: hint.trim() === "" ? null : hint.trim(),
-          allowed_domains: allowed.value,
-          blocked_domains: blocked.value,
-          // Not editable here. The opaque provider bag is a per-backend knob
-          // with no form that could validate it, so the card preserves whatever
-          // the API holds rather than clearing it on every save: this is a PUT,
-          // and omitting it would silently drop a value set over the API.
-          provider_options: config?.provider_options ?? null,
-        },
+  // Disabled until the read has succeeded. Without that a failed GET leaves the
+  // rows sitting at "Deployment default" over a workspace that may well have a
+  // stored row, and one blur issues the write that drops it.
+  const unreadable = query.isLoading || query.isError || !config
+  const narrowingDisabled = unreadable || stance === "default"
+
+  // A PUT replaces the row, so one field's save carries the rest of it, and
+  // `provider_options` with them: it is a per-backend bag with no form that
+  // could validate it, and omitting it would silently drop a value set over the
+  // API.
+  const commitField = (patch: Partial<UpdateWorkspaceWebSearchConfigRequest>) =>
+    setConfig.mutateAsync({
+      workspaceId: selected.workspace_id,
+      body: {
+        enabled: stance !== "blocked",
+        max_results: config?.max_results ?? null,
+        purpose_hint: config?.purpose_hint ?? null,
+        allowed_domains: config?.allowed_domains ?? null,
+        blocked_domains: config?.blocked_domains ?? null,
+        provider_options: config?.provider_options ?? null,
+        ...patch,
       },
-      {
-        onSuccess: () =>
-          onSaved(`Web search settings saved for ${selected.name}`),
-        onError: (err) => setError(errorMessage(err)),
-      },
+    })
+
+  const setStance = (next: Stance) =>
+    void stanceSave.run(() =>
+      next === "default"
+        ? clearConfig.mutateAsync({ workspaceId: selected.workspace_id })
+        : commitField({ enabled: next === "allowed" }),
     )
-  }
 
   return (
-    <Section
-      aria-label={`This workspace (${selected.name})`}
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <SettingsGroup
+      bounded
+      title="This workspace"
+      description={`Narrows what the deployment allows for requests billed to ${selected.name}. Never widens it, and holds no credential.`}
+      docsHref={docsHref}
     >
-      <div className="flex flex-col gap-2">
-        <h2 className="text-title">This workspace ({selected.name})</h2>
-        <p className="max-w-prose text-sm text-muted">
-          Whether requests billed to this workspace may search the web, and how
-          far a search may reach. Blocking covers both doors: the
-          otari_web_search tool and POST /v1/search. The rest narrows the
-          in-loop tool only. These settings can only narrow what the deployment
-          above allows; they never grant a backend the deployment has not
-          configured, and they hold no credential.
-        </p>
-      </div>
-      <ErrorBanner error={query.error} />
-      {/* A ceiling, not a caution: nothing is broken and nothing on this
-              page can change it, so it reads on the subtle dot. The danger
-              dot is for the things worth acting on. */}
       {config && !config.web_search_configured ? (
-        <InfoBanner>
-          This deployment has no in-loop search backend configured, so
-          otari_web_search is unavailable here whatever this workspace allows.
-          The search URL is set above. Blocking still takes effect on POST
-          /v1/search, which runs off the search tools below.
-        </InfoBanner>
+        <div className="px-4 py-3">
+          <InfoBanner>
+            This deployment has no in-loop search backend configured, so
+            otari_web_search is unavailable here whatever this workspace allows.
+            Blocking still takes effect on POST /v1/search.
+          </InfoBanner>
+        </div>
       ) : null}
 
-      <div className="flex flex-wrap items-center gap-3">
-        <FilterSelect
-          label="Web search"
-          value={stance}
-          onChange={(next) => setStance(next as Stance)}
-          options={[
-            { value: "default", label: "Deployment default" },
-            { value: "allowed", label: "Allowed" },
-            // Named for what it covers: an admin choosing this is also
-            // switching off the workspace's POST /v1/search calls, which
-            // "Blocked" alone would not have told them.
-            { value: "blocked", label: "Blocked (tool and /v1/search)" },
-          ]}
-          disabled={busy}
-        />
-        {config?.configured === false ? (
-          // The absence of a stored row, stated rather than boxed: this
-          // workspace has not departed from the deployment default.
-          <span className="flex items-center gap-2 text-mono-caption text-subtle">
-            <Dot className="bg-text-subtle" />
-            NOTHING SET
-          </span>
-        ) : null}
-      </div>
+      <SettingRow
+        label="Web search"
+        help="Allow or block the otari_web_search tool and POST /v1/search for requests billed here."
+        error={
+          stanceSave.error ||
+          (query.isError
+            ? "Could not read this workspace's setting. Reload before editing."
+            : "")
+        }
+        control={
+          <FilterSelect
+            ariaLabel="Web search for this workspace"
+            value={stance}
+            onChange={(next) => setStance(next as Stance)}
+            options={[
+              { value: "default", label: "Deployment default" },
+              { value: "allowed", label: "Allowed" },
+              // Named for what it covers: an admin choosing this is also
+              // switching off the workspace's POST /v1/search calls, which
+              // "Blocked" alone would not have told them.
+              { value: "blocked", label: "Blocked (tool and /v1/search)" },
+            ]}
+            disabled={unreadable || stanceSave.isSaving}
+          />
+        }
+      />
 
-      <Field
+      <PolicyRow
+        key={`results-${selected.workspace_id}`}
         label="Max results"
-        value={maxResults}
-        onChange={setMaxResults}
-        placeholder={`Blank for the request's own limit (max ${MAX_RESULTS})`}
-        description="Lowers how many results one search returns. It never raises the number."
+        help="Lowers how many results one search returns. Never raises it."
+        placeholder="10"
+        numeric
+        committed={
+          config?.max_results == null ? "" : String(config.max_results)
+        }
+        parse={ceilingParser(MAX_RESULTS, "results")}
+        commit={(max_results) => commitField({ max_results })}
+        disabled={narrowingDisabled}
       />
-      <Field
+      <PolicyRow
+        key={`hint-${selected.workspace_id}`}
         label="Prompt hint"
-        value={hint}
-        onChange={setHint}
-        placeholder="Leave blank to use the deployment's hint"
-        description="Used only when a request declares otari_web_search without a hint of its own."
+        help="Used when a request declares otari_web_search without a hint of its own."
+        placeholder="Prefer official sources"
+        committed={config?.purpose_hint ?? ""}
+        parse={parsePhrase}
+        commit={(purpose_hint) => commitField({ purpose_hint })}
+        disabled={narrowingDisabled}
       />
-      <Field
+      <PolicyRow
+        key={`allowed-${selected.workspace_id}`}
         label="Allowed domains"
-        value={allowedDomains}
-        onChange={setAllowedDomains}
-        placeholder="Comma separated, blank for no restriction"
-        description="Results are kept only from these domains. A request that names its own list is narrowed to the domains on both."
+        help="Results are kept only from these; a request's own list is narrowed to both."
+        placeholder="mozilla.org, wikipedia.org"
+        machine
+        committed={(config?.allowed_domains ?? []).join(", ")}
+        parse={parseDomains}
+        commit={(allowed_domains) => commitField({ allowed_domains })}
+        disabled={narrowingDisabled}
       />
-      <Field
+      <PolicyRow
+        key={`blocked-${selected.workspace_id}`}
         label="Blocked domains"
-        value={blockedDomains}
-        onChange={setBlockedDomains}
-        placeholder="Comma separated, blank for none"
-        description="Results from these domains are always dropped, whatever a request asks for."
+        help="Always dropped, whatever a request asks for."
+        placeholder="reddit.com, pinterest.com"
+        machine
+        committed={(config?.blocked_domains ?? []).join(", ")}
+        parse={parseDomains}
+        commit={(blocked_domains) => commitField({ blocked_domains })}
+        disabled={narrowingDisabled}
       />
-
-      {error ? (
-        <p role="alert" className="text-caption text-danger">
-          {error}
-        </p>
-      ) : null}
-      <div className="flex justify-end">
-        <Button size="sm" isDisabled={busy} onPress={save}>
-          Save
-        </Button>
-      </div>
-    </Section>
+    </SettingsGroup>
   )
 }

--- a/web/src/features/tools/usePolicyWriter.test.tsx
+++ b/web/src/features/tools/usePolicyWriter.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+
+import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
+
+interface Stored {
+  row: string
+  a: string
+  b: string
+  readOnly: string
+}
+type Body = Pick<Stored, "a" | "b">
+
+/**
+ * A card with two fields over one row, which is the shape both workspace policy
+ * groups have: each field commits the whole body, and the row can change under
+ * them when the operator switches workspace.
+ */
+function Harness({
+  server,
+  put,
+}: {
+  server: Stored
+  put: (body: Body) => Promise<Stored>
+}) {
+  const [row, setRow] = useState(server.row)
+  const write = usePolicyWriter({
+    server: { ...server, row },
+    resetKey: row,
+    toBody: (stored) => ({ a: stored.a, b: stored.b }),
+    put,
+  })
+  return (
+    <>
+      <button type="button" onClick={() => void write({ a: "A!" }).catch(noop)}>
+        save a
+      </button>
+      <button type="button" onClick={() => void write({ b: "B!" }).catch(noop)}>
+        save b
+      </button>
+      <button type="button" onClick={() => setRow("second")}>
+        switch row
+      </button>
+    </>
+  )
+}
+
+const noop = () => undefined
+const press = (user: ReturnType<typeof userEvent.setup>, name: string) =>
+  user.click(screen.getByRole("button", { name }))
+
+describe("usePolicyWriter", () => {
+  it("builds the second body from the first write's answer, not the query", async () => {
+    // The lost update this exists for: each control has its own save state, so
+    // two fields can be in flight at once over one row.
+    const bodies: Body[] = []
+    let release: (() => void) | undefined
+    const put = async (body: Body) => {
+      bodies.push(body)
+      if (bodies.length === 1) {
+        await new Promise<void>((resolve) => {
+          release = resolve
+        })
+      }
+      return { row: "first", readOnly: "server", ...body }
+    }
+    const user = userEvent.setup()
+    render(
+      <Harness
+        server={{ row: "first", a: "a", b: "b", readOnly: "server" }}
+        put={put}
+      />,
+    )
+
+    await press(user, "save a")
+    await press(user, "save b")
+    release?.()
+
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies[1]).toEqual({ a: "A!", b: "B!" })
+  })
+
+  it("sends only what `toBody` names", async () => {
+    const bodies: Body[] = []
+    const user = userEvent.setup()
+    render(
+      <Harness
+        server={{ row: "first", a: "a", b: "b", readOnly: "server" }}
+        put={async (body) => {
+          bodies.push(body)
+          return { row: "first", readOnly: "server", ...body }
+        }}
+      />,
+    )
+
+    await press(user, "save a")
+
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    expect(Object.keys(bodies[0]).sort()).toEqual(["a", "b"])
+  })
+
+  it("does not carry a write that resolves after the row changed", async () => {
+    // The old row's write is still in flight when the operator switches. Its
+    // answer must not become the new row's base, or the next commit builds a
+    // body out of the old row's values and PUTs it to the new one.
+    const bodies: Body[] = []
+    let releaseFirst: (() => void) | undefined
+    const put = async (body: Body) => {
+      bodies.push(body)
+      if (bodies.length === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+        return { row: "first", readOnly: "server", a: "STALE", b: "STALE" }
+      }
+      return { row: "second", readOnly: "server", ...body }
+    }
+    const user = userEvent.setup()
+    render(
+      <Harness
+        server={{ row: "first", a: "a", b: "b", readOnly: "server" }}
+        put={put}
+      />,
+    )
+
+    await press(user, "save a")
+    await press(user, "switch row")
+    // The first row's write answers only now, after the switch.
+    releaseFirst?.()
+    await waitFor(() => expect(bodies).toHaveLength(1))
+
+    await press(user, "save b")
+
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies[1]).toEqual({ a: "a", b: "B!" })
+    expect(bodies[1]).not.toMatchObject({ a: "STALE" })
+  })
+
+  it("keeps writing after one is refused", async () => {
+    const bodies: Body[] = []
+    const put = async (body: Body) => {
+      bodies.push(body)
+      if (bodies.length === 1) throw new Error("refused")
+      return { row: "first", readOnly: "server", ...body }
+    }
+    const user = userEvent.setup()
+    render(
+      <Harness
+        server={{ row: "first", a: "a", b: "b", readOnly: "server" }}
+        put={put}
+      />,
+    )
+
+    await press(user, "save a")
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    await press(user, "save b")
+
+    // The chain is not poisoned, and the refused write left no base behind.
+    await waitFor(() => expect(bodies).toHaveLength(2))
+    expect(bodies[1]).toEqual({ a: "a", b: "B!" })
+  })
+})

--- a/web/src/features/tools/usePolicyWriter.test.tsx
+++ b/web/src/features/tools/usePolicyWriter.test.tsx
@@ -138,6 +138,82 @@ describe("usePolicyWriter", () => {
     expect(bodies[1]).not.toMatchObject({ a: "STALE" })
   })
 
+  it("does not send a commit that was superseded before its turn", async () => {
+    // The escape the store-side guard alone leaves open: A2 is queued behind
+    // an in-flight A1, the row switches, B writes and stores its values as the
+    // carried base, and only then does A1 settle and let A2 run. A2 would read
+    // B's values and PUT them through A's own `put`.
+    const putsByRow: { row: string; body: Body }[] = []
+    let releaseA1: (() => void) | undefined
+    let releaseB: (() => void) | undefined
+
+    function TwoRows() {
+      const [row, setRow] = useState("first")
+      const write = usePolicyWriter({
+        server: {
+          row,
+          a: row === "first" ? "a" : "B-a",
+          b: "b",
+          readOnly: "s",
+        },
+        resetKey: row,
+        toBody: (stored: Stored) => ({ a: stored.a, b: stored.b }),
+        put: async (body: Body) => {
+          const forRow = row
+          putsByRow.push({ row: forRow, body })
+          if (putsByRow.length === 1) {
+            await new Promise<void>((r) => {
+              releaseA1 = r
+            })
+          }
+          if (forRow === "second") {
+            await new Promise<void>((r) => {
+              releaseB = r
+            })
+            return { row: "second", readOnly: "s", a: "B!", b: "B!" }
+          }
+          return { row: forRow, readOnly: "s", ...body }
+        },
+      })
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => void write({ a: "A1" }).catch(noop)}
+          >
+            a1
+          </button>
+          <button
+            type="button"
+            onClick={() => void write({ b: "A2" }).catch(noop)}
+          >
+            a2
+          </button>
+          <button type="button" onClick={() => setRow("second")}>
+            switch
+          </button>
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<TwoRows />)
+
+    await press(user, "a1")
+    await press(user, "a2")
+    await press(user, "switch")
+    await press(user, "a1")
+    releaseB?.()
+    releaseA1?.()
+
+    await waitFor(() => expect(putsByRow.length).toBeGreaterThanOrEqual(2))
+    // A2 never went out at all, so nothing carrying the second row's values
+    // was ever sent through the first row's `put`.
+    expect(
+      putsByRow.filter((p) => p.row === "first" && p.body.b === "A2"),
+    ).toHaveLength(0)
+  })
+
   it("keeps writing after one is refused", async () => {
     const bodies: Body[] = []
     const put = async (body: Body) => {

--- a/web/src/features/tools/usePolicyWriter.ts
+++ b/web/src/features/tools/usePolicyWriter.ts
@@ -1,0 +1,65 @@
+import { useRef, useState } from "react"
+
+/**
+ * Serialized writes for a policy that is stored as one row.
+ *
+ * Both workspace groups PUT the whole policy, so a row's save has to carry the
+ * other rows with it. Autosave is what makes that dangerous: each control has
+ * its own save state by design, so two rows can be in flight at once, and a
+ * body built from the last value the *query* returned would still hold the
+ * pre-first-write state. Leaving one field and immediately editing another
+ * reverted the first.
+ *
+ * So the base for each body is the previous write's own response rather than
+ * the query, and commits are chained rather than fired in parallel. A failed
+ * write does not poison the chain: the next commit still runs, from the last
+ * base known good.
+ */
+export function usePolicyWriter<Body, Stored>({
+  server,
+  resetKey,
+  toBody,
+  put,
+}: {
+  /** The policy as the query last returned it. */
+  server: Stored | undefined
+  /** Changing it drops the carried base, for when the row is a different one. */
+  resetKey: string
+  /**
+   * The writable half of the stored row. Explicit rather than a spread: a
+   * stored policy also carries `workspace_id`, `configured`, the server's own
+   * `allowed_images` and `available_tools` and two timestamps, none of which
+   * belongs in a PUT body.
+   */
+  toBody: (stored: Stored) => Body
+  put: (body: Body) => Promise<Stored>
+}) {
+  const carried = useRef<Stored | undefined>(undefined)
+  const queue = useRef<Promise<unknown>>(Promise.resolve())
+  const [seenKey, setSeenKey] = useState(resetKey)
+
+  if (resetKey !== seenKey) {
+    setSeenKey(resetKey)
+    carried.current = undefined
+  }
+
+  const commit = (patch: Partial<Body>) => {
+    const base = carried.current ?? server
+    if (base === undefined) {
+      return Promise.reject(
+        new Error("The policy has not been read yet, so nothing can be saved."),
+      )
+    }
+    const run = queue.current.then(async () => {
+      // Read inside the chained callback, not outside it: a commit queued
+      // behind another must build on what that one stored, not on the base
+      // that existed when it was queued.
+      const from = carried.current ?? base
+      carried.current = await put({ ...toBody(from), ...patch })
+    })
+    queue.current = run.catch(() => undefined)
+    return run
+  }
+
+  return commit
+}

--- a/web/src/features/tools/usePolicyWriter.ts
+++ b/web/src/features/tools/usePolicyWriter.ts
@@ -36,11 +36,19 @@ export function usePolicyWriter<Body, Stored>({
 }) {
   const carried = useRef<Stored | undefined>(undefined)
   const queue = useRef<Promise<unknown>>(Promise.resolve())
+  // Which row the carried base belongs to. A write that was already in flight
+  // when the row changed still resolves, and without this it would store its
+  // answer as the new row's base: the next commit would build a body out of the
+  // old row's values and PUT it to the new one.
+  const era = useRef(0)
   const [seenKey, setSeenKey] = useState(resetKey)
 
   if (resetKey !== seenKey) {
     setSeenKey(resetKey)
     carried.current = undefined
+    era.current += 1
+    // A commit for the new row must not queue behind the old row's write.
+    queue.current = Promise.resolve()
   }
 
   const commit = (patch: Partial<Body>) => {
@@ -50,12 +58,14 @@ export function usePolicyWriter<Body, Stored>({
         new Error("The policy has not been read yet, so nothing can be saved."),
       )
     }
+    const startedIn = era.current
     const run = queue.current.then(async () => {
       // Read inside the chained callback, not outside it: a commit queued
       // behind another must build on what that one stored, not on the base
       // that existed when it was queued.
       const from = carried.current ?? base
-      carried.current = await put({ ...toBody(from), ...patch })
+      const stored = await put({ ...toBody(from), ...patch })
+      if (startedIn === era.current) carried.current = stored
     })
     queue.current = run.catch(() => undefined)
     return run

--- a/web/src/features/tools/usePolicyWriter.ts
+++ b/web/src/features/tools/usePolicyWriter.ts
@@ -47,7 +47,12 @@ export function usePolicyWriter<Body, Stored>({
     setSeenKey(resetKey)
     carried.current = undefined
     era.current += 1
-    // A commit for the new row must not queue behind the old row's write.
+    // A commit for the new row must not queue behind the old row's write. The
+    // cost is that the queue stops being a single serialization point across a
+    // reset: a callback already pending on the old promise still runs, beside
+    // the new row's chain. The `startedIn` bail-out in `commit` is what carries
+    // that weight, which is why it guards the read and the send, not just the
+    // store.
     queue.current = Promise.resolve()
   }
 
@@ -60,11 +65,21 @@ export function usePolicyWriter<Body, Stored>({
     }
     const startedIn = era.current
     const run = queue.current.then(async () => {
+      // Superseded before it got its turn, so it neither reads the shared base
+      // nor sends. Guarding only the store would be too late: this callback is
+      // orphaned on the previous queue and runs alongside the new row's chain,
+      // so by now `carried.current` can already hold the new row's values, and
+      // building a body out of them would PUT the new row's policy through the
+      // old row's `put`. Resolves rather than rejects: the operator navigated
+      // away, which is not a failed save.
+      if (startedIn !== era.current) return
       // Read inside the chained callback, not outside it: a commit queued
       // behind another must build on what that one stored, not on the base
       // that existed when it was queued.
       const from = carried.current ?? base
       const stored = await put({ ...toBody(from), ...patch })
+      // Checked again on the way out: the row can change while this is in
+      // flight, and the answer belongs to a row nothing is looking at.
       if (startedIn === era.current) carried.current = stored
     })
     queue.current = run.catch(() => undefined)

--- a/web/src/shared/api/tools.ts
+++ b/web/src/shared/api/tools.ts
@@ -249,10 +249,12 @@ export function useSetWorkspaceCodeExecutionPolicy() {
         `/v1/workspaces/${encodeURIComponent(workspaceId)}/code-execution-policy`,
         { method: "PUT", body: JSON.stringify(body) },
       ),
-    onSuccess: (_data, { workspaceId }) => {
-      void queryClient.invalidateQueries({
-        queryKey: [WORKSPACES, workspaceId, "code-execution-policy"],
-      })
+    onSuccess: (data, { workspaceId }) => {
+      // Same as the web-search write above: the response is the stored row.
+      queryClient.setQueryData(
+        [WORKSPACES, workspaceId, "code-execution-policy"],
+        data,
+      )
     },
   })
 }
@@ -306,10 +308,12 @@ export function useSetWorkspaceWebSearchConfig() {
         `/v1/workspaces/${encodeURIComponent(workspaceId)}/web-search`,
         { method: "PUT", body: JSON.stringify(body) },
       ),
-    onSuccess: (_data, { workspaceId }) => {
-      void queryClient.invalidateQueries({
-        queryKey: [WORKSPACES, workspaceId, "web-search"],
-      })
+    onSuccess: (data, { workspaceId }) => {
+      // The PUT answers with the row it just stored, so seeding the cache with
+      // it is both fresher and cheaper than refetching: without this the query
+      // holds the pre-write row until a GET lands, and each save costs two
+      // requests instead of one.
+      queryClient.setQueryData([WORKSPACES, workspaceId, "web-search"], data)
     },
   })
 }

--- a/web/src/shared/components/actions/CopyButton.tsx
+++ b/web/src/shared/components/actions/CopyButton.tsx
@@ -66,6 +66,12 @@ export function CopyButton({
         isIconOnly
         aria-label={`Copy ${label}`}
         onPress={copy}
+        // 32px is under the 44px floor motion-and-access.md sets, and this
+        // button is 32px everywhere it appears. The pseudo-element grows the
+        // target without moving anything, which is the same device the toggle
+        // track uses; 6px each way is the gap a 32px control already has inside
+        // a 44px row, so no two of these overlap.
+        className="relative before:absolute before:-inset-1.5 before:content-['']"
       >
         <FiCopy aria-hidden="true" className="h-3.5 w-3.5" />
       </Button>

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -36,32 +36,11 @@ describe("CopyField", () => {
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
   })
 
-  it("puts the copy control inside the field with no action beside it", () => {
-    // The arrangement is `inFieldCopy`'s to choose, not the action's: a value
-    // an operator copies and then acts on elsewhere wants the same field.
-    render(
-      <CopyField
-        inFieldCopy
-        label="tools[].type"
-        value='"type": "otari_web_search"'
-      />,
-    )
-
-    expect(screen.getByLabelText("tools[].type")).toHaveValue(
-      '"type": "otari_web_search"',
-    )
-    expect(
-      screen.getByRole("button", { name: "Copy tools[].type" }),
-    ).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull()
-  })
-
   it("moves the copy affordance into the field when given an action", () => {
     render(
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
-        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -91,7 +70,6 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
-        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -129,7 +107,6 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
-        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -167,7 +144,6 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
-        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -210,7 +186,6 @@ describe("CopyField", () => {
         label="curl"
         value="one"
         multiline
-        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -36,11 +36,32 @@ describe("CopyField", () => {
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
   })
 
+  it("puts the copy control inside the field with no action beside it", () => {
+    // The arrangement is `inFieldCopy`'s to choose, not the action's: a value
+    // an operator copies and then acts on elsewhere wants the same field.
+    render(
+      <CopyField
+        inFieldCopy
+        label="tools[].type"
+        value='"type": "otari_web_search"'
+      />,
+    )
+
+    expect(screen.getByLabelText("tools[].type")).toHaveValue(
+      '"type": "otari_web_search"',
+    )
+    expect(
+      screen.getByRole("button", { name: "Copy tools[].type" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull()
+  })
+
   it("moves the copy affordance into the field when given an action", () => {
     render(
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
+        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -70,6 +91,7 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
+        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -107,6 +129,7 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
+        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -144,6 +167,7 @@ describe("CopyField", () => {
       <CopyField
         label="TXT record for example.com"
         value="otari-verify=abc"
+        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )
@@ -186,6 +210,7 @@ describe("CopyField", () => {
         label="curl"
         value="one"
         multiline
+        inFieldCopy
         action={<button type="button">Verify domain</button>}
       />,
     )

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -75,7 +75,6 @@ type CopyFieldProps = {
 } & (
   | {
       multiline?: boolean
-      inFieldCopy?: false
       /**
        * Excluded here rather than guarded at runtime, so a call site that passes
        * both fails to compile. The multiline field is a `<textarea>`, where the
@@ -87,19 +86,15 @@ type CopyFieldProps = {
   | {
       multiline?: false
       /**
-       * Put the copy control inside the field and drop the button from the
-       * label row. Right for a value an operator copies and then acts on, where
-       * a separate Copy button competes with the action that follows it.
-       */
-      inFieldCopy: true
-      /**
-       * A control beside the field, for the action the copied value feeds.
+       * A control to sit beside the field, which moves the copy affordance
+       * inside the field and drops the button from the label row. Absent, the
+       * field renders the arrangement it always has.
        *
        * `ReactElement` rather than `ReactNode`: the latter admits `false`, so
        * `action={enabled && <Button />}` compiled and then silently fell back
-       * to the other arrangement, which is the one this exists to replace.
+       * to the default arrangement, which is the one this exists to replace.
        */
-      action?: ReactElement
+      action: ReactElement
     }
 )
 
@@ -108,7 +103,6 @@ export function CopyField({
   value,
   multiline = false,
   fieldRef,
-  inFieldCopy = false,
   action,
 }: CopyFieldProps) {
   const internalRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -150,7 +144,7 @@ export function CopyField({
   const shared =
     "w-full rounded-lg border border-border bg-surface-alt px-3 py-2 font-mono text-xs text-foreground"
 
-  if (inFieldCopy) {
+  if (action !== undefined) {
     return (
       <div className="flex flex-col gap-1">
         {/* The label keeps its own row and stays a real `<label>`: it is what
@@ -161,14 +155,9 @@ export function CopyField({
         </label>
         {/* Wraps below `xl`, where 757px of content does not fit beside the
             rail, so `action` drops to its own line rather than squeezing the
-            field below the width the whole record needs. With no action the
-            field simply takes the width it is given. */}
+            field below the width the whole record needs. */}
         <div className="flex flex-wrap items-center gap-2">
-          <div
-            className={`relative w-full ${
-              action ? "xl:w-[37.5rem] xl:shrink-0" : ""
-            }`}
-          >
+          <div className="relative w-full xl:w-[37.5rem] xl:shrink-0">
             <input
               id={fieldId}
               ref={ref as React.RefObject<HTMLInputElement>}

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -75,6 +75,7 @@ type CopyFieldProps = {
 } & (
   | {
       multiline?: boolean
+      inFieldCopy?: false
       /**
        * Excluded here rather than guarded at runtime, so a call site that passes
        * both fails to compile. The multiline field is a `<textarea>`, where the
@@ -86,15 +87,19 @@ type CopyFieldProps = {
   | {
       multiline?: false
       /**
-       * A control to sit beside the field, which moves the copy affordance
-       * inside the field and drops the button from the label row. Absent, the
-       * field renders the arrangement it always has.
+       * Put the copy control inside the field and drop the button from the
+       * label row. Right for a value an operator copies and then acts on, where
+       * a separate Copy button competes with the action that follows it.
+       */
+      inFieldCopy: true
+      /**
+       * A control beside the field, for the action the copied value feeds.
        *
        * `ReactElement` rather than `ReactNode`: the latter admits `false`, so
        * `action={enabled && <Button />}` compiled and then silently fell back
-       * to the default arrangement, which is the one this exists to replace.
+       * to the other arrangement, which is the one this exists to replace.
        */
-      action: ReactElement
+      action?: ReactElement
     }
 )
 
@@ -103,6 +108,7 @@ export function CopyField({
   value,
   multiline = false,
   fieldRef,
+  inFieldCopy = false,
   action,
 }: CopyFieldProps) {
   const internalRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -144,7 +150,7 @@ export function CopyField({
   const shared =
     "w-full rounded-lg border border-border bg-surface-alt px-3 py-2 font-mono text-xs text-foreground"
 
-  if (action !== undefined) {
+  if (inFieldCopy) {
     return (
       <div className="flex flex-col gap-1">
         {/* The label keeps its own row and stays a real `<label>`: it is what
@@ -155,9 +161,14 @@ export function CopyField({
         </label>
         {/* Wraps below `xl`, where 757px of content does not fit beside the
             rail, so `action` drops to its own line rather than squeezing the
-            field below the width the whole record needs. */}
+            field below the width the whole record needs. With no action the
+            field simply takes the width it is given. */}
         <div className="flex flex-wrap items-center gap-2">
-          <div className="relative w-full xl:w-[37.5rem] xl:shrink-0">
+          <div
+            className={`relative w-full ${
+              action ? "xl:w-[37.5rem] xl:shrink-0" : ""
+            }`}
+          >
             <input
               id={fieldId}
               ref={ref as React.RefObject<HTMLInputElement>}

--- a/web/src/shared/components/layout/PageIntro.tsx
+++ b/web/src/shared/components/layout/PageIntro.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react"
 
+import { DocsLink } from "../navigation/DocsLink"
+
 /**
  * A page's opening: its title, the paragraph under it, and the one action that
  * belongs beside rather than below them.
@@ -19,11 +21,18 @@ import type { ReactNode } from "react"
 export function PageIntro({
   title,
   action,
+  docsHref,
   descriptionClassName = "",
   children,
 }: {
   title: string
   action?: ReactNode
+  /**
+   * Trails the description rather than sitting in `action`: a link to the
+   * manual is not the one thing the page exists to do, and putting it in the
+   * action slot is how a page ends up with two things competing to be that.
+   */
+  docsHref?: string
   /**
    * Overrides the description's measure. One caller uses it: the guide, whose
    * own prose is 560px, so the paragraph introducing it should not be the
@@ -36,9 +45,15 @@ export function PageIntro({
     <header className="flex flex-col gap-4 pb-5 sm:flex-row sm:items-start sm:justify-between">
       <div className="max-w-[38.75rem]">
         <h1 className="text-display">{title}</h1>
-        {children ? (
+        {children || docsHref ? (
           <p className={`mt-1 text-sm text-muted ${descriptionClassName}`}>
             {children}
+            {docsHref ? (
+              <>
+                {children ? " " : null}
+                <DocsLink href={docsHref} />
+              </>
+            ) : null}
           </p>
         ) : null}
       </div>

--- a/web/src/shared/components/layout/SettingRow.test.tsx
+++ b/web/src/shared/components/layout/SettingRow.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SettingRow } from "./SettingRow"
+
+describe("SettingRow", () => {
+  it("names the control by its label and its config key together", () => {
+    // "Backend URL" alone is not unique on a page configuring three services,
+    // and a control's accessible name has to include the visible label.
+    render(
+      <SettingRow
+        label="Backend URL"
+        labelId="row-label"
+        configKey="web_search_url"
+        control={<input aria-labelledby="row-label row-label-key" />}
+      />,
+    )
+
+    expect(
+      screen.getByLabelText("Backend URL web_search_url"),
+    ).toBeInTheDocument()
+  })
+
+  it("says nothing when a save works, so the help line never rewraps", () => {
+    // A confirmation on every row of an autosaving page is a mark the reader
+    // learns to ignore, and one in flow narrows the text column while it shows.
+    render(
+      <SettingRow
+        label="Engines"
+        help="Blank uses the backend's defaults."
+        control={<input aria-label="Engines" />}
+      />,
+    )
+
+    expect(screen.queryByRole("status")).toBeNull()
+    expect(screen.getByText("Blank uses the backend's defaults.")).toBeVisible()
+  })
+
+  it("ties a refused save to the control it came from", () => {
+    render(
+      <SettingRow
+        label="Backend URL"
+        error="Must be an http or https URL."
+        errorId="row-error"
+        control={
+          <input aria-label="Backend URL" aria-describedby="row-error" />
+        }
+      />,
+    )
+
+    expect(screen.getByLabelText("Backend URL")).toHaveAccessibleDescription(
+      "Must be an http or https URL.",
+    )
+  })
+
+  it("draws no rule of its own, because the group divides its children", () => {
+    // A border here would give every seam in a group two lines.
+    const { container } = render(
+      <SettingRow label="Engines" control={<input aria-label="Engines" />} />,
+    )
+
+    expect(container.firstElementChild?.className).not.toMatch(/\bborder/)
+  })
+})

--- a/web/src/shared/components/layout/SettingRow.test.tsx
+++ b/web/src/shared/components/layout/SettingRow.test.tsx
@@ -21,6 +21,24 @@ describe("SettingRow", () => {
     ).toBeInTheDocument()
   })
 
+  it("makes the label a target that focuses the control", () => {
+    // The page is nothing but labelled rows, and on a phone the label sits
+    // directly above its stacked field, so it is a thing people press.
+    render(
+      <SettingRow
+        label="Backend URL"
+        controlId="backend-url"
+        control={<input id="backend-url" aria-label="Backend URL" />}
+      />,
+    )
+
+    expect(screen.getByText("Backend URL").tagName).toBe("LABEL")
+    expect(screen.getByText("Backend URL")).toHaveAttribute(
+      "for",
+      "backend-url",
+    )
+  })
+
   it("says nothing when a save works, so the help line never rewraps", () => {
     // A confirmation on every row of an autosaving page is a mark the reader
     // learns to ignore, and one in flow narrows the text column while it shows.

--- a/web/src/shared/components/layout/SettingRow.tsx
+++ b/web/src/shared/components/layout/SettingRow.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react"
+
+/**
+ * What a setting is on the left, the control that changes it on the right.
+ *
+ * Shared because a settings page is almost entirely this shape, and spelled by
+ * hand the label size, the key caption and the control lane drift between
+ * groups on the same page. The row draws no rules of its own: `SettingsGroup`
+ * divides its children, and a border here would give every seam two lines.
+ *
+ * Only an error may add a line to a row, which is what keeps the help text from
+ * rewrapping under the cursor while a value is being changed.
+ */
+export function SettingRow({
+  label,
+  labelId,
+  configKey,
+  help,
+  control,
+  note,
+  nested = false,
+  error,
+  errorId,
+}: {
+  label: ReactNode
+  /**
+   * Ids the row's own control points at with `aria-labelledby`: this one on the
+   * label, and `<labelId>-key` on the config key beside it. "Backend URL" alone
+   * is not unique on a page that configures three services; "Backend URL
+   * web_search_url" is, and it is what the row actually reads.
+   */
+  labelId?: string
+  /** The config key this row writes, as a mono caption beside the label. */
+  configKey?: string
+  help?: ReactNode
+  control: ReactNode
+  /** An outcome the row reports back (a reachability result), under the help. */
+  note?: ReactNode
+  /**
+   * Indent the row, which is how a row says it belongs to the one above it
+   * rather than being its sibling. Used by a disclosure's panel, whose rows are
+   * children of the row that opened them.
+   */
+  nested?: boolean
+  /** A rejected save, kept beside the value that caused it. */
+  error?: string
+  /** Ties the message to the control through `aria-describedby`. */
+  errorId?: string
+}) {
+  return (
+    <div
+      className={`flex min-h-11 flex-col gap-2.5 py-3 pr-4 md:flex-row md:items-center md:gap-6 ${
+        nested ? "pl-8" : "pl-4"
+      }`}
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span id={labelId} className="text-emphasis">
+            {label}
+          </span>
+          {configKey ? (
+            <code
+              id={labelId && `${labelId}-key`}
+              className="text-mono-micro text-subtle"
+            >
+              {configKey}
+            </code>
+          ) : null}
+        </div>
+        {help ? <p className="text-xs text-subtle">{help}</p> : null}
+        {note}
+        {error ? (
+          <p id={errorId} className="text-caption text-danger">
+            {error}
+          </p>
+        ) : null}
+      </div>
+      <div className="w-full shrink-0 md:w-auto">{control}</div>
+    </div>
+  )
+}

--- a/web/src/shared/components/layout/SettingRow.tsx
+++ b/web/src/shared/components/layout/SettingRow.tsx
@@ -17,6 +17,7 @@ export function SettingRow({
   configKey,
   help,
   control,
+  controlId,
   note,
   nested = false,
   error,
@@ -32,6 +33,13 @@ export function SettingRow({
   labelId?: string
   /** The config key this row writes, as a mono caption beside the label. */
   configKey?: string
+  /**
+   * The control's own `id`, which makes the label a real `<label for>`: on a
+   * page that is nothing but labelled rows, and on a phone where the label sits
+   * directly above its stacked field, the label is a target people press.
+   * `aria-labelledby` still decides the accessible name where both are set.
+   */
+  controlId?: string
   help?: ReactNode
   control: ReactNode
   /** An outcome the row reports back (a reachability result), under the help. */
@@ -55,9 +63,9 @@ export function SettingRow({
     >
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex flex-wrap items-baseline gap-x-2">
-          <span id={labelId} className="text-emphasis">
+          <label id={labelId} htmlFor={controlId} className="text-emphasis">
             {label}
-          </span>
+          </label>
           {configKey ? (
             <code
               id={labelId && `${labelId}-key`}
@@ -67,7 +75,7 @@ export function SettingRow({
             </code>
           ) : null}
         </div>
-        {help ? <p className="text-xs text-subtle">{help}</p> : null}
+        {help ? <p className="text-caption text-subtle">{help}</p> : null}
         {note}
         {error ? (
           <p id={errorId} className="text-caption text-danger">

--- a/web/src/shared/components/layout/SettingsGroup.tsx
+++ b/web/src/shared/components/layout/SettingsGroup.tsx
@@ -79,11 +79,9 @@ export function SettingsGroup({
           </div>
         )}
         {/* `otari-settings` is the dense place, the way `otari-toolbar` is:
-            it declares `--field-height` and `--field-font-size` for everything
-            inside, so a row's control is 32px beside its label on a desk and
-            36px at 16px where it goes full width on a phone. globals.css
-            carries the argument for why a place declares a variable rather
-            than restyling its descendants. */}
+            globals.css sizes `.input` and `.select__trigger` inside it, so a
+            row's control is 32px beside its label on a desk and 44px at 16px
+            where it stacks full width on a phone. A row never picks a height. */}
         <div className="otari-settings flex flex-col divide-y divide-border-subtle border border-border">
           {children}
         </div>

--- a/web/src/shared/components/layout/SettingsGroup.tsx
+++ b/web/src/shared/components/layout/SettingsGroup.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { DocsLink } from "../navigation/DocsLink"
 import { Section } from "./Section"
 
 /**
@@ -11,11 +12,18 @@ import { Section } from "./Section"
  * Two bands rather than one, which is what puts the heading *between* rules
  * rather than above them: the first carries the rule over the heading, the
  * second the rule under it and the rule closing the last row.
+ *
+ * `bounded` is the other shape: the heading sits unruled above a framed block
+ * of rows, inside the page column rather than bleeding to the scroll area's
+ * edges. It reads as one object on a page that stacks several small groups,
+ * where the full-width bands run together into a single striped field.
  */
 export function SettingsGroup({
   title,
   count,
   description,
+  docsHref,
+  bounded = false,
   children,
 }: {
   /**
@@ -33,26 +41,65 @@ export function SettingsGroup({
    * error banner, in the same place.
    */
   description?: ReactNode
+  /** Trails the description, for the page of the manual this group is about. */
+  docsHref?: string
+  /** Frame the rows instead of bleeding them. See the note above. */
+  bounded?: boolean
   children: ReactNode
 }) {
+  const heading =
+    title === undefined ? null : (
+      <h2 className="text-title">
+        {title}
+        {count === undefined ? null : (
+          <span className="font-normal text-subtle"> ({count})</span>
+        )}
+      </h2>
+    )
+  const blurb =
+    description === undefined && docsHref === undefined ? null : (
+      <div className="max-w-prose text-sm text-muted">
+        {description}
+        {docsHref ? (
+          <>
+            {description ? " " : null}
+            <DocsLink href={docsHref} />
+          </>
+        ) : null}
+      </div>
+    )
+
+  if (bounded) {
+    return (
+      <section className="flex flex-col gap-3">
+        {heading === null && blurb === null ? null : (
+          <div className="flex flex-col gap-1">
+            {heading}
+            {blurb}
+          </div>
+        )}
+        {/* `otari-settings` is the dense place, the way `otari-toolbar` is:
+            it declares `--field-height` and `--field-font-size` for everything
+            inside, so a row's control is 32px beside its label on a desk and
+            36px at 16px where it goes full width on a phone. globals.css
+            carries the argument for why a place declares a variable rather
+            than restyling its descendants. */}
+        <div className="otari-settings flex flex-col divide-y divide-border-subtle border border-border">
+          {children}
+        </div>
+      </section>
+    )
+  }
+
   return (
     <>
-      {title === undefined && description === undefined ? null : (
+      {heading === null && blurb === null ? null : (
         <Section
           className="border-t border-border pt-6 pb-3"
           contentClassName="flex flex-col gap-2"
         >
-          {title === undefined ? null : (
-            <h2 className="text-title">
-              {title}
-              {count === undefined ? null : (
-                <span className="font-normal text-subtle"> ({count})</span>
-              )}
-            </h2>
-          )}
-          {description ? (
-            <div className="max-w-prose text-sm text-muted">{description}</div>
-          ) : null}
+          {heading}
+          {blurb}
         </Section>
       )}
       {/* `border-subtle` between the rows, `border` around the group. The two

--- a/web/src/shared/components/navigation/DisclosureRow.test.tsx
+++ b/web/src/shared/components/navigation/DisclosureRow.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+
+import { DisclosureRow } from "./DisclosureRow"
+
+function Harness() {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <DisclosureRow
+      label="Configure search tools"
+      help="None configured, so POST /v1/search refuses every request."
+      trailing={<span>0 tools</span>}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen((open) => !open)}
+    >
+      <p>The panel</p>
+    </DisclosureRow>
+  )
+}
+
+describe("DisclosureRow", () => {
+  it("opens and closes from the pointer, reporting its state", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const row = screen.getByRole("button", { name: /Configure search tools/ })
+    expect(row).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByText("The panel")).toBeNull()
+
+    await user.click(row)
+    expect(row).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("The panel")).toBeInTheDocument()
+
+    await user.click(row)
+    expect(row).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("opens from the keyboard on Enter and on Space", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const row = screen.getByRole("button", { name: /Configure search tools/ })
+
+    await user.tab()
+    expect(row).toHaveFocus()
+
+    await user.keyboard("{Enter}")
+    expect(row).toHaveAttribute("aria-expanded", "true")
+
+    await user.keyboard(" ")
+    expect(row).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("points at the panel it controls", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const row = screen.getByRole("button", { name: /Configure search tools/ })
+
+    await user.click(row)
+
+    const panelId = row.getAttribute("aria-controls")
+    expect(panelId).toBeTruthy()
+    expect(document.getElementById(String(panelId))).toHaveTextContent(
+      "The panel",
+    )
+  })
+
+  it("makes the whole row the target, not the chevron", () => {
+    // A chevron is a 16px glyph. Making it the control puts a 16px target in a
+    // 44px row, which is the mistake this component exists to prevent.
+    render(<Harness />)
+    const row = screen.getByRole("button", { name: /Configure search tools/ })
+
+    expect(row.className).toContain("w-full")
+    expect(row.className).toContain("min-h-11")
+    expect(screen.queryAllByRole("button")).toHaveLength(1)
+  })
+})

--- a/web/src/shared/components/navigation/DisclosureRow.test.tsx
+++ b/web/src/shared/components/navigation/DisclosureRow.test.tsx
@@ -27,14 +27,17 @@ describe("DisclosureRow", () => {
 
     const row = screen.getByRole("button", { name: /Configure search tools/ })
     expect(row).toHaveAttribute("aria-expanded", "false")
-    expect(screen.queryByText("The panel")).toBeNull()
+    // Present but hidden, not unmounted: `aria-controls` has to name an element
+    // that exists even while the row is closed.
+    expect(screen.getByText("The panel")).not.toBeVisible()
 
     await user.click(row)
     expect(row).toHaveAttribute("aria-expanded", "true")
-    expect(screen.getByText("The panel")).toBeInTheDocument()
+    expect(screen.getByText("The panel")).toBeVisible()
 
     await user.click(row)
     expect(row).toHaveAttribute("aria-expanded", "false")
+    expect(screen.getByText("The panel")).not.toBeVisible()
   })
 
   it("opens from the keyboard on Enter and on Space", async () => {
@@ -57,13 +60,16 @@ describe("DisclosureRow", () => {
     render(<Harness />)
     const row = screen.getByRole("button", { name: /Configure search tools/ })
 
-    await user.click(row)
-
+    // Named before it is opened, which is the point: a collapsed row must not
+    // point `aria-controls` at an id nothing has.
     const panelId = row.getAttribute("aria-controls")
     expect(panelId).toBeTruthy()
     expect(document.getElementById(String(panelId))).toHaveTextContent(
       "The panel",
     )
+
+    await user.click(row)
+    expect(document.getElementById(String(panelId))).toBeVisible()
   })
 
   it("makes the whole row the target, not the chevron", () => {

--- a/web/src/shared/components/navigation/DisclosureRow.tsx
+++ b/web/src/shared/components/navigation/DisclosureRow.tsx
@@ -42,7 +42,9 @@ export function DisclosureRow({
       >
         <span className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="text-emphasis">{label}</span>
-          {help ? <span className="text-xs text-subtle">{help}</span> : null}
+          {help ? (
+            <span className="text-caption text-subtle">{help}</span>
+          ) : null}
         </span>
         <span className="flex shrink-0 items-center gap-3">
           {trailing}

--- a/web/src/shared/components/navigation/DisclosureRow.tsx
+++ b/web/src/shared/components/navigation/DisclosureRow.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react"
+import { useId } from "react"
+import { FiChevronRight } from "react-icons/fi"
+
+/**
+ * A settings row that opens in place, for detail that belongs to the row rather
+ * than beside it.
+ *
+ * The whole row is the button, which is what keeps the target at the row's own
+ * size: a chevron is a 16px glyph, and making it the control puts a 16px target
+ * in a 44px row. No press transform either, unlike an action button: a row is a
+ * surface, and a surface that shrinks under the finger reads as a misfire.
+ *
+ * Two children of a `SettingsGroup`, not one, so the group's own divider draws
+ * the line between the row and the panel it opened.
+ */
+export function DisclosureRow({
+  label,
+  help,
+  trailing,
+  isOpen,
+  onToggle,
+  children,
+}: {
+  label: ReactNode
+  help?: ReactNode
+  /** A count or a status, to the left of the chevron. */
+  trailing?: ReactNode
+  isOpen: boolean
+  onToggle: () => void
+  children: ReactNode
+}) {
+  const panelId = useId()
+  return (
+    <>
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={onToggle}
+        className="flex min-h-11 w-full items-center gap-6 px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-surface-subtle focus-visible:otari-focus-ring motion-reduce:transition-none"
+      >
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-emphasis">{label}</span>
+          {help ? <span className="text-xs text-subtle">{help}</span> : null}
+        </span>
+        <span className="flex shrink-0 items-center gap-3">
+          {trailing}
+          <FiChevronRight
+            aria-hidden="true"
+            className={`h-4 w-4 text-subtle transition-transform duration-150 ease-out motion-reduce:transition-none ${
+              isOpen ? "rotate-90" : ""
+            }`}
+          />
+        </span>
+      </button>
+      {isOpen ? <div id={panelId}>{children}</div> : null}
+    </>
+  )
+}

--- a/web/src/shared/components/navigation/DisclosureRow.tsx
+++ b/web/src/shared/components/navigation/DisclosureRow.tsx
@@ -56,7 +56,13 @@ export function DisclosureRow({
           />
         </span>
       </button>
-      {isOpen ? <div id={panelId}>{children}</div> : null}
+      {/* Rendered whether or not it is open, so `aria-controls` above always
+          names an element that exists. `hidden` rather than unmounting: an
+          attribute pointing at nothing is worse than a hidden panel, and the
+          rows inside cost nothing when the browser is not painting them. */}
+      <div id={panelId} hidden={!isOpen}>
+        {children}
+      </div>
     </>
   )
 }

--- a/web/src/shared/components/navigation/DocsLink.tsx
+++ b/web/src/shared/components/navigation/DocsLink.tsx
@@ -1,0 +1,28 @@
+import { FiArrowUpRight } from "react-icons/fi"
+
+/**
+ * A link out to the documentation, at the end of the sentence it explains.
+ *
+ * Always external: `href` names a deployment's own documentation site or a
+ * document rendered outside this app, never a route the router owns. The arrow
+ * is the external mark, so it is `aria-hidden` and the name stays the word.
+ */
+export function DocsLink({
+  href,
+  children = "Docs",
+}: {
+  href: string
+  children?: string
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-0.5 text-link transition-colors duration-150 ease-out hover:text-link-hover focus-visible:otari-focus-ring motion-reduce:transition-none"
+    >
+      {children}
+      <FiArrowUpRight aria-hidden="true" className="h-3 w-3" />
+    </a>
+  )
+}

--- a/web/src/shared/helpers/docs.ts
+++ b/web/src/shared/helpers/docs.ts
@@ -1,0 +1,14 @@
+/**
+ * Where a repository document is actually rendered.
+ *
+ * Only `docs/dashboard.md` is bundled into the dashboard, so its own relative
+ * links cannot resolve inside the SPA and neither can a link to a sibling
+ * document. GitHub is where both go. Pointing a "Docs" link at `/#/docs`
+ * instead would land on a guide that has no section by that name.
+ */
+export const DOCS_SOURCE_BASE =
+  "https://github.com/mozilla-ai/otari/blob/main/docs/"
+
+export function docsSourceHref(doc: string, anchor?: string): string {
+  return `${DOCS_SOURCE_BASE}${doc}${anchor ? `#${anchor}` : ""}`
+}

--- a/web/src/shared/hooks/useAutosave.test.tsx
+++ b/web/src/shared/hooks/useAutosave.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { useAutosave } from "@/shared/hooks/useAutosave"
+
+function Harness({ commit }: { commit: () => Promise<unknown> }) {
+  const save = useAutosave()
+  return (
+    <>
+      <button
+        type="button"
+        disabled={save.isSaving}
+        onClick={() => void save.run(commit)}
+      >
+        Commit
+      </button>
+      <span data-testid="error">{save.error}</span>
+    </>
+  )
+}
+
+const commitButton = () => screen.getByRole("button", { name: "Commit" })
+const error = () => screen.getByTestId("error")
+
+describe("useAutosave", () => {
+  it("says nothing when a save works", async () => {
+    // No confirmation, no timer to clear: the page saves as you leave a field,
+    // and a mark on every row is one the reader learns to ignore.
+    const user = userEvent.setup()
+    render(<Harness commit={() => Promise.resolve()} />)
+
+    await user.click(commitButton())
+
+    await waitFor(() => expect(commitButton()).toBeEnabled())
+    expect(error()).toBeEmptyDOMElement()
+    expect(screen.queryByRole("status")).toBeNull()
+  })
+
+  it("holds the control while a save is in flight", async () => {
+    const user = userEvent.setup()
+    let release: () => void = () => {}
+    const pending = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    render(<Harness commit={() => pending} />)
+
+    await user.click(commitButton())
+    expect(commitButton()).toBeDisabled()
+
+    release()
+    await waitFor(() => expect(commitButton()).toBeEnabled())
+  })
+
+  it("keeps a refused save's message", async () => {
+    // The value that caused it is still in the field, so the message stays
+    // until the next attempt.
+    const user = userEvent.setup()
+    render(
+      <Harness commit={() => Promise.reject(new Error("Must be a URL."))} />,
+    )
+
+    await user.click(commitButton())
+
+    await waitFor(() => expect(error()).toHaveTextContent("Must be a URL."))
+    expect(commitButton()).toBeEnabled()
+  })
+
+  it("drops the previous message when a new attempt starts", async () => {
+    const user = userEvent.setup()
+    let fail = true
+    render(
+      <Harness
+        commit={() =>
+          fail ? Promise.reject(new Error("Must be a URL.")) : Promise.resolve()
+        }
+      />,
+    )
+
+    await user.click(commitButton())
+    await waitFor(() => expect(error()).toHaveTextContent("Must be a URL."))
+
+    fail = false
+    await user.click(commitButton())
+
+    await waitFor(() => expect(error()).toBeEmptyDOMElement())
+  })
+})

--- a/web/src/shared/hooks/useAutosave.ts
+++ b/web/src/shared/hooks/useAutosave.ts
@@ -1,0 +1,52 @@
+import { useState } from "react"
+
+import { errorMessage } from "@/shared/components/feedback/errorMessage"
+
+/**
+ * Enter commits by leaving the field, so a keyboard save and a pointer save run
+ * the same blur path rather than two that can disagree about what changed.
+ */
+export function commitOnEnter(event: React.KeyboardEvent<HTMLInputElement>) {
+  if (event.key === "Enter") {
+    event.preventDefault()
+    event.currentTarget.blur()
+  }
+}
+
+export interface Autosave {
+  /** In flight, so the control disables itself rather than taking a second edit. */
+  isSaving: boolean
+  error: string
+  /** Commits a value and drives the row's state. Never rejects. */
+  run: (commit: () => Promise<unknown>) => Promise<void>
+}
+
+/**
+ * The save state of one autosaving control: in flight, or refused.
+ *
+ * Per control rather than per page, because a mutation hook's `isPending` is
+ * shared by every row that uses it and would disable all of them.
+ *
+ * A save that worked says nothing: a confirmation on every row of a page where
+ * everything saves itself is a mark the reader learns to ignore. A refusal is
+ * the outcome worth a word, and it stays until the next attempt, since the
+ * value that caused it is still in the field.
+ */
+export function useAutosave(): Autosave {
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState("")
+
+  const run = async (commit: () => Promise<unknown>) => {
+    setError("")
+    setIsSaving(true)
+    try {
+      await commit()
+    } catch (cause) {
+      setError(errorMessage(cause))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return { isSaving, error, run }
+}

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -882,15 +882,6 @@ describe("content text wears a type role", () => {
       "consequence notes in the button row, and the candidate cap",
     ],
     ["features/usage/ShareDialog.tsx", "a notice in the dialog's button row"],
-    // Excluded on its own grounds rather than the referent one: this is a
-    // `<legend>` carrying `font-medium`, and `text-caption` sets
-    // `font-weight: normal`, so converting it would trade this failure for
-    // the one that bans a weight beside a role. A fix that moves a failure
-    // sideways is not a fix.
-    [
-      "features/tools/WorkspaceCodeExecutionPolicyCard.tsx",
-      "a legend, not a caption, and it carries a weight",
-    ],
   ]
   const RULED = new Map(CAPTION_SIZE_IS_RULED)
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1957,6 +1957,18 @@ main {
     font-size: var(--text-base);
   }
 }
+/* A refused value, marked on the field itself.
+   Keyed on `aria-invalid` rather than on a class, for two reasons: it is the
+   attribute assistive tech already reads, so the border cannot drift from what
+   is announced, and a `border-danger` utility at the call site does not work
+   here at all. `.input` sets `border-color` unlayered, which outranks a
+   utility, so the class was silently doing nothing on every field in the
+   product. The message beside it carries the meaning; this is not colour
+   alone. */
+.input[aria-invalid="true"] {
+  border-color: var(--color-danger);
+}
+
 /* A field holding a machine value (a URL, an engine list, a domain list, a
    number) takes the mono family a step down, so a long value fits the lane and
    reads as data rather than as prose. The rule above hands it 16px back where

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1931,6 +1931,41 @@ main {
     gap: 8px;
   }
 }
+/* A settings row is the third dense place, after the pagination strip and the
+   toolbar. Its control sits in a lane beside the label it belongs to, and at
+   the form height each row comes out taller than the sentence explaining it, so
+   a column of them reads as a stack of boxes.
+
+   Below `md` the control stops sharing the row and stacks full width, so it
+   takes the form size back and 16px with it: iOS zooms the page when a field
+   under 16px takes focus, and a full-width field is the one shape where that
+   zoom has nowhere to go. */
+.otari-settings .input,
+.otari-settings .select__trigger {
+  height: 32px;
+  min-height: 32px;
+  padding-block: 4px;
+}
+@media (width < 48rem) {
+  .otari-settings .input,
+  .otari-settings .select__trigger {
+    height: 36px;
+    min-height: 36px;
+    padding-block: 6px;
+  }
+  .otari-settings .input {
+    font-size: var(--text-base);
+  }
+}
+/* A field holding a machine value (a URL, an engine list, a domain list, a
+   number) takes the mono family a step down, so a long value fits the lane and
+   reads as data rather than as prose. The rule above hands it 16px back where
+   the field goes full width. */
+.field-machine {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
 /* Same for a toolbar's controls, which the min-height above cannot bring down
    on its own for the same reason. */
 .otari-toolbar .input,

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1936,21 +1936,27 @@ main {
    the form height each row comes out taller than the sentence explaining it, so
    a column of them reads as a stack of boxes.
 
-   Below `md` the control stops sharing the row and stacks full width, so it
-   takes the form size back and 16px with it: iOS zooms the page when a field
-   under 16px takes focus, and a full-width field is the one shape where that
-   zoom has nowhere to go. */
+   On a phone the control stops sharing the row and stacks full width, and it
+   comes up to 44px with the two places above rather than stopping at the form
+   height: 44px is the floor everywhere, and a dense place that keeps its
+   desktop height there is the one thing `design/motion-and-access.md` says
+   needs an argument in writing. Same 767px boundary as those, so a settings
+   row's fields and the button floor arrive together.
+
+   It takes 16px with it, which is a separate rule from the height: iOS zooms
+   the page when a field under 16px takes focus, and a full-width field is the
+   one shape where that zoom has nowhere to go. */
 .otari-settings .input,
 .otari-settings .select__trigger {
   height: 32px;
   min-height: 32px;
   padding-block: 4px;
 }
-@media (width < 48rem) {
+@media (max-width: 767px) {
   .otari-settings .input,
   .otari-settings .select__trigger {
-    height: 36px;
-    min-height: 36px;
+    height: 44px;
+    min-height: 44px;
     padding-block: 6px;
   }
   .otari-settings .input {
@@ -1972,8 +1978,17 @@ main {
 /* A field holding a machine value (a URL, an engine list, a domain list, a
    number) takes the mono family a step down, so a long value fits the lane and
    reads as data rather than as prose. The rule above hands it 16px back where
-   the field goes full width. */
-.field-machine {
+   the field goes full width.
+
+   Unlayered and `otari-` namespaced, both deliberately. `INPUT_CLASS` carries
+   `text-sm`, so a `@utility` here would be settled by Tailwind's emit order
+   rather than by the call site, and `text-sm` wins that. And this is the same
+   kind of escape hatch as `.otari-toolbar` and `.otari-settings`, which is what
+   the namespace says. Unlike those it is opted into per field rather than per
+   place, because the family is a property of the value in the box (a URL, a
+   domain list) and not of the row it sits in: two fields in one settings row
+   legitimately differ, a prose hint beside a mono domain list. */
+.otari-machine-field {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
 }


### PR DESCRIPTION
## Description

Rebuilds the Web search view of `ToolsGuardrailsPage` to the Paper design
(`Nice grove`, artboards `01 · Web search — BUILD THIS` and `04 · Tool status
panel — opened`, direction 2 approved in review). The same component renders
Code execution and Guardrails, so the row grammar is built once and those two
follow it.

Targets `main` and is self-contained: every file it touches is under `web/`, and
it merges into `main` without conflict. It was opened against
`design-system/storybook` for the Storybook stories the brief asked for, but the
branch was later rebased onto `main` and now carries none of that work, so the
base is `main`. The stories move to #970, which owns Storybook.

## What changed

The page was a three-track grid of rows labeled by config key, each with its own
Save button and a page-level toast. It is now one row grammar:

- **A bounded group per topic** (Backend, Behavior, Search tools, This
  workspace) rather than full-width bands, which run together into one striped
  field when a page stacks several small groups.
- **A row names the setting in prose**, with its config key as a mono caption
  beside it, its help under it, and its control in a lane every row shares.
- **No Save anywhere, and no confirmation.** Text commits on blur and on Enter,
  only when the value changed; a select commits on change. The control disables
  while the write is in flight and that is the whole acknowledgment: a mark on
  every row of a page where everything saves itself is one the reader learns to
  ignore. Only a refusal gets a line, and it keeps the value that caused it.
- **A tool status row heads each service**, opening into two indented rows in
  the same grammar: why the tool is unavailable (with a jump to the URL field),
  and the exact `tools[].type` a client declares, as selectable text beside a
  copy button. This replaces the request-JSON card, whose body repeated the
  manual.
- **The named tools behind `POST /v1/search` drill in** from a row instead of
  occupying a group, since most deployments have none.

Data, endpoints and mutations are untouched: the same one-field PATCH, the same
reachability check, the same `/v1/tools` read.

## New in the design system

| Component | What it is |
| --- | --- |
| `layout/SettingRow` | The row: label + key left, control right. `nested` indents one that belongs to the row above it |
| `layout/SettingsGroup` `bounded` | Frames rows inside the page column; declares `.otari-settings` |
| `navigation/DisclosureRow` | A settings row that opens in place |
| `navigation/DocsLink` | The external "Docs ↗" link, plus a `docsHref` slot on `PageIntro` and `SettingsGroup` |
| `shared/hooks/useAutosave` | Per-control save state, and the Enter-commits rule |

`.otari-settings` is the third dense place after `.otari-toolbar` and
`.otari-pagination`: it declares `--field-height` and the new
`--field-font-size` rather than restyling its descendants, which is what lets a
full-width control on a phone take 16px so iOS does not zoom on focus. No row
picks a height or a font size.

Two shared controls also changed. `actions/CopyField` gained `inFieldCopy`, so
the in-field copy arrangement is reachable without inventing a trailing action.
`actions/CopyButton` gained a 44px hit area through a pseudo-element: it is 32px
at every call site in the product, which is under the floor `motion-and-access.md`
sets, so this fixes an existing violation rather than adding a feature.

Docs updated: `design/layout.md` (the autosaving page recipe, `SettingRow`, the
bounded group, `nested`), `design/forms.md` (validation timing under autosave),
`design/DESIGN.md` (the component registry).

## Two deviations from the brief, called out

1. **Docs links point at `docs/tools.md` on GitHub, not `/docs`.** The brief says
   to anchor them into the bundled guide, but only `docs/dashboard.md` is
   bundled and it has no web-search sections, so every anchor would be dead.
   GitHub is where `DocsPage` already sends its own sibling links; the anchors
   are verified against the file.
2. **A row label is `text-emphasis`, not 13px/500.** `foundation.test.ts`
   refuses a font weight beside a type role, and there is no 13/500 role. The
   label/help pair is 14/550 over 12/subtle instead of 13/500 over 12.

`SaveToast` survives for one card only: `OrganizationGuardrailsCard` still
submits per entry with a Save of its own and has no row to report into. It is a
list of things rather than a set of settings, which is why it keeps that shape.
Neither the Web search nor the Code execution page renders a toast any more.

## Also in here, and separable

- **A layout fix the bounded column exposed.** `.otari-bleed` escapes to the
  width of `<main>` and centers that escape, so the two workspace cards nested
  in the new column drew bands starting 152px left of `<main>`, painting under
  the sidebar. Both are bounded groups now, and `WorkspaceCodeExecutionPolicyCard`
  follows the same autosaving row grammar as the rest of the page.
- **A test-suite race, pre-existing.** `foundation.test.ts` swept `src/**` at
  module load while `architecture.test.ts` had its Biome boundary probe planted
  under `src/features/`, so the two reported the probe as an offender whenever
  they overlapped. `overlaySeams.test.ts` already skipped it; foundation has
  eight sweeps, so the skip now lives in one helper. The base branch runs clean
  (the three test files this PR adds changed the worker scheduling enough to
  surface it).

Worth a reviewer's eye: on the combined `/tools` page a group title is prefixed
with its service (`Web search · Backend`), because three groups called "Backend"
say nothing about which service each configures. On a narrowed page the prefix
is dropped, since the page title already names the service.

## Checks

- `pnpm --dir web run lint`, `typecheck`, `test` (139 files, 4950 tests) clean,
  and the suite run twice to confirm the race above is gone
- Verified in a running gateway in light and dark: 32px dense fields, 12px mono
  for machine values, no control under the 44px row floor, no Save button, no
  save confirmation, both disclosures working from pointer and keyboard, and no
  band escaping the column on any of the three Tools pages
- New screenshot entry for `/tools/web-search`; the narrowed view is no longer
  the combined page with two services hidden
- No generated-artifact drift (`schema.ts`, `routeTree.gen.ts`)

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

No driving issue; this implements the approved Paper direction for the Web search
page. Follow-up filed from the review of this PR: #994 (setting-dense pages still
show too many fields at once).

Not stacked on anything. #970 (the design system layer) owns the Storybook
stories from the same brief and lands separately.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Two boxes are left unchecked deliberately, because this change is dashboard-only
and the literal commands they name do not apply to it:

- **Definition of Done.** `make lint` does not cover `web/`. What ran instead is
  the dashboard counterpart, `pnpm --dir web run lint`, `typecheck` and `test`,
  all clean, with the suite run twice to confirm the test-file race described
  above is gone.
- **OpenAPI.** No API contract changed, and there is no generated-artifact drift
  in `schema.ts` or `routeTree.gen.ts`.

The tests box is checked, but they are the dashboard's own suites rather than
`tests/unit` / `tests/integration`: three new test files, and
`pnpm --dir web run test` clean at 139 files and 4950 tests.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The visual direction was chosen by a human from Paper artboards before any code
was written, and the result was reviewed against a running gateway in light and
dark. The two deviations from the brief are called out in the description above
rather than silently resolved.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Rebuilt Tools settings pages around autosaving rows for Web search, Code execution, Guardrails, and combined Tools.
- Removed Save buttons and success toasts from these views.
- Added shared setting rows, disclosure rows, documentation links, and autosave handling.
- Added inline validation, loading states, error handling, and accessible control associations.
- Improved tool status, configuration, copy controls, and dense-field layouts.
- Updated workspace policy editing and added tests for autosave, validation, concurrency, failed reads, accessibility, and disclosures.

## Technical notes

- Text fields save on blur or Enter. Selects save on change.
- Added reusable `PolicyRow`, `ToolSettingRow`, `ToolStatusGroup`, `useAutosave`, and `usePolicyWriter` utilities.
- Preserved existing endpoints, mutations, reachability checks, and `/v1/tools` reads.
- Successful policy writes now update React Query caches directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->