### PR TITLE
feat(dashboard): give the tenant Overview the budget signal it had none of

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -104,6 +104,12 @@ manages every key in the organization and chooses each key's owner, while a
 member sees the same page scoped to their own keys, always billed to themselves
 and never budget-exempt.
 
+Overview splits the same way. Everyone lands on their own spend, traffic and
+recent requests. An organization owner or admin also gets a budget-health
+figure, read from the spend ceilings holding their organization, while a
+deployment operator gets provider health and the deployment's own budgets
+instead.
+
 ## Observability
 
 Activity is the per-request log. Usage provides aggregates and time series.

--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -125,23 +125,23 @@ not already in its list, naming what to use instead.
 
 | Do not use | Use instead | Still in |
 | --- | --- | --- |
-| `deprecated/PageHeader` | `layout/PageIntro` | 4 pages, one use each |
-| `deprecated/StatCard` | `metrics/KpiStrip` + `KpiCell` | Overview only, 4 uses |
+| `deprecated/PageHeader` | `layout/PageIntro` | 3 pages, one use each |
+| `deprecated/StatCard` | `metrics/KpiStrip` + `KpiCell` | **nothing. Dead code** |
 | `deprecated/RowActions` | `actions/RowActionRow` | 1 use, in `PasskeysCard` |
 | `deprecated/SettingsSection` | `layout/SettingsGroup` | **nothing. Dead code** |
 | HeroUI `Card` | `Section`, or a bare band | 6 components |
 
 The gate derives **which files** import each one, so a row naming a page that no
