### PR TITLE
ci: add Dependabot version updates for uv and refresh uv.lock weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,14 @@ updates:
   # lockfile (the thing CI and the Docker image actually install from, both via
   # --frozen) untouched while editing pyproject.toml.
   #
-  # Note this covers only what a constraint or an advisory forces. A dependency
-  # already satisfying its declared floor is not something Dependabot chases, so
-  # a floored package can sit many releases behind without a single PR being
-  # opened. otari-lock-refresh.yml covers that gap.
+  # This block adds *version* updates. Security updates are a separate feature
+  # that needs no config and already runs here, which is why advisory-driven
+  # bumps arrived for years while a stale-but-unvulnerable package like
+  # genai-prices sat six releases behind.
+  #
+  # What version updates do for a lockfile entry whose declared floor already
+  # permits the newer version is not documented for uv, so
+  # otari-lock-refresh.yml is the path that does not depend on the answer.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,14 +34,9 @@ updates:
           - "minor"
           - "patch"
 
-  # Dashboard dependencies. pnpm lives under the "npm" ecosystem, and the
-  # directory is where package.json and pnpm-lock.yaml sit, not the repo root.
-  - package-ecosystem: "npm"
-    directory: "/web"
-    schedule:
-      interval: "weekly"
-    groups:
-      dashboard-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
+  # No entry for the dashboard, deliberately. pnpm belongs to the "npm"
+  # ecosystem, but Dependabot documents pnpm support only through v10 and
+  # web/package.json requires pnpm 11.25.0, so an entry here would target a
+  # lockfile format it cannot resolve. Revisit when the supported-ecosystems
+  # table lists pnpm 11; until then web/ dependencies move by hand or through a
+  # tool that supports pnpm 11 (Renovate does).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,9 +34,6 @@ updates:
           - "minor"
           - "patch"
 
-  # No entry for the dashboard, deliberately. pnpm belongs to the "npm"
-  # ecosystem, but Dependabot documents pnpm support only through v10 and
-  # web/package.json requires pnpm 11.25.0, so an entry here would target a
-  # lockfile format it cannot resolve. Revisit when the supported-ecosystems
-  # table lists pnpm 11; until then web/ dependencies move by hand or through a
-  # tool that supports pnpm 11 (Renovate does).
+  # No entry for the dashboard: Dependabot documents pnpm support only through
+  # v10 and web/ requires pnpm 11, so one would target a lockfile format it
+  # cannot resolve. Tracked in #1001.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,34 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Python dependencies resolved through uv. The ecosystem must be "uv", not
+  # "pip": the pip ecosystem does not understand uv.lock, so it would leave the
+  # lockfile (the thing CI and the Docker image actually install from, both via
+  # --frozen) untouched while editing pyproject.toml.
+  #
+  # Note this covers only what a constraint or an advisory forces. A dependency
+  # already satisfying its declared floor is not something Dependabot chases, so
+  # a floored package can sit many releases behind without a single PR being
+  # opened. otari-lock-refresh.yml covers that gap.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Dashboard dependencies. pnpm lives under the "npm" ecosystem, and the
+  # directory is where package.json and pnpm-lock.yaml sit, not the repo root.
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      dashboard-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/otari-lock-refresh.yml
+++ b/.github/workflows/otari-lock-refresh.yml
@@ -59,10 +59,15 @@ jobs:
       pull-requests: write
 
     steps:
-      # Credentials stay persisted here, unlike the sibling workflows that drop
-      # them: this job pushes a branch, and create-pull-request expects the
-      # standard checkout.
+      # persist-credentials: false matters more here than in the sibling
+      # workflows that set it. This job holds contents: write and then installs
+      # and executes a freshly upgraded dependency set, so a persisted
+      # write-capable token would sit in .git/config while brand-new third-party
+      # code runs against it. create-pull-request pushes with its own `token`
+      # input, so nothing needs the persisted credential.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:

