### PR TITLE
fix(dashboard): remove bulk price editing from the models page

### DIFF
--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -1061,39 +1061,6 @@ describe("ModelsPage", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("bulk-sets pricing on the selected models", async () => {
-    const fetchMock = mockApi()
-    const user = userEvent.setup()
-
-    renderWithClient(<ModelsPage />)
-    await screen.findByText("openai:gpt-4o")
-
-    const row = tableRow("openai:gpt-4o")
-    await user.click(within(row).getByRole("checkbox"))
-
-    const bar = (await screen.findByText("1 selected")).closest("div")!
-    await user.click(within(bar).getByRole("button", { name: "Set pricing" }))
-
-    const dialog = await screen.findByRole("alertdialog")
-    await user.type(within(dialog).getByLabelText("Input $ / 1M"), "5")
-    await user.type(within(dialog).getByLabelText("Output $ / 1M"), "12")
-    await user.click(within(dialog).getByRole("button", { name: "Set price" }))
-
-    await vi.waitFor(() => {
-      const call = fetchMock.mock.calls.find(
-        ([u, init]) =>
-          String(u).includes("/v1/pricing") &&
-          (init?.method ?? "").toUpperCase() === "POST",
-      )
-      expect(call).toBeTruthy()
-      expect(JSON.parse(String(call![1]!.body))).toMatchObject({
-        model_key: "openai:gpt-4o",
-        input_price_per_million: 5,
-        output_price_per_million: 12,
-      })
-    })
-  })
-
   // -- pricing a model the catalog does not list --------------------------
 
   it("prices the searched selector when nothing matches, seeded from the search box", async () => {
@@ -1404,21 +1371,18 @@ describe("ModelsPage", () => {
     expect(urls.some((url) => url.includes("/v1/models/metadata"))).toBe(false)
   })
 
-  // Selection is the route into bulk pricing, so it is an operator control.
-  // Left ungated, a member could select rows, press "Set pricing" and fire the
-  // bulk write: the price-write class of defect, reached by another door.
-  it("offers a non-operator no row selection, and so no bulk pricing", async () => {
-    mockApi({
-      context: organizationContext({
-        deployment_operator: false,
-        role: "member",
-      }),
-    })
+  // Bulk price editing was removed (otari-ai#2096): mass-editing prices was
+  // never a capability the models page should have offered. Selection existed
+  // only to feed it, so the checkbox column goes with it. Asserted against an
+  // operator, the role that used to have both. The checkbox assertions are the
+  // real check (they fail if selection comes back); the last two are weaker
+  // guards that would only bite on a bulk bar reintroduced without selection,
+  // since with no checkbox there is no way to make a selection here.
+  it("offers no row selection and no bulk pricing, even to an operator", async () => {
+    mockApi()
     renderWithClient(<ModelsPage />)
     await screen.findByText("openai:gpt-4o")
 
-    // No checkbox on the row and none in the header, so there is nothing to
-    // select and the bulk bar has no way to appear.
     const row = tableRow("openai:gpt-4o")
     expect(within(row).queryByRole("checkbox")).toBeNull()
     expect(screen.queryByRole("checkbox")).toBeNull()
@@ -1426,17 +1390,5 @@ describe("ModelsPage", () => {
     expect(
       screen.queryByRole("button", { name: "Set pricing" }),
     ).not.toBeInTheDocument()
-  })
-
-  it("still offers an operator the selection that feeds it", async () => {
-    // The other half, so the gate above cannot be satisfied by removing
-    // selection for everyone.
-    mockApi()
-    renderWithClient(<ModelsPage />)
-    await screen.findByText("openai:gpt-4o")
-
-    expect(
-      within(tableRow("openai:gpt-4o")).getByRole("checkbox"),
-    ).toBeInTheDocument()
   })
 })

--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -1371,13 +1371,9 @@ describe("ModelsPage", () => {
     expect(urls.some((url) => url.includes("/v1/models/metadata"))).toBe(false)
   })
 
-  // Bulk price editing was removed (otari-ai#2096): mass-editing prices was
-  // never a capability the models page should have offered. Selection existed
-  // only to feed it, so the checkbox column goes with it. Asserted against an
-  // operator, the role that used to have both. The checkbox assertions are the
-  // real check (they fail if selection comes back); the last two are weaker
-  // guards that would only bite on a bulk bar reintroduced without selection,
-  // since with no checkbox there is no way to make a selection here.
+  // The models page offers no row selection, because there is no bulk price
+  // write for it to feed (otari-ai#2096). The checkbox assertions are the real
+  // check; the last two only bite on a bulk bar reintroduced without selection.
   it("offers no row selection and no bulk pricing, even to an operator", async () => {
     mockApi()
     renderWithClient(<ModelsPage />)

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
   useState,
 } from "react"
-import type { Selection, SortDescriptor } from "react-aria-components"
+import type { SortDescriptor } from "react-aria-components"
 import { FiInfo } from "react-icons/fi"
 import type { DiscoverableProvider, ModelMetadata, PricingTier } from "@/client"
 import { isPricingTier } from "@/client"
@@ -33,7 +33,6 @@ import {
 import { useSettings } from "@/shared/api/settings"
 import { ConfirmButton } from "@/shared/components/actions/ConfirmButton"
 import { CopyableValue } from "@/shared/components/actions/CopyField"
-import { BulkActionBar } from "@/shared/components/data/BulkActionBar"
 import {
   DataTable,
   type DataTableColumn,
@@ -56,10 +55,6 @@ import {
   formatCost,
   formatReleaseDate,
 } from "@/shared/helpers/format"
-import {
-  resolveSelectedIds,
-  useTableSelection,
-} from "@/shared/helpers/tableSelection"
 import { useUrlValue } from "@/shared/helpers/urlState"
 
 // `owned_by` the gateway stamps on a configured alias (ALIAS_OWNED_BY in
@@ -1389,8 +1384,6 @@ function ModelTable({
   onSelect,
   onEditPricing,
   comparisonContextTokens,
-  selectedKeys,
-  onSelectionChange,
 }: {
   rows: ModelRow[]
   isLoading: boolean
@@ -1400,16 +1393,14 @@ function ModelTable({
   selectedKey: string | null
   onSelect: (key: string) => void
   // Absent for a caller who may not write pricing: the price cells render as
-  // text and row selection (which exists only to feed bulk pricing) is off.
+  // text.
   onEditPricing?: (key: string) => void
   comparisonContextTokens: number | null
-  selectedKeys: Selection
-  onSelectionChange: (keys: Selection) => void
 }) {
   // Memoized on their real inputs so DataTable's per-row cache holds across
-  // selection clicks (see the DataTable docstring). rowClassName intentionally
+  // re-renders (see the DataTable docstring). rowClassName intentionally
   // depends on selectedKey: the drilled-row highlight must invalidate the
-  // cache when the selection target changes.
+  // cache when the drilled row changes.
   const columns = useMemo<DataTableColumn<ModelRow>[]>(() => {
     const comparisonLabel =
       comparisonContextTokens == null
@@ -1542,12 +1533,6 @@ function ModelTable({
         getRowKey={getModelRowKey}
         isLoading={isLoading}
         emptyContent={empty}
-        // Selection exists to feed the bulk pricing action, so it is offered
-        // only to a caller who can price. `onEditPricing` arrives already
-        // gated on operator authority, which is what makes it the right key.
-        selectionMode={onEditPricing ? "multiple" : "none"}
-        selectedKeys={selectedKeys}
-        onSelectionChange={onSelectionChange}
         sortDescriptor={sortDescriptor}
         onSortChange={onSortChange}
         onRowAction={onSelect}
@@ -1661,10 +1646,6 @@ export function ModelsPage() {
   const [pricingKey, setPricingKey] = useState<string | null>(null)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [sort, setSort] = useState<Sort>(readStoredSort)
-  const selection = useTableSelection()
-  const [bulkPriceOpen, setBulkPriceOpen] = useState(false)
-  const [bulkPending, setBulkPending] = useState(false)
-  const [bulkError, setBulkError] = useState<unknown>(undefined)
   // Non-null while the hand-pricing dialog is open, holding the key it opened
   // with: a searched selector, a provider prefix, or "" for a blank field.
   const [customPriceKey, setCustomPriceKey] = useState<string | null>(null)
@@ -2125,53 +2106,11 @@ export function ModelsPage() {
     [],
   )
 
-  // Selection targets the visible page; "select all matching" expands to every
-  // filtered model so a bulk price can be applied to the whole result set.
-  const selectableKeys = pageModels.map((row) => row.key)
-  const selectedModelKeys = resolveSelectedIds(
-    selection.selectedKeys,
-    selectableKeys,
-  )
-  const allPageSelected =
-    selectableKeys.length > 0 &&
-    selectedModelKeys.length === selectableKeys.length
-  const canSelectAllMatching =
-    allPageSelected && total > selectedModelKeys.length
-  const bulkTargetKeys = selection.allMatching
-    ? filteredModels.map((row) => row.key)
-    : selectedModelKeys
-  const bulkCount = selection.allMatching ? total : selectedModelKeys.length
   const pricingRow = pricingKey
     ? (filteredModels.find((row) => row.key === pricingKey) ??
       rowsByKey.get(pricingKey) ??
       null)
     : null
-
-  const runBulkPricing = async (rates: ManualRates) => {
-    setBulkPending(true)
-    setBulkError(undefined)
-    try {
-      for (const key of bulkTargetKeys) {
-        await setPricing.mutateAsync({
-          model_key: key,
-          input_price_per_million: rates.input_price_per_million,
-          output_price_per_million: rates.output_price_per_million,
-          cache_read_price_per_million:
-            rates.cache_read_price_per_million ?? null,
-          cache_write_price_per_million:
-            rates.cache_write_price_per_million ?? null,
-          cache_write_1h_price_per_million: null,
-          pricing_tiers: [],
-        })
-      }
-      selection.clear()
-      setBulkPriceOpen(false)
-    } catch (error) {
-      setBulkError(error)
-    } finally {
-      setBulkPending(false)
-    }
-  }
 
   // A backend with no /v1/models endpoint serves models the catalog never
   // lists, so the only way to meter them is a key typed by hand. The stored key
@@ -2354,29 +2293,6 @@ export function ModelsPage() {
           onPriceModel={setCustomPriceKey}
         />
 
-        {/* Gated on authority as well as on a selection. The table only offers
-            selection to an operator, so this is the second of two locks rather
-            than the only one: it means a non-operator reaching a selected key
-            by any other route still cannot open the pricing dialog. */}
-        {isOperator && selectedModelKeys.length > 0 ? (
-          <BulkActionBar
-            selectedCount={bulkCount}
-            allMatching={selection.allMatching}
-            matchingTotal={total}
-            canSelectAllMatching={canSelectAllMatching}
-            onSelectAllMatching={selection.enableAllMatching}
-            onClear={selection.clear}
-          >
-            <Button
-              size="sm"
-              variant="primary"
-              onPress={() => setBulkPriceOpen(true)}
-            >
-              Set pricing
-            </Button>
-          </BulkActionBar>
-        ) : null}
-
         <div
           className={`grid gap-4 lg:items-start ${
             selectedRow ? "lg:grid-cols-[minmax(0,1fr)_360px]" : "grid-cols-1"
@@ -2393,8 +2309,6 @@ export function ModelsPage() {
               onSelect={setSelectedKey}
               onEditPricing={isOperator ? onEditPricing : undefined}
               comparisonContextTokens={comparisonContextTokens}
-              selectedKeys={selection.selectedKeys}
-              onSelectionChange={selection.onSelectionChange}
             />
 
             {pricingRow ? (
@@ -2448,21 +2362,6 @@ export function ModelsPage() {
           ) : null}
         </div>
       </div>
-
-      <SetPriceDialog
-        isOpen={bulkPriceOpen}
-        onOpenChange={setBulkPriceOpen}
-        targetCount={bulkCount}
-        isPending={bulkPending}
-        error={bulkError}
-        onSubmit={runBulkPricing}
-        title="Set pricing"
-        description={(count) =>
-          `Apply these per-1M rates to ${count.toLocaleString()} selected ${
-            count === 1 ? "model" : "models"
-          }. This replaces each model's price; pricing tiers and the 1h cache rate are cleared. Edit a single model for tiers.`
-        }
-      />
 
       <SetPriceDialog
         isOpen={customPriceKey !== null}


### PR DESCRIPTION
## Description

The models page let an operator select several models and apply one price to all of them. That write is blunt: it replaces each selected model's price and clears its pricing tiers and 1h cache rate, across as many rows as the current filter matches, since "select all matching" expands past the visible page. Mass-editing prices is not a capability the page should offer, so it is removed.

The multi-select existed only to feed that action, so the checkbox column goes with it. Confirmed before deleting it: nothing else on this page consumed the selection. `useTableSelection`, `resolveSelectedIds` and `BulkActionBar` are shared and stay, because Activity, Budgets and Keys still use them.

Per-model pricing is untouched:

- the inline editor opened by clicking a price cell
- the detail panel editor
- the "Price a model" dialog, for a selector the catalog does not list

### The sticky lane needs no CSS change, and deliberately gets none

`globals.css` has one shared sticky rule that pins `:first-child` for four tables, models among them. On `main` that first child is the checkbox lane, so the models table freezes its checkboxes and lets the model name scroll away, which is the opposite of the comment on that rule and of what its three sibling tables do. Removing the selection column makes `model` the first child, so the pin lands on the identity lane by itself.

That is why this diff touches no CSS, and the absence is intentional rather than an oversight. Adding a `data-key="model"` sticky rule would pin the lane twice and take models back out of step with its siblings.

Measured on the running branch build, with the scroll container narrowed to force horizontal overflow: the model cell computes `position: sticky; left: 0`, holds at x=536 while its neighbor moves from 756 to 551.5 under a 204.5px scroll, and `data-scrolled="true"` lands on the table so the cell's `border-right` goes from 0px to 1px. The lane and its border both retarget with no rule change.

Verified on a local build against a seeded database. With the branch bundle served, the models table renders its rows with zero checkboxes and no bulk bar; the same seed on a `main` bundle renders the same rows with the checkbox column present. Clicking a price cell still opens the inline editor with its Save and Reset price controls.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2096

The issue is filed on `otari-ai`, but the models page lives here and reaches that repo through its `otari` submodule, so the fix belongs in this repo. GitHub does not auto-close across repositories, so that issue needs closing by hand once this ships.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the boxes above.

Tests: the change is dashboard-only, so the tests are the dashboard's (`pnpm --dir web test`), not `tests/unit` or `tests/integration`. Three tests changed. Removed: "bulk-sets pricing on the selected models", which exercised the capability being removed, and "still offers an operator the selection that feeds it", which asserted the checkbox column exists. Replaced: "offers a non-operator no row selection, and so no bulk pricing" becomes "offers no row selection and no bulk pricing, even to an operator". Two of those are deletions rather than a test cleanup: the behavior they covered is gone on purpose.

That new case is a check, not a guard. Reverting the source change and re-running it fails it on the checkbox assertion, which is the regression it claims to catch. Its last two assertions are weaker guards and the comment on the test says so: with no checkbox there is no way to make a selection, so they would only bite on a bulk bar reintroduced without one.

Documentation: no user-facing doc describes the bulk action, so nothing was left stale. Searched for it rather than assuming.

OpenAPI: no route, schema or docstring changed, so there was nothing to regenerate and no artifact to commit. Ticked to record that it was checked, not skipped.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The removal was written mechanically and the resulting diff was read line by line before committing. The seam was audited first: a repo-wide search established that the shared selection helpers have other consumers and must not be deleted, and that the second `SetPriceDialog` mount on this page is the "Price a model" dialog rather than a second bulk one, so it stays.

One judgment call worth a reviewer's attention. Removing selection also removes the role gate that made it operator-only, so the security property that gate protected is now satisfied by the capability not existing at all rather than by an authority check. That is a stronger position, but it does mean the two tests that documented the gate are gone, and a future reviewer will not find them.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed bulk price editing from the dashboard Models page.
- Removed row selection and the bulk action bar.
- Kept single-model pricing options unchanged.
- Updated tests to confirm that operators cannot select rows or use bulk pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->