-longer reaches for it fails. It does not count usages, so the "one use each" and
-"4 uses" figures are prose and can drift the way the previous two did (`StatCard`
+longer reaches for it fails. It does not count usages, so the "one use each"
+figures are prose and can drift the way the previous two did (`StatCard`
 was listed on Usage after Usage stopped using it, and `RowActions` on two call
 sites when it had one). Check them against the tree rather than against this
 table.
 
-`SettingsSection` is the row to act on: it has no call site anywhere, and it
-shadowed `layout/SettingsGroup` while diverging from this tree's
-`export function` convention. It is a deletion waiting for a maintainer rather
-than a migration.
+`SettingsSection` and `StatCard` are the rows to act on: neither has a call
+site anywhere. `SettingsSection` also shadowed `layout/SettingsGroup` while
+diverging from this tree's `export function` convention. Both are deletions
+waiting for a maintainer rather than migrations.
 
 HeroUI `Card` is the one row with no module of ours behind it, so it stays a
 review note rather than a gate.

--- a/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
@@ -6,7 +6,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { OrganizationBudget, OrganizationSpendCeiling } from "@/client"
 import { OrganizationBudgetsPage } from "@/features/budgets/OrganizationBudgetsPage"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
-import { bootstrap, organizationContext, workspace } from "@/tests/fixtures"
+import {
+  bootstrap,
+  organizationContext,
+  organizationSpendCeiling as spendCeiling,
+  workspace,
+} from "@/tests/fixtures"
 
 interface RecordedRequest {
   url: string
@@ -27,36 +32,6 @@ function organizationBudget(
     budget_duration_sec: null,
     reset_alignment: "calendar_month",
     ceiling_count: 0,
-    created_at: "2026-01-01T00:00:00+00:00",
-    updated_at: "2026-01-01T00:00:00+00:00",
-    ...overrides,
-  }
-}
-
-function spendCeiling(
-  overrides: Partial<OrganizationSpendCeiling> = {},
-): OrganizationSpendCeiling {
-  return {
-    id: "cccccccc-1111-2222-3333-444444444444",
-    scope_type: "organization",
-    scope_id: "11111111-1111-1111-1111-111111111111",
-    provider_key_id: null,
-    budget_id: "bbbbbbbb-1111-2222-3333-444444444444",
-    name: null,
-    max_budget: 250,
-    current_spend: 12.5,
-    reserved_spend: 0,
-    token_limit: null,
-    current_tokens: 0,
-    reserved_tokens: 0,
-    request_limit: null,
-    current_requests: 0,
-    reserved_requests: 0,
-    budget_duration_sec: null,
-    reset_alignment: "calendar_month",
-    period_start: "2026-08-01T00:00:00+00:00",
-    period_end: "2026-09-01T00:00:00+00:00",
-    manageable: true,
     created_at: "2026-01-01T00:00:00+00:00",
     updated_at: "2026-01-01T00:00:00+00:00",
     ...overrides,

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type { ApiKey, DeploymentBootstrap, User } from "@/client"
 import { KeysPage } from "@/features/keys/KeysPage"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
-import { bootstrap, organizationMember } from "@/tests/fixtures"
+import { apiKey, bootstrap, organizationMember } from "@/tests/fixtures"
 import { renderWithRouter } from "@/tests/router"
 import { pickOption } from "@/tests/select"
 
@@ -30,27 +30,6 @@ function user(overrides: Partial<User> = {}): User {
     blocked: false,
     created_at: "2026-01-01T00:00:00+00:00",
     updated_at: "2026-01-01T00:00:00+00:00",
-    metadata: {},
-    ...overrides,
-  }
-}
-
-function apiKey(overrides: Partial<ApiKey> = {}): ApiKey {
-  return {
-    capture_agent_telemetry: null,
-    id: "key-1",
-    // NOT NULL on the server: a key always belongs to exactly one workspace.
-    workspace_id: "11111111-1111-1111-1111-111111111111",
-    key_prefix: "gw-AbC3dE",
-    key_name: "ci-bot",
-    user_id: "alice",
-    created_at: "2026-01-01T00:00:00+00:00",
-    last_used_at: null,
-    expires_at: null,
-    is_active: true,
-    allowed_models: null,
-    exclude_from_budget: false,
-    reject_user_mismatch: null,
     metadata: {},
     ...overrides,
   }

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -14,9 +14,12 @@ import {
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
 import {
+  apiKey,
   bootstrap,
   HOSTED_SURFACES,
   organizationContext,
+  organizationSpendCeiling,
+  seriesPoint,
   usageTotals,
   workspaceActivation,
   workspaceMember,
@@ -30,7 +33,10 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-function summary(totals: Partial<UsageSummary["totals"]>): UsageSummary {
+function summary(
+  totals: Partial<UsageSummary["totals"]>,
+  series: UsageSummary["series"] = [],
+): UsageSummary {
   return {
     start_date: "2026-06-22T00:00:00Z",
     end_date: "2026-07-22T00:00:00Z",
@@ -56,7 +62,7 @@ function summary(totals: Partial<UsageSummary["totals"]>): UsageSummary {
     by_provider: [],
     by_tool: [],
     errors_by_status_code: [],
-    series: [],
+    series,
   }
 }
 
@@ -64,8 +70,12 @@ interface Bodies {
   today?: Partial<UsageSummary["totals"]>
   period?: Partial<UsageSummary["totals"]>
   prev?: Partial<UsageSummary["totals"]>
+  /** The 30-day daily series, which is what the spend chart draws. */
+  series?: UsageSummary["series"]
   health?: unknown
   budgets?: unknown
+  /** The organization's spend ceilings, which is the tenant's budget signal. */
+  ceilings?: unknown
   keys?: unknown
   users?: unknown
   logs?: unknown
@@ -122,7 +132,7 @@ function mockApi(b: Bodies) {
       if (url.includes("bucket=hour"))
         return jsonResponse(summary(b.today ?? {}))
       if (url.includes("end_date=")) return jsonResponse(summary(b.prev ?? {}))
-      return jsonResponse(summary(b.period ?? {}))
+      return jsonResponse(summary(b.period ?? {}, b.series))
     }
     if (url.includes("/v1/providers/health")) {
       return jsonResponse(
@@ -365,11 +375,11 @@ describe("OverviewPage", () => {
     expect(screen.getAllByText("up")).toHaveLength(1)
   })
 
-  it("reserves no trend row for a tile with no comparable previous window", async () => {
+  it("reserves no trend row for a cell with no comparable previous window", async () => {
     // No previous window on the wire leaves every delta null, and TrendChip
     // renders nothing for a null fraction. The chip has to be gated on the
-    // fraction rather than on the query, or StatCard reserves the aside row for
-    // an element that draws nothing.
+    // fraction rather than on the query: the *element* is truthy either way,
+    // and a cell handed one keeps a line for something that draws nothing.
     mockApi({
       today: { cost: 5 },
       period: { cost: 200, request_count: 2000, error_count: 40 },
@@ -830,10 +840,24 @@ function mockScopedApi(b: Bodies): string[] {
       if (url.includes("bucket=hour"))
         return jsonResponse(summary(b.today ?? {}))
       if (url.includes("end_date=")) return jsonResponse(summary(b.prev ?? {}))
-      return jsonResponse(summary(b.period ?? {}))
+      return jsonResponse(summary(b.period ?? {}, b.series))
     }
     if (url.includes("/v1/organizations/me/usage")) {
       return jsonResponse(b.logs ?? [])
+    }
+    // The tenant surface the rest of the page reads: the organization's spend
+    // ceilings behind the budget cell (owner or admin, in a `Paged` envelope),
+    // its own keys, and the selected workspace's roster, which any member of
+    // that workspace may read.
+    if (url.includes("/v1/organizations/me/spend-ceilings")) {
+      return jsonResponse({ data: b.ceilings ?? [] })
+    }
+    if (url.includes("/v1/organizations/me/keys")) {
+      return jsonResponse(b.keys ?? [])
+    }
+    const scopedRoster = url.match(/\/v1\/workspaces\/([^/?]+)\/members/)
+    if (scopedRoster) {
+      return jsonResponse({ data: b.workspaceMembers?.[scopedRoster[1]] ?? [] })
     }
     // The two reads the setup guide adds to this page. Both are open to any
     // signed-in caller: the catalog is scoped to the caller's own providers
@@ -876,22 +900,17 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     ).not.toBeInTheDocument()
   })
 
-  it("reads only the organization-scoped surface and shows no operator tile", async () => {
+  it("reads only the organization-scoped surface", async () => {
     const requested = mockScopedApi({
       period: { cost: 200, request_count: 2000 },
     })
     renderPage(<OverviewIndex />)
     await screen.findByText("$200.00")
 
-    // The deployment-wide panels stay on the operator page: no tile here reads
-    // budgets, keys, or the deployment roster.
-    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
-    expect(screen.queryByText("Active keys")).not.toBeInTheDocument()
-    expect(screen.queryByText("Active members")).not.toBeInTheDocument()
-    // And nothing left the scoped surface: beyond the context, every request
-    // this page made names /v1/organizations/me/usage. A bare /v1/usage read
-    // here would be a cross-tenant read the server refuses, so the page must
-    // not even attempt it.
+    // Nothing left the scoped surface: beyond the context, every request this
+    // page made is under /v1/organizations/me. A bare /v1/usage, /v1/budgets or
+    // /v1/keys read here would be a deployment-wide one the server refuses, so
+    // the page must not even attempt it, and neither must it ask the gate.
     expect(requested.some((url) => url.endsWith("/v1/admin/access"))).toBe(
       false,
     )
@@ -900,8 +919,28 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     )
     expect(scoped.length).toBeGreaterThan(0)
     for (const url of scoped) {
-      expect(url).toContain("/v1/organizations/me/usage")
+      expect(url).toContain("/v1/organizations/me/")
     }
+  })
+
+  it("shows no deployment-wide panel", async () => {
+    mockScopedApi({ period: { cost: 200, request_count: 2000 } })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    // Provider health and the deployment's budgets are the attention strip's
+    // two sources and both are operator surfaces, so the strip is correctly
+    // absent here rather than merely empty (otari-ai#2085).
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Some status data could not be loaded."),
+    ).not.toBeInTheDocument()
+    // And the header is the tenant's, not the gateway's.
+    expect(
+      screen.queryByText(
+        "At-a-glance spend, traffic, and health across the gateway.",
+      ),
+    ).not.toBeInTheDocument()
   })
 
   it("previews the caller's recent requests with a link to the full log", async () => {
@@ -983,6 +1022,236 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     renderPage(<OverviewIndex />)
 
     expect(await screen.findByText(/usage exploded/)).toBeInTheDocument()
+  })
+})
+
+// The parity gaps otari-ai#2085 is about, all on the page a caller who does not
+// operate the deployment lands on. Note what is *not* asserted anywhere below:
+// no entitlement (base otari has no entitlements server), no surface (nothing
+// publishes one for this), and no operator check, which is what this page is
+// the other branch of.
+describe("the tenant Overview's budget signal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("shows an organization admin their tightest spend ceiling", async () => {
+    const requested = mockScopedApi({
+      context: { role: "admin" },
+      period: { cost: 200, request_count: 2000 },
+      ceilings: [
+        organizationSpendCeiling({ current_spend: 50, max_budget: 250 }),
+        organizationSpendCeiling({
+          id: "dddddddd-1111-2222-3333-444444444444",
+          name: "Staging cap",
+          current_spend: 180,
+          reserved_spend: 20,
+          max_budget: 250,
+        }),
+      ],
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(await screen.findByText("Budget health")).toBeInTheDocument()
+    // 200 of 250, reserved included: a ceiling refuses on spend plus what is
+    // held against requests in flight, so the cell judges the same sum.
+    expect(await screen.findByText("80.0%")).toBeInTheDocument()
+    expect(screen.getByText("NEAR LIMIT")).toBeInTheDocument()
+    // The same meter the Spend page's own rows draw, naming the row it is about.
+    expect(
+      screen.getByRole("progressbar", {
+        name: "Tightest spend ceiling: Staging cap",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      requested.some((url) =>
+        url.includes("/v1/organizations/me/spend-ceilings"),
+      ),
+    ).toBe(true)
+    // And never `/v1/budgets`, the operator cell's endpoint, which is
+    // deployment-wide and answers 403 to this caller.
+    expect(requested.some((url) => url.includes("/v1/budgets"))).toBe(false)
+  })
+
+  it("counts a ceiling this organization cannot edit", async () => {
+    // `manageable` says whose figure it is, not whose spend. A ceiling naming a
+    // budget the organization does not own is enforcing against it today, so
+    // reading that field as a filter would let the page report "on track" while
+    // the tenant is over the cap that is actually refusing their requests.
+    mockScopedApi({
+      context: { role: "admin" },
+      ceilings: [
+        organizationSpendCeiling({
+          name: "Deployment cap",
+          manageable: false,
+          current_spend: 300,
+          max_budget: 250,
+        }),
+      ],
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(await screen.findByText("120.0%")).toBeInTheDocument()
+    expect(screen.getByText("OVER BUDGET")).toBeInTheDocument()
+  })
+
+  it("withholds the cell from a member, without asking for it", async () => {
+    // The matrix has Spend & budgets Hidden for a member, and the server agrees:
+    // both halves of the organization budget surface go through
+    // `require_active_organization_management_access`. So the query is not made
+    // rather than made and its refusal painted.
+    const requested = mockScopedApi({
+      context: { role: "member" },
+      period: { cost: 200, request_count: 2000 },
+    })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
+    expect(
+      requested.some((url) =>
+        url.includes("/v1/organizations/me/spend-ceilings"),
+      ),
+    ).toBe(false)
+  })
+
+  it("reads a failed ceiling query as unknown, not as zero spend", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(
+          organizationContext({ deployment_operator: false, role: "admin" }),
+        )
+      }
+      if (url.includes("/v1/organizations/me/spend-ceilings")) {
+        return jsonResponse({ detail: "ceilings exploded" }, 500)
+      }
+      if (url.includes("/v1/organizations/me/usage/summary")) {
+        return jsonResponse(summary({ cost: 200, request_count: 2000 }))
+      }
+      return jsonResponse([])
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(await screen.findByText(/ceilings exploded/)).toBeInTheDocument()
+    const cell = (await screen.findByText("Budget health")).parentElement
+    expect(cell).not.toBeNull()
+    // An em dash and "no data", never a percentage: a refused read that renders
+    // as 0% claims the tenant has spent nothing (otari-ai#1935, #1961).
+    expect(within(cell as HTMLElement).getByText("—")).toBeInTheDocument()
+    expect(within(cell as HTMLElement).getByText("no data")).toBeInTheDocument()
+    expect(
+      within(cell as HTMLElement).queryByRole("progressbar"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("says so when the organization has capped nothing", async () => {
+    mockScopedApi({ context: { role: "admin" }, ceilings: [] })
+    renderPage(<OverviewIndex />)
+
+    // Awaited, not read off the first paint: an unresolved query and an empty
+    // list both leave the value an em dash, and only the subline tells them
+    // apart.
+    const subline = await screen.findByText("no spend ceilings set")
+    expect(subline.closest("div")).toHaveTextContent("Budget health")
+  })
+})
+
+describe("the tenant Overview's chart and rail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("draws the month's shape under the numbers", async () => {
+    mockScopedApi({
+      period: { cost: 200, request_count: 2000 },
+      series: [
+        seriesPoint({ bucket_start: "2026-07-01T00:00:00Z", cost: 10 }),
+        seriesPoint({ bucket_start: "2026-07-02T00:00:00Z", cost: 30 }),
+      ],
+    })
+    renderPage(<OverviewIndex />)
+
+    // The heading, not the KPI cell's label of the same words.
+    expect(
+      await screen.findByRole("heading", { name: "Spend, last 30 days" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /view usage/i })).toHaveAttribute(
+      "href",
+      "/usage",
+    )
+  })
+
+  it("counts the tenant's own keys and the workspace's roster", async () => {
+    const requested = mockScopedApi({
+      context: { ...TWO_WORKSPACES, role: "admin" },
+      keys: [
+        apiKey(),
+        apiKey({ id: "key-2", is_active: false }),
+        apiKey({ id: "key-3" }),
+      ],
+      workspaceMembers: {
+        [WORKSPACE_A]: [
+          workspaceMember({ id: "a1" }),
+          workspaceMember({ id: "a2" }),
+          workspaceMember({ id: "a3", status: "invited" }),
+        ],
+      },
+    })
+    renderPageInWorkspace(<OverviewIndex />, WORKSPACE_A)
+
+    const rail = (await screen.findByText("This workspace")).closest("section")
+    expect(rail).not.toBeNull()
+    await waitFor(() => {
+      expect(
+        within(rail as HTMLElement).getByText("Active keys").parentElement,
+      ).toHaveTextContent("2")
+    })
+    await waitFor(() => {
+      expect(
+        within(rail as HTMLElement).getByText("Active members").parentElement,
+      ).toHaveTextContent("2")
+    })
+    // Their own key list, which is the surface otari-ai#1941 gave them, and not
+    // the deployment-wide `/v1/keys` the operator page reads.
+    expect(
+      requested.some((url) => url.includes("/v1/organizations/me/keys")),
+    ).toBe(true)
+  })
+
+  it("offers a member only the destinations that will serve them", async () => {
+    mockScopedApi({ context: { role: "member" }, period: { cost: 200 } })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    const rail = (await screen.findByText("This workspace")).closest("section")
+    expect(rail).not.toBeNull()
+    const inRail = within(rail as HTMLElement)
+    expect(inRail.getByRole("link", { name: "API keys" })).toBeInTheDocument()
+    expect(inRail.getByRole("link", { name: "Activity" })).toBeInTheDocument()
+    // Members and Budgets are reached through the organization rail, which
+    // `AppShell` opens only to a caller who manages the organization, and both
+    // destinations refuse a member on the server too.
+    expect(
+      inRail.queryByRole("link", { name: "Budgets" }),
+    ).not.toBeInTheDocument()
+    expect(
+      inRail.queryByRole("link", { name: "Members" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("offers an admin all four", async () => {
+    mockScopedApi({ context: { role: "admin" }, period: { cost: 200 } })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    const rail = (await screen.findByText("This workspace")).closest("section")
+    expect(rail).not.toBeNull()
+    const inRail = within(rail as HTMLElement)
+    expect(inRail.getByRole("link", { name: "Budgets" })).toBeInTheDocument()
+    expect(inRail.getByRole("link", { name: "Members" })).toBeInTheDocument()
   })
 })
 
@@ -1081,8 +1350,13 @@ describe("OverviewIndex operator-ness", () => {
     )
     expect(asked.length).toBeGreaterThan(0)
     for (const url of asked) {
-      expect(url).toContain("/v1/organizations/me/usage")
+      expect(url).toContain("/v1/organizations/me/")
     }
+    // The ceilings among them: an errored context names no role, and the page
+    // withholds a read the server may refuse rather than painting its refusal.
+    expect(
+      asked.some((url) => url.includes("/v1/organizations/me/spend-ceilings")),
+    ).toBe(false)
   })
 })
 
@@ -1105,7 +1379,11 @@ describe("the setup guide on either Overview", () => {
       await screen.findByRole("heading", { name: "Send your first request" }),
     ).toBeInTheDocument()
     // On the tenant page, rather than by falling through to the operator one.
-    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "At-a-glance spend, traffic, and health across the gateway.",
+      ),
+    ).not.toBeInTheDocument()
     // And its gate came from the catalog, which this caller may read, and not
     // from the operator-gated provider list.
     expect(requested.some((url) => url.includes("/v1/models"))).toBe(true)

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -89,6 +89,7 @@ interface Bodies {
   models?: string[]
 }
 
+/** The catalog shape `/v1/models` answers, which is the setup guide's gate. */
 function modelCatalog(ids: string[]) {
   return {
     object: "list",
@@ -151,6 +152,7 @@ function mockApi(b: Bodies) {
   })
 }
 
+/** Reports where a navigation landed, for the routes `renderPage` mounts. */
 function LocationProbe() {
   const loc = useLocation()
   return <div data-testid="loc">{loc.pathname}</div>

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -778,9 +778,13 @@ export function OverviewPage({
   )
 }
 
-// `children` is the standfirst, which is the one part of the header that
-// differs between the two pages: an operator is told about the gateway, a
-// tenant about their organization.
+/**
+ * The page title, its window caption and its Refresh control.
+ *
+ * `children` is the standfirst, which is the one part of the header that
+ * differs between the two pages: an operator is told about the gateway, a
+ * tenant about their organization.
+ */
 function OverviewHeader({
   refresh,
   isRefreshing,

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -4,16 +4,17 @@ import { Link, useNavigate } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import { useEffect, useMemo, useState } from "react"
 import type { UsageEntry } from "@/client"
+import { scopeLabel } from "@/features/budgets/organizationBudget"
 import { SetupGuideCard } from "@/features/onboarding/SetupGuideCard"
-import { isDeploymentOperator } from "@/features/organization/roles"
+import { canManage, isDeploymentOperator } from "@/features/organization/roles"
 import {
   budgetHealth,
   errorRateHealth,
   providerHealthStatus,
-  toStatStatus,
+  spendCeilingHealth,
 } from "@/features/overview/overview"
 import { useKeys } from "@/shared/api/apiKeys"
-import { useBudgets } from "@/shared/api/budgets"
+import { useBudgets, useOrganizationSpendCeilings } from "@/shared/api/budgets"
 import { useModels } from "@/shared/api/models"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import { useProviderHealth, useProviders } from "@/shared/api/providers"
@@ -29,11 +30,6 @@ import {
   DataTable,
   type DataTableColumn,
 } from "@/shared/components/data/DataTable"
-// Still reached by `UsageStatTiles`, which the organization overview seats
-// beside its own tiles. The operator overview's KPI strip replaced its use of
-// these, the organization one's has not been rebuilt yet.
-import { PageHeader } from "@/shared/components/deprecated/PageHeader"
-import { StatCard } from "@/shared/components/deprecated/StatCard"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { PageLoading } from "@/shared/components/feedback/PageLoading"
 import { Dot } from "@/shared/components/indicators/Dot"
@@ -156,35 +152,44 @@ const BUDGET_WORDS = {
   alert: "Over budget",
 } as const
 
-// The four usage tiles both overviews open with: spend today, spend and request
-// volume over the window, and the window's error rate. A fragment rather than
-// its own grid, so each page seats them beside its own tiles.
-function UsageStatTiles({
+/**
+ * The four cells both overviews open with: spend today, spend and request
+ * volume over the window, and the window's error rate.
+ *
+ * A fragment rather than its own strip, so each page seats them beside whatever
+ * else it is entitled to show. The derivations are pure and cheap, so a page
+ * that also needs one of them (the operator's attention strip reads the error
+ * rate) derives it again rather than threading it out of here.
+ */
+function UsageKpiCells({
   today,
   period,
   previous,
+  empty,
 }: {
   today: ReturnType<typeof useUsageSummary>
   period: ReturnType<typeof useUsageSummary>
   previous: ReturnType<typeof useUsageSummary>
+  empty: boolean
 }) {
   const todayTotals = today.data?.totals
   const periodTotals = period.data?.totals
   const prevTotals = previous.data?.totals
 
-  // The 30-day daily series is already on the wire (used for tile sparklines).
-  // A single point has no trend to draw, so sparklines only appear with 2+ days.
+  // The 30-day daily series is already on the wire, and so is today's hourly
+  // one: the today window is requested at `"hour"` granularity for exactly this.
+  // A single point has no trend to draw, so a sparkline needs two.
   const periodSeries = period.data?.series ?? []
+  const todaySeries = today.data?.series ?? []
   const hasTrend = periodSeries.length > 1
+  const hasHourlyTrend = todaySeries.length > 1
 
   const err = errorRateHealth(periodTotals)
   const errPrev = errorRateHealth(prevTotals)
-  // Each delta is its own const so the tile below can gate its chip on the
+  // Each delta is its own const so the cell below can gate its chip on the
   // fraction rather than on the query: `deltaFraction` also returns null once
   // the current window has landed but the previous one has not, and when the
-  // previous value is 0. TrendChip renders nothing for a null fraction, but the
-  // *element* is truthy, and StatCard reserves the aside row for whatever it is
-  // handed, so an ungated chip costs a tile 42px of dead space.
+  // previous value is 0.
   const costDelta = periodTotals
     ? deltaFraction(periodTotals.cost, prevTotals?.cost)
     : null
@@ -198,69 +203,112 @@ function UsageStatTiles({
 
   return (
     <>
-      <StatCard
+      <KpiCell
         label="Spend today"
+        // A real zero where zero is a fact, an em dash where the value is
+        // unknown: a failed query must not read as "you spent nothing".
         value={todayTotals ? formatUsd(todayTotals.cost) : "—"}
+        // "midnight" and not "00:00 UTC": `useWindows` builds this window from
+        // the caller's *local* midnight, deliberately and with a comment saying
+        // so, so a UTC string would be false for everyone not on it.
+        subline={
+          empty ? "no prior spend" : todayTotals ? "since midnight" : "no data"
+        }
+        graphic={
+          !empty && hasHourlyTrend ? (
+            <Sparkline
+              values={todaySeries.map((p) => p.cost)}
+              ariaLabel="Spend by hour today"
+              height={40}
+            />
+          ) : undefined
+        }
       />
-      <StatCard
+      <KpiCell
         label="Spend, last 30 days"
         value={periodTotals ? formatUsd(periodTotals.cost) : "—"}
+        subline={
+          empty ? "no prior spend" : periodTotals ? undefined : "no data"
+        }
         // Spend falling is the improvement, so a rise paints danger while the
         // arrow keeps telling the truth about which way it went.
-        trend={
+        delta={
           costDelta !== null ? (
             <TrendChip
               fraction={costDelta}
               polarity="down-is-good"
               caption="vs prev"
             />
-          ) : null
+          ) : undefined
         }
-        chart={
-          hasTrend ? (
+        graphic={
+          !empty && hasTrend ? (
             <Sparkline
               values={periodSeries.map((p) => p.cost)}
               ariaLabel="Spend trend over the last 30 days"
+              height={40}
             />
           ) : undefined
         }
       />
-      <StatCard
+      <KpiCell
         label="Requests, last 30 days"
         value={periodTotals ? formatNumber(periodTotals.request_count) : "—"}
-        // Volume, so `neutral`: more traffic through the gateway is neither a
-        // win nor a regression on its own, and the error rate tile beside it
-        // is what carries the judgment.
-        trend={
+        subline={
+          empty ? "no prior traffic" : periodTotals ? undefined : "no data"
+        }
+        // Volume, so no polarity: more traffic through the gateway is neither
+        // a win nor a regression on its own, and the error rate beside it is
+        // what carries the judgment.
+        delta={
           requestDelta !== null ? (
             <TrendChip fraction={requestDelta} caption="vs prev" />
-          ) : null
+          ) : undefined
         }
-        chart={
-          hasTrend ? (
+        graphic={
+          !empty && hasTrend ? (
             <Sparkline
               values={periodSeries.map((p) => p.requests)}
               ariaLabel="Request volume trend over the last 30 days"
+              height={40}
             />
           ) : undefined
         }
       />
-      <StatCard
+      <KpiCell
         label="Error rate, last 30 days"
         value={err.rate === null ? "—" : formatPct(err.rate)}
-        status={toStatStatus(err.status)}
-        statusLabel={
-          err.status === "neutral" ? undefined : ERROR_WORDS[err.status]
+        // The word is present whenever there is a rate to judge, "Healthy"
+        // included: a line that appears only when something is wrong makes
+        // its absence ambiguous with a page that has not loaded.
+        severity={
+          err.status === "neutral"
+            ? undefined
+            : { status: err.status, word: ERROR_WORDS[err.status] }
+        }
+        subline={
+          err.rate === null
+            ? empty
+              ? "NO REQUESTS YET"
+              : "no requests in range"
+            : undefined
         }
         // Errors falling is the improvement, as with spend.
-        trend={
+        delta={
           errDelta !== null ? (
             <TrendChip
               fraction={errDelta}
               polarity="down-is-good"
               caption="vs prev"
             />
-          ) : null
+          ) : undefined
+        }
+        graphic={
+          !empty && periodTotals ? (
+            <span className="text-xs text-muted">
+              {`${formatNumber(periodTotals.error_count)} of ${formatNumber(periodTotals.request_count)} requests`}
+            </span>
+          ) : undefined
         }
       />
     </>
@@ -313,16 +361,30 @@ export function OverviewIndex() {
  *
  * The 11 Aug roles matrix has Overview as "my usage" for every role
  * (otari-ai#1946), so this is a real page rather than a card apologizing for
- * the operator one (otari-ai#1929): the same usage tiles and recent-request
- * preview the operator page opens with, served by the scope-aware usage hooks,
- * which read `/v1/organizations/me/usage` for this caller. The server narrows
- * those rows to what the caller may read (their organization for an admin, the
- * workspaces they belong to for a member; otari#837), so nothing here
- * re-derives roles. The deployment-wide panels (provider health, budgets, keys,
- * accounts) stay on the operator page, whose endpoints refuse this caller.
+ * the operator one (otari-ai#1929), and it is built from the same primitives:
+ * the usage cells, the spend chart, the recent-request preview and the rail,
+ * served by the scope-aware hooks, which read `/v1/organizations/me/...` for
+ * this caller. The server narrows those rows to what the caller may read (their
+ * organization for an admin, the workspaces they belong to for a member;
+ * otari#837), so nothing here re-derives roles for them.
+ *
+ * Two things the operator page has are deliberately absent. The attention strip
+ * reads provider health and the deployment's budgets, neither of which is this
+ * caller's to see. And there is no `isDeploymentOperator` anywhere below this
+ * line: this *is* the non-operator branch, so asking again is how otari-ai#2080
+ * happened.
  */
 function OrganizationOverview() {
   const { scope, today, period, previous, recent } = useUsageOverview()
+  const context = useOrganizationContext()
+  // Owner or admin, which is the line the server already draws on the ceilings
+  // route: `require_active_organization_management_access`, the same gate that
+  // opens the organization rail in `AppShell`. A member is refused there, so a
+  // member is not asked here (the matrix has Spend & budgets Hidden for them).
+  // `canManage` is narrower than the server on one point, a superuser with no
+  // management role, and `roles.ts` says why that is the safe direction.
+  const managesSpend = canManage(context.data)
+  const ceilings = useOrganizationSpendCeilings(managesSpend)
   // What this caller could route a request to, which is the setup guide's gate
   // here: `/v1/providers`, the operator page's answer to the same question,
   // refuses this caller. The catalog is not operator-gated and is filtered to
@@ -331,44 +393,83 @@ function OrganizationOverview() {
   // to send a request to yet. Not asked until a workspace is selected, since the
   // guide is about one.
   const models = useModels(scope !== undefined)
+  // The two rail counts, both on surfaces this caller already reads:
+  // `useKeys` picks `/v1/organizations/me/keys` for a non-operator
+  // (otari-ai#1941), and a workspace's roster is readable by any member of it.
+  const keys = useKeys(scope)
+  const members = useWorkspaceMembers(scope ?? null)
+
+  const periodSeries = period.data?.series ?? []
+  const organizationName =
+    context.data?.organization.name ?? "This organization"
+  const ceilingHealth = spendCeilingHealth(
+    ceilings.data ?? [],
+    (ceiling) =>
+      ceiling.name ??
+      // No workspace roster is loaded here, so a workspace ceiling reads as
+      // "A workspace", which is what the Spend page shows for an id it cannot
+      // resolve either.
+      scopeLabel(ceiling, { organizationName, workspaces: [] }),
+  )
+
+  // Why the cell has no percentage to show, once the read has landed. The two
+  // are told apart because they ask for different things: nothing is capped
+  // yet, or what is capped is capped on tokens or requests rather than dollars.
+  const noCeilingReason =
+    (ceilings.data?.length ?? 0) === 0
+      ? "no spend ceilings set"
+      : "no ceiling caps spend"
+
+  const activeKeys = (keys.data ?? []).filter((k) => k.is_active).length
+  const activeMembers = (members.data ?? []).filter(
+    (member) => member.status === "active",
+  ).length
 
   // Recent activity is excluded for the operator page's reason: it renders its
   // own inline banner, so including it here would double-report. The previous
   // window is included: its only reader is the trend chips, so its failure
   // would otherwise just silently strip them. The catalog is excluded too: it
   // decides whether an optional offer appears, not whether this page is right.
-  const loadError = today.error ?? period.error ?? previous.error
+  const loadError =
+    today.error ??
+    period.error ??
+    previous.error ??
+    ceilings.error ??
+    keys.error ??
+    members.error
 
   const refresh = () => {
     void today.refetch()
     void period.refetch()
     void previous.refetch()
     void recent.refetch()
-    // So a caller who has just been given a provider key can bring the guide out
-    // with the button already in front of them. Guarded because `refetch` runs a
-    // disabled query, which would ask for a catalog with no workspace to use it.
+    void keys.refetch()
+    void members.refetch()
+    // Both guarded because `refetch` runs a disabled query: the catalog would be
+    // asked with no workspace to use it, and the ceilings with a role the server
+    // refuses.
     if (scope !== undefined) void models.refetch()
+    if (managesSpend) void ceilings.refetch()
   }
   const isRefreshing =
     today.isFetching ||
     period.isFetching ||
     previous.isFetching ||
     recent.isFetching ||
+    keys.isFetching ||
+    members.isFetching ||
+    ceilings.isFetching ||
     models.isFetching
 
   return (
-    <div className="flex flex-col gap-6">
-      <PageHeader
-        title="Overview"
-        description="At-a-glance spend, traffic, and recent activity in your organization."
-        action={
-          <RefreshButton
-            onRefresh={refresh}
-            isFetching={isRefreshing}
-            updatedAt={period.dataUpdatedAt}
-          />
-        }
-      />
+    <div className="flex flex-col">
+      <OverviewHeader
+        refresh={refresh}
+        isRefreshing={isRefreshing}
+        updatedAt={period.dataUpdatedAt}
+      >
+        At-a-glance spend, traffic, and recent activity in your organization.
+      </OverviewHeader>
 
       {/* Offered to whoever manages the workspace, which on a multi-tenant
           deployment is this caller. It decides for itself whether to render. */}
@@ -376,14 +477,65 @@ function OrganizationOverview() {
 
       <ErrorBanner error={loadError} />
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-4">
-        <UsageStatTiles today={today} period={period} previous={previous} />
-      </div>
+      <KpiStrip empty={false} columns={managesSpend ? 5 : 4}>
+        <UsageKpiCells
+          today={today}
+          period={period}
+          previous={previous}
+          empty={false}
+        />
+        {managesSpend ? (
+          <KpiCell
+            label="Budget health"
+            // Keyed on the data and not on the query's phase: an errored
+            // read goes back to pending on its next fetch, and a cell that
+            // read that as "loaded, and zero" is the false zero
+            // otari-ai#1935 and #1961 were both about.
+            value={
+              ceilings.data && ceilingHealth.worst
+                ? formatPct(ceilingHealth.worst.pct)
+                : "—"
+            }
+            severity={
+              ceilings.data &&
+              ceilingHealth.worst &&
+              ceilingHealth.status !== "neutral"
+                ? {
+                    status: ceilingHealth.status,
+                    word: BUDGET_WORDS[ceilingHealth.status],
+                  }
+                : undefined
+            }
+            subline={
+              ceilings.data && ceilingHealth.worst
+                ? undefined
+                : ceilings.data
+                  ? noCeilingReason
+                  : "no data"
+            }
+            // `SpendMeter`, not the plain accent `Meter`, and the same
+            // component the Spend page's own rows use, so the two cannot say
+            // different things about one ceiling.
+            graphic={
+              ceilings.data && ceilingHealth.worst ? (
+                <SpendMeter
+                  spent={ceilingHealth.worst.spent}
+                  allocated={ceilingHealth.worst.allocated}
+                  ariaLabel={`Tightest spend ceiling: ${ceilingHealth.worst.name}`}
+                />
+              ) : undefined
+            }
+          />
+        ) : null}
+      </KpiStrip>
 
-      <RecentActivity
-        entries={recent.data ?? []}
-        loading={recent.isLoading}
-        error={recent.error}
+      <SpendChart series={periodSeries} ready={period.isSuccess} />
+
+      <ActivitySplit
+        recent={recent}
+        activeKeys={keys.data ? activeKeys : null}
+        activeMembers={members.data ? activeMembers : null}
+        links={railLinks(managesSpend)}
       />
     </div>
   )
@@ -461,36 +613,11 @@ export function OverviewPage({
   // overcount the rail and stay put when the switcher moves.
   const members = useWorkspaceMembers(usage.scope ?? null)
 
-  const todayTotals = today.data?.totals
-  const periodTotals = period.data?.totals
-  const prevTotals = previous.data?.totals
-
-  // The 30-day daily series is already on the wire, and so is today's hourly
-  // one: the today window is requested at `"hour"` granularity for exactly this.
-  // A single point has no trend to draw, so a sparkline needs two.
   const periodSeries = period.data?.series ?? []
-  const todaySeries = today.data?.series ?? []
-  const hasTrend = periodSeries.length > 1
-  const hasHourlyTrend = todaySeries.length > 1
 
-  // The status strip reads the window's error rate too; errorRateHealth is
-  // pure, so it is derived here again rather than threaded out of the tiles.
-  const err = errorRateHealth(periodTotals)
-  const errPrev = errorRateHealth(prevTotals)
-  // Each delta is its own const so the cell below can gate its chip on the
-  // fraction rather than on the query: `deltaFraction` also returns null once
-  // the current window has landed but the previous one has not, and when the
-  // previous value is 0.
-  const costDelta = periodTotals
-    ? deltaFraction(periodTotals.cost, prevTotals?.cost)
-    : null
-  const requestDelta = periodTotals
-    ? deltaFraction(periodTotals.request_count, prevTotals?.request_count)
-    : null
-  const errDelta =
-    err.rate !== null && errPrev.rate !== null
-      ? deltaFraction(err.rate, errPrev.rate)
-      : null
+  // The attention strip reads the window's error rate too; errorRateHealth is
+  // pure, so it is derived here again rather than threaded out of the cells.
+  const err = errorRateHealth(period.data?.totals)
 
   const budget = budgetHealth(budgets.data ?? [])
   const providerHealth = providerHealthStatus(health.data)
@@ -587,117 +714,11 @@ export function OverviewPage({
       />
 
       <KpiStrip empty={isEmpty}>
-        <KpiCell
-          label="Spend today"
-          // A real zero where zero is a fact, an em dash where the value is
-          // unknown: a failed query must not read as "you spent nothing".
-          value={todayTotals ? formatUsd(todayTotals.cost) : "—"}
-          // "midnight" and not "00:00 UTC": `useWindows` builds this window from
-          // the operator's *local* midnight, deliberately and with a comment
-          // saying so, so a UTC string would be false for everyone not on it.
-          subline={
-            isEmpty
-              ? "no prior spend"
-              : todayTotals
-                ? "since midnight"
-                : "no data"
-          }
-          graphic={
-            !isEmpty && hasHourlyTrend ? (
-              <Sparkline
-                values={todaySeries.map((p) => p.cost)}
-                ariaLabel="Spend by hour today"
-                height={40}
-              />
-            ) : undefined
-          }
-        />
-        <KpiCell
-          label="Spend, last 30 days"
-          value={periodTotals ? formatUsd(periodTotals.cost) : "—"}
-          subline={
-            isEmpty ? "no prior spend" : periodTotals ? undefined : "no data"
-          }
-          // Spend falling is the improvement, so a rise paints danger while the
-          // arrow keeps telling the truth about which way it went.
-          delta={
-            costDelta !== null ? (
-              <TrendChip
-                fraction={costDelta}
-                polarity="down-is-good"
-                caption="vs prev"
-              />
-            ) : undefined
-          }
-          graphic={
-            !isEmpty && hasTrend ? (
-              <Sparkline
-                values={periodSeries.map((p) => p.cost)}
-                ariaLabel="Spend trend over the last 30 days"
-                height={40}
-              />
-            ) : undefined
-          }
-        />
-        <KpiCell
-          label="Requests, last 30 days"
-          value={periodTotals ? formatNumber(periodTotals.request_count) : "—"}
-          subline={
-            isEmpty ? "no prior traffic" : periodTotals ? undefined : "no data"
-          }
-          // Volume, so no polarity: more traffic through the gateway is neither
-          // a win nor a regression on its own, and the error rate beside it is
-          // what carries the judgment.
-          delta={
-            requestDelta !== null ? (
-              <TrendChip fraction={requestDelta} caption="vs prev" />
-            ) : undefined
-          }
-          graphic={
-            !isEmpty && hasTrend ? (
-              <Sparkline
-                values={periodSeries.map((p) => p.requests)}
-                ariaLabel="Request volume trend over the last 30 days"
-                height={40}
-              />
-            ) : undefined
-          }
-        />
-        <KpiCell
-          label="Error rate, last 30 days"
-          value={err.rate === null ? "—" : formatPct(err.rate)}
-          // The word is present whenever there is a rate to judge, "Healthy"
-          // included: a line that appears only when something is wrong makes
-          // its absence ambiguous with a page that has not loaded.
-          severity={
-            err.status === "neutral"
-              ? undefined
-              : { status: err.status, word: ERROR_WORDS[err.status] }
-          }
-          subline={
-            err.rate === null
-              ? isEmpty
-                ? "NO REQUESTS YET"
-                : "no requests in range"
-              : undefined
-          }
-          // Errors falling is the improvement, as with spend.
-          delta={
-            errDelta !== null ? (
-              <TrendChip
-                fraction={errDelta}
-                polarity="down-is-good"
-                caption="vs prev"
-              />
-            ) : undefined
-          }
-          graphic={
-            !isEmpty && periodTotals ? (
-              <span className="text-xs text-muted">
-                {`${formatNumber(periodTotals.error_count)} of ${formatNumber(periodTotals.request_count)} requests`}
-              </span>
-            ) : undefined
-          }
+        <UsageKpiCells
+          today={today}
+          period={period}
+          previous={previous}
+          empty={isEmpty}
         />
         <KpiCell
           label="Budget health"
@@ -745,33 +766,31 @@ export function OverviewPage({
         <SpendChart series={periodSeries} ready={period.isSuccess} />
       )}
 
-      <div className="flex flex-col lg:flex-row lg:items-stretch">
-        <div className="min-w-0 flex-1">
-          <RecentActivity
-            entries={recent.data ?? []}
-            loading={recent.isLoading}
-            error={recent.error}
-          />
-        </div>
-        <div className="border-border lg:w-[300px] lg:shrink-0 lg:border-l">
-          <WorkspaceRail
-            activeKeys={keys.data ? activeKeys : null}
-            activeMembers={members.data ? activeMembers : null}
-          />
-        </div>
-      </div>
+      <ActivitySplit
+        recent={recent}
+        activeKeys={keys.data ? activeKeys : null}
+        activeMembers={members.data ? activeMembers : null}
+        // An operator reaches every one of these; the rail on the tenant page
+        // drops the two the organization rail withholds from a member.
+        links={RAIL_LINKS}
+      />
     </div>
   )
 }
 
+// `children` is the standfirst, which is the one part of the header that
+// differs between the two pages: an operator is told about the gateway, a
+// tenant about their organization.
 function OverviewHeader({
   refresh,
   isRefreshing,
   updatedAt,
+  children = "At-a-glance spend, traffic, and health across the gateway.",
 }: {
   refresh: () => void
   isRefreshing: boolean
   updatedAt: number
+  children?: ReactNode
 }) {
   return (
     <PageIntro
@@ -787,7 +806,7 @@ function OverviewHeader({
         </div>
       }
     >
-      At-a-glance spend, traffic, and health across the gateway.
+      {children}
     </PageIntro>
   )
 }
@@ -1309,16 +1328,83 @@ function RecentActivity({
 }
 
 /**
- * The workspace's own numbers, beside the deployment-wide table rather than in
- * it. A rail and not two more KPI cells: these count things that belong to one
- * workspace, and the strip above counts what the gateway did.
+ * The page's lower half: the activity preview against the workspace rail.
+ *
+ * One component rather than the same wrappers on both overviews, because the
+ * rail's fixed lane and the rule between the two are layout they share.
+ */
+function ActivitySplit({
+  recent,
+  activeKeys,
+  activeMembers,
+  links,
+}: {
+  recent: ReturnType<typeof useUsageLogs>
+  activeKeys: number | null
+  activeMembers: number | null
+  links: readonly RailDestination[]
+}) {
+  return (
+    <div className="flex flex-col lg:flex-row lg:items-stretch">
+      <div className="min-w-0 flex-1">
+        <RecentActivity
+          entries={recent.data ?? []}
+          loading={recent.isLoading}
+          error={recent.error}
+        />
+      </div>
+      <div className="border-border lg:w-[18.75rem] lg:shrink-0 lg:border-l">
+        <WorkspaceRail
+          activeKeys={activeKeys}
+          activeMembers={activeMembers}
+          links={links}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface RailDestination {
+  to: LinkProps["to"]
+  label: string
+  /** Reached through the organization rail, which opens only to its managers. */
+  organization?: true
+}
+
+const RAIL_LINKS: readonly RailDestination[] = [
+  { to: "/keys", label: "API keys" },
+  { to: "/organization/members", label: "Members", organization: true },
+  { to: "/budgets", label: "Budgets", organization: true },
+  { to: "/activity", label: "Activity" },
+]
+
+/**
+ * Where a caller may actually go from here.
+ *
+ * Members and Budgets sit behind the organization rail, which `AppShell` opens
+ * only to a caller who manages the organization, and both destinations refuse a
+ * member on the server too. Offering them anyway would send that member to a
+ * page of refusals from the one page they land on without choosing to.
+ */
+function railLinks(managesOrganization: boolean): readonly RailDestination[] {
+  return managesOrganization
+    ? RAIL_LINKS
+    : RAIL_LINKS.filter((link) => !link.organization)
+}
+
+/**
+ * The workspace's own numbers, beside the activity table rather than in it. A
+ * rail and not two more KPI cells: these count things that belong to one
+ * workspace, and the strip above counts what was served.
  */
 function WorkspaceRail({
   activeKeys,
   activeMembers,
+  links,
 }: {
   activeKeys: number | null
   activeMembers: number | null
+  links: readonly RailDestination[]
 }) {
   return (
     <section className="flex flex-col gap-6 pt-6 lg:pl-6">
@@ -1338,10 +1424,11 @@ function WorkspaceRail({
       <div>
         <h2 className="text-overline">Go to</h2>
         <ul className="mt-1 flex flex-col">
-          <RailLink to="/keys">API keys</RailLink>
-          <RailLink to="/organization/members">Members</RailLink>
-          <RailLink to="/budgets">Budgets</RailLink>
-          <RailLink to="/activity">Activity</RailLink>
+          {links.map((link) => (
+            <RailLink key={link.label} to={link.to}>
+              {link.label}
+            </RailLink>
+          ))}
         </ul>
       </div>
     </section>

--- a/web/src/features/overview/overview.test.ts
+++ b/web/src/features/overview/overview.test.ts
@@ -114,6 +114,25 @@ describe("budgetHealth", () => {
     })
   })
 
+  it("reads spend against a cap of zero as over, not as within budget", () => {
+    // `max_budget` is `ge=0` on the wire, so a budget that admits nothing is a
+    // real figure, and spend recorded before it was lowered to zero is a real
+    // state. Dividing was the trap: it left the row at 0% and the strip
+    // reporting "All within budget" over a cap that refuses every request.
+    const result = budgetHealth([
+      budget({ max_budget: 0, user_count: 2, total_spend: 5, name: "frozen" }),
+    ])
+    expect(result.status).toBe("alert")
+    expect(result.overCount).toBe(1)
+    expect(result.worst?.pct).toBe(1)
+
+    // An untouched zero cap has nothing to report and stays on track.
+    expect(
+      budgetHealth([budget({ max_budget: 0, user_count: 2, total_spend: 0 })])
+        .status,
+    ).toBe("ok")
+  })
+
   it("flags near-limit at 80% and picks the worst-off budget", () => {
     const result = budgetHealth([
       budget({
@@ -189,6 +208,24 @@ describe("spendCeilingHealth", () => {
     expect(result.status).toBe("alert")
     expect(result.overCount).toBe(1)
     expect(result.worst?.name).toBe("Deployment cap")
+  })
+
+  it("reads spend against a ceiling of zero as over", () => {
+    const result = spendCeilingHealth(
+      [
+        organizationSpendCeiling({
+          name: "Frozen",
+          max_budget: 0,
+          current_spend: 5,
+        }),
+      ],
+      named,
+    )
+    expect(result.status).toBe("alert")
+    expect(result.overCount).toBe(1)
+    // 100%, not Infinity: the share has no finite value, and the severity word
+    // beside it is what says the cap was exceeded rather than reached.
+    expect(result.worst?.pct).toBe(1)
   })
 
   it("picks the worst-off ceiling", () => {

--- a/web/src/features/overview/overview.test.ts
+++ b/web/src/features/overview/overview.test.ts
@@ -5,9 +5,9 @@ import {
   budgetHealth,
   errorRateHealth,
   providerHealthStatus,
-  toStatStatus,
+  spendCeilingHealth,
 } from "@/features/overview/overview"
-import { usageTotals } from "@/tests/fixtures"
+import { organizationSpendCeiling, usageTotals } from "@/tests/fixtures"
 
 function budget(over: Partial<Budget>): Budget {
   return {
@@ -135,11 +135,80 @@ describe("budgetHealth", () => {
   })
 })
 
-describe("toStatStatus", () => {
-  it("maps neutral to undefined and passes the rest through", () => {
-    expect(toStatStatus("neutral")).toBeUndefined()
-    expect(toStatStatus("ok")).toBe("ok")
-    expect(toStatStatus("warn")).toBe("warn")
-    expect(toStatStatus("alert")).toBe("alert")
+describe("spendCeilingHealth", () => {
+  const named = (ceiling: { name: string | null }) => ceiling.name ?? "a scope"
+
+  it("is neutral with nothing capped", () => {
+    expect(spendCeilingHealth([], named).status).toBe("neutral")
+    expect(
+      spendCeilingHealth(
+        [organizationSpendCeiling({ max_budget: null, current_spend: 9999 })],
+        named,
+      ).cappedCount,
+    ).toBe(0)
+  })
+
+  it("judges spend plus what is reserved against the ceiling's own figure", () => {
+    // A ceiling refuses on the sum, so the cell has to judge the sum. Its
+    // `max_budget` is the pooled figure, not a per-user cap, so no roster
+    // multiplies it the way `budgetHealth` multiplies a budget's.
+    const result = spendCeilingHealth(
+      [
+        organizationSpendCeiling({
+          name: "Staging cap",
+          max_budget: 250,
+          current_spend: 180,
+          reserved_spend: 20,
+        }),
+      ],
+      named,
+    )
+    expect(result.status).toBe("warn")
+    expect(result.worst).toEqual({
+      name: "Staging cap",
+      spent: 200,
+      allocated: 250,
+      pct: 0.8,
+    })
+  })
+
+  it("counts a ceiling the organization may not edit", () => {
+    // `manageable` is descriptive, never a permission: the row is enforcing
+    // against this organization whoever set its figure, so it is judged.
+    const result = spendCeilingHealth(
+      [
+        organizationSpendCeiling({
+          name: "Deployment cap",
+          manageable: false,
+          max_budget: 100,
+          current_spend: 150,
+        }),
+      ],
+      named,
+    )
+    expect(result.status).toBe("alert")
+    expect(result.overCount).toBe(1)
+    expect(result.worst?.name).toBe("Deployment cap")
+  })
+
+  it("picks the worst-off ceiling", () => {
+    const result = spendCeilingHealth(
+      [
+        organizationSpendCeiling({
+          id: "a",
+          max_budget: 100,
+          current_spend: 10,
+        }),
+        organizationSpendCeiling({
+          id: "b",
+          name: "tightest",
+          max_budget: 100,
+          current_spend: 90,
+        }),
+      ],
+      named,
+    )
+    expect(result.worst?.name).toBe("tightest")
+    expect(result.nearCount).toBe(1)
   })
 })

--- a/web/src/features/overview/overview.ts
+++ b/web/src/features/overview/overview.ts
@@ -1,17 +1,14 @@
-import type { Budget, ProviderHealthResponse, UsageTotals } from "@/client"
+import type {
+  Budget,
+  OrganizationSpendCeiling,
+  ProviderHealthResponse,
+  UsageTotals,
+} from "@/client"
 
 // Attention-routing status for an overview tile / the system-status strip.
 // "neutral" means "nothing to judge here" (no data, unlimited, none configured)
 // and renders as a plain tile with no color, never as green/red.
 export type Health = "ok" | "warn" | "alert" | "neutral"
-
-// StatCard only carries ok/warn/alert (a colored accent); neutral maps to an
-// un-statused (plain) tile.
-export function toStatStatus(
-  health: Health,
-): "ok" | "warn" | "alert" | undefined {
-  return health === "neutral" ? undefined : health
-}
 
 // ---------- error rate ----------
 
@@ -53,10 +50,8 @@ export function providerHealthStatus(
 
 // ---------- budget health ----------
 
-// >=80% of allocation amber, >=100% red. `max_budget` is a PER-USER cap and users
-// share a budget, so the honest allocation is cap * user_count (matches
-// BudgetsPage's UsageCell). Unlimited caps and user-less budgets have no
-// meaningful utilization and are excluded.
+// >=80% of allocation amber, >=100% red, for either signal below. What an
+// allocation *is* differs between them, and each says so.
 export const BUDGET_WARN = 0.8
 
 export interface BudgetHealth {
@@ -64,54 +59,45 @@ export interface BudgetHealth {
   label: string
   overCount: number
   nearCount: number
-  // Budgets with a finite cap and at least one user (the ones we can judge).
+  // The rows with a finite cap, which are the ones we can judge.
   cappedCount: number
   worst?: { name: string; spent: number; allocated: number; pct: number }
 }
 
-export function budgetHealth(budgets: Budget[]): BudgetHealth {
-  if (budgets.length === 0) {
-    return {
-      status: "neutral",
-      label: "No budgets configured",
-      overCount: 0,
-      nearCount: 0,
-      cappedCount: 0,
-    }
-  }
-  const capped = budgets.filter(
-    (b) => b.max_budget !== null && b.user_count > 0,
-  )
-  if (capped.length === 0) {
-    return {
-      status: "neutral",
-      label: "No capped budgets",
-      overCount: 0,
-      nearCount: 0,
-      cappedCount: 0,
-    }
-  }
+/** One judgeable row: what it is called, what it has spent, what it may spend. */
+interface Allocation {
+  name: string
+  spent: number
+  allocated: number
+}
 
+function noneToJudge(label: string): BudgetHealth {
+  return {
+    status: "neutral",
+    label,
+    overCount: 0,
+    nearCount: 0,
+    cappedCount: 0,
+  }
+}
+
+// The judgment, once rows are reduced to allocations. Shared by the two signals
+// below so the deployment strip and the tenant one cannot classify the same
+// utilization differently.
+function allocationHealth(capped: Allocation[]): BudgetHealth {
   let overCount = 0
   let nearCount = 0
   let worst: BudgetHealth["worst"]
   let worstPct = -1
-  for (const b of capped) {
-    const allocated = (b.max_budget as number) * b.user_count
-    const pct = allocated > 0 ? b.total_spend / allocated : 0
+  for (const row of capped) {
+    const pct = row.allocated > 0 ? row.spent / row.allocated : 0
     if (pct >= 1) overCount += 1
     else if (pct >= BUDGET_WARN) nearCount += 1
     if (pct > worstPct) {
       worstPct = pct
-      worst = {
-        name: b.name ?? b.budget_id,
-        spent: b.total_spend,
-        allocated,
-        pct,
-      }
+      worst = { ...row, pct }
     }
   }
-
   const status: Health = overCount > 0 ? "alert" : nearCount > 0 ? "warn" : "ok"
   const label =
     overCount > 0
@@ -127,4 +113,64 @@ export function budgetHealth(budgets: Budget[]): BudgetHealth {
     cappedCount: capped.length,
     worst,
   }
+}
+
+/**
+ * The deployment's own budgets, as the operator strip reads them.
+ *
+ * `max_budget` there is a PER-USER cap that users share, so the honest
+ * allocation is cap * user_count (which is what BudgetsPage's UsageCell shows).
+ * Unlimited caps and user-less budgets have no utilization to judge.
+ */
+export function budgetHealth(budgets: Budget[]): BudgetHealth {
+  if (budgets.length === 0) {
+    return noneToJudge("No budgets configured")
+  }
+  const capped = budgets
+    .filter((b) => b.max_budget !== null && b.user_count > 0)
+    .map((b) => ({
+      name: b.name ?? b.budget_id,
+      spent: b.total_spend,
+      allocated: (b.max_budget as number) * b.user_count,
+    }))
+  if (capped.length === 0) {
+    return noneToJudge("No capped budgets")
+  }
+  return allocationHealth(capped)
+}
+
+/**
+ * The same judgment over the rows a tenant can read: their organization's spend
+ * ceilings.
+ *
+ * A ceiling carries its own counters, so the allocation is `max_budget` itself
+ * rather than a per-user cap times a roster, and what it is judged against is
+ * `current_spend + reserved_spend`, the sum a ceiling actually refuses on.
+ *
+ * `manageable` is deliberately not consulted. It says whose figure this is, not
+ * whose spend: a ceiling naming a budget the organization does not own is
+ * enforcing against that organization today, so dropping it would let the page
+ * read as uncapped.
+ *
+ * `nameOf` names a row for the reader, because a ceiling's own label is optional
+ * and what it caps is an id on the wire.
+ */
+export function spendCeilingHealth(
+  ceilings: readonly OrganizationSpendCeiling[],
+  nameOf: (ceiling: OrganizationSpendCeiling) => string,
+): BudgetHealth {
+  if (ceilings.length === 0) {
+    return noneToJudge("No spend ceilings configured")
+  }
+  const capped = ceilings
+    .filter((c) => c.max_budget !== null)
+    .map((c) => ({
+      name: nameOf(c),
+      spent: c.current_spend + c.reserved_spend,
+      allocated: c.max_budget as number,
+    }))
+  if (capped.length === 0) {
+    return noneToJudge("No ceiling caps spend")
+  }
+  return allocationHealth(capped)
 }

--- a/web/src/features/overview/overview.ts
+++ b/web/src/features/overview/overview.ts
@@ -71,6 +71,7 @@ interface Allocation {
   allocated: number
 }
 
+/** No row here has a utilization, so there is nothing to be healthy or not. */
 function noneToJudge(label: string): BudgetHealth {
   return {
     status: "neutral",
@@ -81,16 +82,24 @@ function noneToJudge(label: string): BudgetHealth {
   }
 }
 
-// The judgment, once rows are reduced to allocations. Shared by the two signals
-// below so the deployment strip and the tenant one cannot classify the same
-// utilization differently.
+/**
+ * The judgment, once rows are reduced to allocations. Shared by the two signals
+ * below so the deployment strip and the tenant one cannot classify the same
+ * utilization differently.
+ */
 function allocationHealth(capped: Allocation[]): BudgetHealth {
   let overCount = 0
   let nearCount = 0
   let worst: BudgetHealth["worst"]
   let worstPct = -1
   for (const row of capped) {
-    const pct = row.allocated > 0 ? row.spent / row.allocated : 0
+    // A zero allocation admits nothing, so anything spent against one is over
+    // it. Reported as a full 100% rather than as the infinite ratio it really
+    // is: the share has no finite value, and a cell reading "Infinity%" tells
+    // the reader less than "Over budget" at 100% does. It is a floor, so a row
+    // measurably further past its limit still wins `worst`.
+    const pct =
+      row.allocated > 0 ? row.spent / row.allocated : row.spent > 0 ? 1 : 0
     if (pct >= 1) overCount += 1
     else if (pct >= BUDGET_WARN) nearCount += 1
     if (pct > worstPct) {

--- a/web/src/shared/components/deprecated/deprecated.test.ts
+++ b/web/src/shared/components/deprecated/deprecated.test.ts
@@ -42,7 +42,6 @@ const REPLACEMENT: Record<string, string> = {
  */
 const KNOWN: Record<string, readonly string[]> = {
   "features/budgets/OrganizationBudgetsPage.tsx": ["PageHeader"],
-  "features/overview/OverviewPage.tsx": ["PageHeader", "StatCard"],
   "features/tools/McpServersPage.tsx": ["PageHeader"],
   "features/workspaces/WorkspaceMembersPage.tsx": ["PageHeader"],
   "features/account/PasskeysCard.tsx": ["RowActions"],

--- a/web/src/shared/components/metrics/KpiStrip.test.tsx
+++ b/web/src/shared/components/metrics/KpiStrip.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { KpiStrip } from "@/shared/components/metrics/KpiStrip"
+
+// The grid's own element, which is the one inside `Section`'s band.
+function track(label: string): HTMLElement {
+  return screen.getByText(label).parentElement as HTMLElement
+}
+
+describe("KpiStrip", () => {
+  it("lays five tracks by default", () => {
+    render(
+      <KpiStrip empty={false}>
+        <span>cell</span>
+      </KpiStrip>,
+    )
+
+    expect(track("cell")).toHaveClass("xl:grid-cols-5")
+  })
+
+  it("narrows to the number of cells the caller passed", () => {
+    // A strip whose track count outruns its children leaves a blank column at
+    // the end of the row, which is what the tenant Overview would get where it
+    // withholds the budget cell from a member.
+    render(
+      <KpiStrip empty={false} columns={4}>
+        <span>cell</span>
+      </KpiStrip>,
+    )
+
+    expect(track("cell")).toHaveClass("xl:grid-cols-4")
+    expect(track("cell")).not.toHaveClass("xl:grid-cols-5")
+  })
+})

--- a/web/src/shared/components/metrics/KpiStrip.test.tsx
+++ b/web/src/shared/components/metrics/KpiStrip.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 
 import { KpiStrip } from "@/shared/components/metrics/KpiStrip"
 
-// The grid's own element, which is the one inside `Section`'s band.
+/** The grid's own element, which is the one inside `Section`'s band. */
 function track(label: string): HTMLElement {
   return screen.getByText(label).parentElement as HTMLElement
 }

--- a/web/src/shared/components/metrics/KpiStrip.tsx
+++ b/web/src/shared/components/metrics/KpiStrip.tsx
@@ -1,17 +1,30 @@
 import type { ReactNode } from "react"
 import { Section } from "@/shared/components/layout/Section"
 
+// Spelled out rather than interpolated: Tailwind scans for whole class names,
+// so `xl:grid-cols-${n}` emits nothing.
+const COLUMNS = {
+  4: "grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4",
+  5: "grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-5",
+} as const
+
 /**
- * Five equal cells divided by vertical rules, between horizontal ones. Equal
- * rather than content-sized so the divisions land on a rhythm rather than
- * wherever the longest label happens to end.
+ * Equal cells divided by vertical rules, between horizontal ones. Equal rather
+ * than content-sized so the divisions land on a rhythm rather than wherever the
+ * longest label happens to end.
+ *
+ * `columns` is the number of cells the caller passes, not a layout preference:
+ * a strip whose track count outruns its children leaves a blank column at the
+ * end of the row.
  */
 export function KpiStrip({
   children,
   empty,
+  columns = 5,
 }: {
   children: ReactNode
   empty: boolean
+  columns?: keyof typeof COLUMNS
 }) {
   return (
     <Section
@@ -20,7 +33,7 @@ export function KpiStrip({
       // other. Without it a label that wraps makes its own cell taller and
       // drops its value below the others'.
       className="border-y border-border"
-      contentClassName="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-5"
+      contentClassName={COLUMNS[columns]}
       // The graphic row is dropped uniformly in the empty state, so the strip
       // gets shorter without any cell changing shape relative to its neighbors.
       data-empty={empty ? "true" : undefined}

--- a/web/src/shared/components/metrics/SpendMeter.test.tsx
+++ b/web/src/shared/components/metrics/SpendMeter.test.tsx
@@ -32,10 +32,13 @@ describe("spendState", () => {
     expect(spendState(40, 5000)).toBe("on-track")
   })
 
-  it("treats an allocation of zero as on track rather than dividing by it", () => {
-    // A budget with no limit reaches here through a caller that has already
-    // said so; what matters is that it cannot produce Infinity or NaN.
-    expect(spendState(10, 0)).toBe("on-track")
+  it("reads spend against a cap of zero as over, without dividing by it", () => {
+    // `max_budget` is `ge=0` on the wire, so a cap that admits nothing is a
+    // real figure, and spend recorded before it was lowered to zero is a real
+    // state. Answered from the spend, so it still cannot produce Infinity or
+    // NaN. An untouched zero cap has nothing to report and stays on track.
+    expect(spendState(10, 0)).toBe("over")
+    expect(spendState(0, 0)).toBe("on-track")
   })
 })
 

--- a/web/src/shared/components/metrics/SpendMeter.tsx
+++ b/web/src/shared/components/metrics/SpendMeter.tsx
@@ -14,7 +14,10 @@ export function spendState(
   allocated: number,
   nearLimitAt = 0.8,
 ): SpendState {
-  if (allocated <= 0) return "on-track"
+  // A cap of zero admits nothing, so any spend against one is past it. Answered
+  // from the spend rather than by dividing, which is what keeps a zero
+  // allocation from producing Infinity or NaN here.
+  if (allocated <= 0) return spent > 0 ? "over" : "on-track"
   if (spent > allocated) return "over"
   return spent >= allocated * nearLimitAt ? "near-limit" : "on-track"
 }
@@ -55,7 +58,9 @@ export function SpendMeter({
   className?: string
 }) {
   const state = spendState(spent, allocated, nearLimitAt)
-  const share = allocated > 0 ? spent / allocated : 0
+  // Full for spend against a zero cap, matching the state above: a bar drawn
+  // empty beside a reading of "over budget" contradicts itself.
+  const share = allocated > 0 ? spent / allocated : spent > 0 ? 1 : 0
   const pct = Math.max(0, Math.min(1, share)) * 100
   const thresholdPct = nearLimitAt * 100
   return (

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -8,6 +8,7 @@
 
 import type {
   ActivationAttempt,
+  ApiKey,
   Budget,
   CallerOrganizationMembership,
   DeploymentBootstrap,
@@ -17,6 +18,7 @@ import type {
   OrganizationDomain,
   OrganizationGuardrail,
   OrganizationMember,
+  OrganizationSpendCeiling,
   OrgProviderKey,
   PendingOrganizationInvitation,
   PricingResponse,
@@ -371,6 +373,66 @@ export function scopedBudget(
     period_end: null,
     created_at: "2026-01-01T00:00:00+00:00",
     updated_at: "2026-01-01T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+/**
+ * One of the caller's organization's spend ceilings, as
+ * `/v1/organizations/me/spend-ceilings` reports it.
+ *
+ * The tenant-scoped view of `scopedBudget`: the same row joined onto its
+ * budget, plus `manageable`, which says whether the figure is this
+ * organization's to change and never whether the ceiling binds it.
+ */
+export function organizationSpendCeiling(
+  overrides: Partial<OrganizationSpendCeiling> = {},
+): OrganizationSpendCeiling {
+  return {
+    id: "cccccccc-1111-2222-3333-444444444444",
+    scope_type: "organization",
+    scope_id: ORGANIZATION_ID,
+    provider_key_id: null,
+    budget_id: "bbbbbbbb-1111-2222-3333-444444444444",
+    name: null,
+    max_budget: 250,
+    current_spend: 12.5,
+    reserved_spend: 0,
+    token_limit: null,
+    current_tokens: 0,
+    reserved_tokens: 0,
+    request_limit: null,
+    current_requests: 0,
+    reserved_requests: 0,
+    budget_duration_sec: null,
+    reset_alignment: "calendar_month",
+    period_start: "2026-08-01T00:00:00+00:00",
+    period_end: "2026-09-01T00:00:00+00:00",
+    manageable: true,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+/** A key as either key surface reports one; both answer the same shape. */
+export function apiKey(overrides: Partial<ApiKey> = {}): ApiKey {
+  return {
+    capture_agent_telemetry: null,
+    id: "key-1",
+    // NOT NULL on the server: a key always belongs to exactly one workspace.
+    workspace_id: "11111111-1111-1111-1111-111111111111",
+    key_prefix: "gw-AbC3dE",
+    key_name: "ci-bot",
+    user_id: "alice",
+    created_at: "2026-01-01T00:00:00+00:00",
+    last_used_at: null,
+    expires_at: null,
+    is_active: true,
+    allowed_models: null,
+    exclude_from_budget: false,
+    reject_user_mismatch: null,
+    metadata: {},
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

`OverviewIndex` resolves to two pages, and the tenant one (`OrganizationOverview`) was built
to answer a dead-end card rather than to reach parity with the operator one. It carried no
budget reference at all, no keys or members rail and no spend chart, and it was still drawn
with the deprecated `PageHeader` and `StatCard` where the operator page had been rebuilt onto
`OverviewHeader` and `KpiStrip`/`KpiCell`. This closes those gaps.

**The budget signal.** The operator's "Budget health" cell reads `/v1/budgets`, which is
deployment-wide and refuses a tenant. The tenant equivalent turned out not to be
`/v1/organizations/me/budgets`: that endpoint carries a budget's figure and no counters, so a
tenant's spend against a cap lives on `/v1/organizations/me/spend-ceilings`, whose rows carry
`current_spend`, `reserved_spend` and the joined `max_budget`. `spendCeilingHealth` judges
`current_spend + reserved_spend` against `max_budget`, which is the sum a ceiling actually
refuses on, and reuses the operator signal's thresholds so the two cannot classify one
utilization differently.

**`manageable` is not a gate.** A ceiling naming a budget the organization does not own
reports `manageable` false and is still counted: the field says whose figure it is, not whose
spend, and that ceiling is enforcing against the organization today. Reading it as a filter
would let the page report "on track" while the cap that is refusing requests is over.

**The role gate.** The cell is offered to an owner or admin and withheld from a member, and
the query is not made rather than made and its refusal painted. That mirrors the server:
`OrganizationBudgetService._managed_organization` puts every read and write on this surface
through `require_active_organization_management_access`, which is owner, admin or superuser.
`canManage` is the existing client predicate for that line and is narrower on the superuser
case only, in the safe direction, for the reason `roles.ts` documents. It is the same
predicate `AppShell` opens the organization rail with, so the Overview and the rail agree
about who is offered Spend & budgets. The rail's "Go to" list drops Members and Budgets for a
member for the same reason.

**Gating axes.**

- **Entitlement: does not apply.** Base otari, no capability name. An entitlement gate would
  hide this from self-hosted otari, which has no entitlements server.
- **Operator: does not apply.** This page is the non-operator branch by definition. There is
  no `isDeploymentOperator` anywhere inside it, and the doc comment says why.
- **Surface: does not apply.** No deployment publishes one for this, and gating on one nobody
  publishes renders it nowhere.

**Also in scope.** The rail's two counts, from surfaces the caller already reads
(`useKeys` picks `/v1/organizations/me/keys` for a non-operator, and a workspace roster is
readable by any member of that workspace); the spend chart, off the series the scoped summary
already returns; and the rebuild onto the shared primitives, which moved the four usage cells
into one `UsageKpiCells` fragment both pages render and left `StatCard` with no call site, so
the deprecated gate's list and DESIGN.md's table lose their rows for it. `toStatStatus`
existed only to feed `StatCard` and goes with it.

**Deliberately not added:** the attention strip. It reads provider health and the deployment's
budgets, both operator surfaces, so its absence here is correct rather than a gap.

`KpiStrip` gains a `columns` prop, because a five-track strip with four cells leaves a blank
column at the end of the row, which is what a member would see.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#2085

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only, so no backend contract moved and no generated artifact changed.
`make lint`, `make typecheck`, `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and
`pnpm --dir web test` (3,924 passing) were run locally. `tests/integration` needs PostgreSQL
and Docker, which this machine does not have, so that suite is left to CI.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code, at @khaledosman's request.

**Any additional AI details you'd like to share:**

The endpoint named in the tracking issue (`/v1/organizations/me/budgets`) turned out to carry
no spend counters, so the signal is read from the ceilings route beside it instead. The
self-review pass caught a dead `toStatStatus` export left by the `StatCard` removal, a
duplicated activity-and-rail layout across the two pages (now one `ActivitySplit`), and a
subline that said "no spend ceilings set" for an organization whose ceilings cap tokens rather
than dollars.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added tenant Overview parity with the operator Overview.
- Added budget health, usage trends, keys, members, recent activity, and navigation.
- Limited budget health and related navigation to organization owners and admins.
- Removed deprecated `StatCard` usage and related documentation.
- Added configurable KPI strip columns and shared test fixtures.

## Technical notes

- Budget health uses organization spend ceilings and combines current and reserved spend.
- Added `spendCeilingHealth` and removed `toStatStatus`.
- Lint, typecheck, and web tests pass. Integration tests remain for CI because they require PostgreSQL and Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->