--- a/.github/workflows/otari-lock-refresh.yml
+++ b/.github/workflows/otari-lock-refresh.yml
@@ -1,0 +1,172 @@
+name: Otari Lock Refresh
+
+# Re-resolves uv.lock against the latest versions the declared constraints allow,
+# and opens a PR when that moves anything.
+#
+# This exists because Dependabot cannot see the staleness it is meant to catch.
+# Dependabot bumps a dependency when a declared constraint or a security advisory
+# forces one; it does not chase a package that still satisfies its floor. Nearly
+# every dependency here is floored rather than pinned, and `uv lock` preserves an
+# existing resolution unless something forces a change, so a floored package stays
+# at whatever version happened to be current the day it was first locked. That is
+# not hypothetical: genai-prices sat at 0.1.0 from the day it was added while six
+# releases shipped upstream, and because it carries a *dataset* (model prices),
+# the stale resolution silently mispriced requests rather than merely missing a
+# feature. CI and the Docker image both install with --frozen, so the lockfile is
+# what ships.
+#
+# The refresh runs the resolution-sensitive checks itself before opening anything,
+# because a PR authored by GITHUB_TOKEN does not trigger `pull_request` workflows
+# (GitHub blocks that to avoid recursive runs). Set a LOCK_REFRESH_TOKEN secret (a
+# PAT or GitHub App token with contents:write and pull-requests:write on this
+# repo) to have the PR's own checks run automatically; without it, the PR body
+# tells the reviewer how to trigger them.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC, ahead of Dependabot's weekly run, so a constraint bump
+    # that Dependabot opens later in the day resolves against a lockfile that is
+    # already current rather than fighting this PR for the same lines.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Refresh only this package (blank refreshes every dependency)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lock-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: 3.14
+          activate-environment: true
+
+      - name: Re-resolve the lockfile
+        id: relock
+        env:
+          PACKAGE: ${{ github.event.inputs.package }}
+        run: |
+          # --dry-run first, purely for the summary: it names each package and
+          # both versions ("Update genai-prices v0.1.0 -> v0.1.6"), which a diff
+          # of uv.lock does not, because the name and the version sit on separate
+          # lines of the entry.
+          if [ -n "${PACKAGE}" ]; then
+            uv lock --upgrade-package "${PACKAGE}" --dry-run 2>&1 | tee /tmp/changes.txt
+            uv lock --upgrade-package "${PACKAGE}"
+          else
+            uv lock --upgrade --dry-run 2>&1 | tee /tmp/changes.txt
+            uv lock --upgrade
+          fi
+          if git diff --quiet -- uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Every dependency already resolves to its newest allowed version."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo '## Dependency changes'
+            echo
+            echo '```'
+            grep -E '^(Update|Add|Remove) ' /tmp/changes.txt || echo 'none'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install the refreshed dependencies
+        if: steps.relock.outputs.changed == 'true'
+        run: uv sync --dev --frozen
+
+      - name: Lint
+        if: steps.relock.outputs.changed == 'true'
+        run: make lint
+
+      - name: Typecheck
+        if: steps.relock.outputs.changed == 'true'
+        run: make typecheck
+
+      - name: Unit tests
+        if: steps.relock.outputs.changed == 'true'
+        run: uv run pytest tests/unit -q -n auto
+
+      - name: Integration tests
+        if: steps.relock.outputs.changed == 'true'
+        # Testcontainers brings up postgres:17 on the runner's Docker daemon, the
+        # same way it does locally when TEST_DATABASE_URL is unset.
+        run: uv run pytest tests/integration -q -n auto
+
+      - name: OSS-edition smoke gate
+        if: steps.relock.outputs.changed == 'true'
+        # The gate that exists for exactly this class of change: it boots the
+        # packaged CLI with --no-dev, so a dev-only or enterprise-only import that
+        # a new resolution dragged onto an OSS code path fails here.
+        run: uv run --frozen --no-dev python scripts/oss_edition_smoke.py
+
+      - name: Open the refresh PR
+        if: steps.relock.outputs.changed == 'true'
+        id: refresh_pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.LOCK_REFRESH_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: chore/uv-lock-refresh
+          delete-branch: true
+          commit-message: |
+            chore(deps): refresh uv.lock against the latest allowed versions
+
+            Re-resolved by .github/workflows/otari-lock-refresh.yml.
+          title: "chore(deps): refresh uv.lock against the latest allowed versions"
+          body: |
+            Automated re-resolution of `uv.lock` by
+            `.github/workflows/otari-lock-refresh.yml`. Nothing in `pyproject.toml`
+            changed: these are the newest versions the existing constraints already
+            allowed, which Dependabot does not open PRs for.
+
+            The workflow ran `make lint`, `make typecheck`, the unit and
+            integration suites, and the OSS-edition smoke gate against this
+            resolution before opening the PR. See the run summary for the
+            package-level diff.
+
+            If the PR's own checks did not start, it was authored by
+            `GITHUB_TOKEN`, which cannot trigger `pull_request` workflows. Push an
+            empty commit to the branch, or close and reopen the PR, to run them.
+
+            ## Description
+
+            Keeps the locked resolution current, so a floored dependency does not
+            sit years behind while its constraint stays satisfied.
+
+            ## PR Type
+
+            - [x] Infrastructure / CI
+
+            ## Relevant issues
+
+            ## Checklist
+
+            - [x] I understand the code I am submitting.
+            - [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
+            - [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
+            - [ ] Documentation was updated where necessary.
+            - [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
+
+            ## AI Usage
+
+            - [x] No AI was used.
+
+            **AI Model/Tool used:** none, this PR is opened by a scheduled workflow.
+
+            - [ ] I am an AI Agent filling out this form (check box if true)

--- a/.github/workflows/otari-lock-refresh.yml
+++ b/.github/workflows/otari-lock-refresh.yml
@@ -21,6 +21,11 @@ name: Otari Lock Refresh
 # PAT or GitHub App token with contents:write and pull-requests:write on this
 # repo) to have the PR's own checks run automatically; without it, the PR body
 # tells the reviewer how to trigger them.
+#
+# A run whose checks fail opens no PR, which is the intended outcome (a broken
+# resolution should not land) but also a silent one: the signal is a red run in
+# the Actions tab plus GitHub's own scheduled-failure notification. A refresh
+# that has not opened a PR in a long while is worth checking rather than trusting.
 
 on:
   schedule:
@@ -45,11 +50,18 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    # Same environment the integration job in otari-tests.yml runs under, so the
+    # suite here sees the secrets it does. The environment carries no protection
+    # rules, so it adds no approval gate to a scheduled run.
+    environment: integration-tests
     permissions:
       contents: write
       pull-requests: write
 
     steps:
+      # Credentials stay persisted here, unlike the sibling workflows that drop
+      # them: this job pushes a branch, and create-pull-request expects the
+      # standard checkout.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -107,6 +119,8 @@ jobs:
         if: steps.relock.outputs.changed == 'true'
         # Testcontainers brings up postgres:17 on the runner's Docker daemon, the
         # same way it does locally when TEST_DATABASE_URL is unset.
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: uv run pytest tests/integration -q -n auto
 
       - name: OSS-edition smoke gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,10 @@ Most dependencies are floored (`>=`) rather than pinned, and `uv.lock` is commit
 because CI and the Docker image both install from it with `--frozen`. Two mechanisms
 keep it current, and they cover different things:
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for the `uv`, `npm`
-  (in `web/`), and `github-actions` ecosystems. It acts on a changed constraint or a
-  security advisory.
+- **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for the `uv` and
+  `github-actions` ecosystems. It acts on a changed constraint or a security
+  advisory. The dashboard is not covered: Dependabot documents pnpm support only
+  through v10 and `web/` requires pnpm 11, so `web/` dependencies move by hand.
 - **`.github/workflows/otari-lock-refresh.yml`** re-resolves `uv.lock` weekly against
   the newest versions the existing constraints already allow, which is the case
   Dependabot does not open PRs for. A floored dependency can otherwise stay at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,10 @@ Most dependencies are floored (`>=`) rather than pinned, and `uv.lock` is commit
 because CI and the Docker image both install from it with `--frozen`. Two mechanisms
 keep it current, and they cover different things:
 
-- **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for the `uv` and
-  `github-actions` ecosystems. It acts on a changed constraint or a security
-  advisory. The dashboard is not covered: Dependabot documents pnpm support only
-  through v10 and `web/` requires pnpm 11, so `web/` dependencies move by hand.
+- **Dependabot** (`.github/dependabot.yml`) opens weekly version-update PRs for the
+  `uv` and `github-actions` ecosystems. Security updates are separate, need no
+  config, and already cover every supported ecosystem here. The dashboard is not
+  covered by either right now; see #1001.
 - **`.github/workflows/otari-lock-refresh.yml`** re-resolves `uv.lock` weekly against
   the newest versions the existing constraints already allow, which is the case
   Dependabot does not open PRs for. A floored dependency can otherwise stay at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,35 @@ make openapi-check
 make postman-check
 ```
 
+## Dependencies
+
+Most dependencies are floored (`>=`) rather than pinned, and `uv.lock` is committed
+because CI and the Docker image both install from it with `--frozen`. Two mechanisms
+keep it current, and they cover different things:
+
+- **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for the `uv`, `npm`
+  (in `web/`), and `github-actions` ecosystems. It acts on a changed constraint or a
+  security advisory.
+- **`.github/workflows/otari-lock-refresh.yml`** re-resolves `uv.lock` weekly against
+  the newest versions the existing constraints already allow, which is the case
+  Dependabot does not open PRs for. A floored dependency can otherwise stay at
+  whatever version was current the day it was first locked.
+
+To do either by hand:
+
+```bash
+uv lock --upgrade --dry-run                    # what would move, and to where
+uv lock --upgrade-package genai-prices         # refresh one package
+uv lock --upgrade                              # refresh everything
+```
+
+A change to dependency resolution also owes the OSS-edition smoke gate, which boots
+the packaged CLI with no dev dependencies:
+
+```bash
+uv run --frozen --no-dev python scripts/oss_edition_smoke.py
+```
+
 ## Tests
 
 - New features need tests covering the happy path and error cases.


### PR DESCRIPTION
## Description

Dependabot **version updates** have never run for this repo's Python dependencies. `.github/dependabot.yml` covered only `github-actions`, and version updates require a config entry, so nothing ever bumped a package that no security advisory named. Combined with almost everything being floored (`>=`) rather than pinned, and `uv lock` preserving an existing resolution unless something forces a change, a floored package stays at whatever version was current the day it was first locked.

`uv lock --upgrade --dry-run` on `main` today reports 130 updates plus 13 additions/removals.

This adds:

1. **A `uv` block in `.github/dependabot.yml`**, grouping minor/patch into one weekly PR the way the existing `github-actions` block does. The ecosystem has to be `uv`, not `pip`: `pip` does not understand `uv.lock`, so it would edit `pyproject.toml` and leave the file CI and Docker actually install from (both `--frozen`) untouched.

   An `npm` block for `/web` was in the first version of this PR and came out after review: pnpm support is documented only through v10 and `web/` requires pnpm 11.25.0. The dashboard is out of scope here and tracked in #1001.

2. **`.github/workflows/otari-lock-refresh.yml`**, which re-resolves `uv.lock` weekly against the newest versions the constraints already allow and opens a PR when anything moves. It runs `make lint`, `make typecheck`, both test suites, and the OSS-edition smoke gate against the new resolution first, because a PR authored by `GITHUB_TOKEN` cannot trigger `pull_request` workflows. An optional `LOCK_REFRESH_TOKEN` secret makes the PR's own checks run; without it the body tells the reviewer how to nudge them.

`CONTRIBUTING.md` gains a short Dependencies section covering both mechanisms and the manual commands.

### What Dependabot already does here, and what it does not

An earlier version of this description claimed the repo's open security alerts could not be fixed because there was no `uv` config. That was wrong, and #968 and #969 are the proof. **Security updates need no `dependabot.yml` entry**, they are enabled here (`automated-security-fixes: enabled`), and they have been opening `dependabot/uv/*` PRs since July, each carrying a CVE or GHSA reference. Two are open right now bumping `httpx2` to 2.12.0 and `httpcore2` to 2.10.0, which are exactly the `httpx2`/`httpcore2` alerts on this repo. They need merging, not enabling.

| | Needs `dependabot.yml`? | Status before this PR |
| --- | --- | --- |
| Security updates (advisory-driven) | No | Working since July; two PRs open and unmerged |
| Version updates (routine bumps) | Yes | Never ran for `uv` |

`genai-prices` sat at 0.1.0 for exactly this reason: no advisory ever named it, so no security update fired, and there was no version-update config to bump it as releases shipped. A dataset-bearing dependency going stale is not a vulnerability, which is why the mechanism that *was* working did not help. Its bundled dataset carries GPT-5.6 Luna's launch pricing rather than the date-constrained period upstream added for OpenAI's 2026-07-30 cut, so a gateway on that resolution bills Luna at 5x. Only local checkouts, CI, and the Docker image are affected, since those install `--frozen`; a `pip install otari` resolves against the floor and already gets 0.1.6.

### Notes for the reviewer

- **On the workflow's necessity.** With a `uv` version-update block in place, Dependabot may catch the `genai-prices` class of staleness on its own. GitHub's docs do not state what version updates do for a lockfile entry whose manifest range already permits the newer version, and I have not tested it for `uv`, so I am not claiming either way. The workflow is still worth having as the bulk re-resolution path (143 changes in one reviewed PR rather than 143 separate ones) and as cover for transitive packages. If the Dependabot block alone proves sufficient over a few weeks, dropping the workflow would be a fair simplification.
- **The first automated run will be a large PR** (the 143 changes above). It may be kinder to land that deliberately as its own reviewed change rather than let the workflow's first output be a 143-package bump. This PR does not touch `uv.lock`.
- **The dashboard looks worse off than "not covered here".** Its Dependabot PRs stop dead at #543 (2026-08-09), and the pnpm migration landed in #637 on 2026-08-19, so security updates for `web/` appear to have been silently broken for three weeks by the move to pnpm 11. The open high-severity `js-yaml` advisory has no PR, where every pre-migration npm-era alert got one. Filed separately; this PR cannot fix it.
- The runtime side of the pricing problem is out of scope and tracked in #998: even a current wheel lags upstream `data.json`, because the dataset changes faster than releases are cut.
- Only config and docs change here, so no Python was touched. `make lint` and `make typecheck` pass; the test suites are unaffected by this diff.

## PR Type

- [x] Infrastructure / CI

## Relevant issues

Fixes #996

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). No Python changed; the diff is CI configuration and docs, which the suites do not cover.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Lint and typecheck pass. The suites are untouched by a config-only diff.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

The diagnosis started from a wrong price in a local dashboard and worked back through the pricing resolution order to the lockfile. Version numbers, dates, and the 143-change count were verified against PyPI, the upstream `genai-prices` feed, and `git log`. The security-updates claim in the first version of this description was not verified before being written, and was corrected after a reviewer pointed at #969.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added weekly `uv` dependency update automation.
- Added a scheduled workflow that refreshes `uv.lock`, runs required checks, and opens a PR when changes are found.
- Added manual refresh support for all packages or one selected package.
- Documented the automation and manual commands in `CONTRIBUTING.md`.
- Clarified that security updates run separately and that dashboard dependencies remain out of scope.

This keeps Python dependencies current and reduces dependency drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->