### PR TITLE
fix(auth): background verification and reset mail sends off the request path

### DIFF
--- a/src/gateway/api/routes/auth_password_reset.py
+++ b/src/gateway/api/routes/auth_password_reset.py
@@ -9,7 +9,7 @@ the same "the request's own token is the whole proof" shape as
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -52,13 +52,14 @@ class ResetPasswordRequest(BaseModel):
 async def request_reset(
     body: RequestPasswordResetRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> RequestPasswordResetResponse:
     """Mail a password-reset link, or do nothing: the response never says which."""
     throttle_public_auth(request)
     try:
-        await request_password_reset(db, config, email=body.email)
+        await request_password_reset(db, config, background_tasks=background_tasks, email=body.email)
     except MailNotConfiguredError as exc:
         raise mail_unavailable(exc) from None
     return RequestPasswordResetResponse(message=_RESET_REQUEST_MESSAGE)

--- a/src/gateway/api/routes/auth_signup.py
+++ b/src/gateway/api/routes/auth_signup.py
@@ -100,6 +100,7 @@ async def signup(
         claimed = await create_user_for_signup(
             db,
             config,
+            background_tasks=background_tasks,
             email=body.email,
             password=body.password,
             full_name=body.full_name,
@@ -140,13 +141,14 @@ async def verify_email_route(
 async def resend_verification(
     body: ResendVerificationRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ResendVerificationResponse:
     """Mail a fresh verification link, or do nothing: the response never says which."""
     throttle_public_auth(request)
     try:
-        await resend_verification_email(db, config, email=body.email)
+        await resend_verification_email(db, config, background_tasks=background_tasks, email=body.email)
     except MailNotConfiguredError as exc:
         raise mail_unavailable(exc) from None
     return ResendVerificationResponse(message=_RESEND_MESSAGE)

--- a/src/gateway/services/tenancy/user_service.py
+++ b/src/gateway/services/tenancy/user_service.py
@@ -51,6 +51,7 @@ below is what gives it a way to sign in.
 
 from datetime import UTC, datetime, timedelta
 
+from fastapi import BackgroundTasks
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -239,6 +240,7 @@ async def create_user_for_signup(
     db: AsyncSession,
     config: GatewayConfig,
     *,
+    background_tasks: BackgroundTasks,
     email: str,
     password: str,
     full_name: str | None = None,
@@ -275,10 +277,14 @@ async def create_user_for_signup(
     Refuses before writing anything if this deployment cannot mail the
     verification link: a signup that could never be verified would strand the
     caller in the unverified, hard-blocked state #650's sign-in gate enforces.
-    The mail send after commit is not guarded by a ``try`` on purpose, the same
-    reason ``organization_service.invite_active_organization_member_for_user``
-    does not guard its own: ``Mailer.send`` never raises, so the account this
-    call creates is durable whether or not the message actually goes out.
+    The mail send is handed to ``background_tasks`` rather than awaited here,
+    the same reason ``GrowthSignalPort`` is: an unauthenticated caller can
+    measure how long this call takes, and an awaited SMTP round-trip on the
+    claim branch alone would let them tell it apart from the enumeration-safe
+    early return above by wall-clock time even though both answer the caller
+    identically. Scheduling after the commit keeps the account durable
+    whether or not the message actually goes out, the same guarantee the
+    previous inline, unguarded ``await`` gave (``Mailer.send`` never raises).
     """
     mailer = Mailer(config)
     mailer.require_ready()
@@ -308,7 +314,8 @@ async def create_user_for_signup(
     db.add(identity)
     await db.commit()
 
-    await mailer.send(
+    background_tasks.add_task(
+        mailer.send,
         to=address,
         message=render_verification_email(
             verify_link=mailer.link(f"/#/verify-email?token={token}"),
@@ -358,7 +365,9 @@ async def verify_email(db: AsyncSession, *, token: str) -> User:
     return identity
 
 
-async def resend_verification_email(db: AsyncSession, config: GatewayConfig, *, email: str) -> None:
+async def resend_verification_email(
+    db: AsyncSession, config: GatewayConfig, *, background_tasks: BackgroundTasks, email: str
+) -> None:
     """Mail a fresh verification link, or do nothing: the caller cannot tell which.
 
     Enumeration-safe by construction rather than by a caller-side generic
@@ -371,9 +380,12 @@ async def resend_verification_email(db: AsyncSession, config: GatewayConfig, *, 
     The early return still pays a bcrypt-equivalent cost first
     (``verify_absent_password_async``), the same reason ``authenticate`` pays
     one for an address with no stored hash: without it, the ineligible path
-    returns after one SELECT while the eligible one goes on to a commit and an
-    awaited mail send, and that gap is measurable enough to narrow down which
-    case a given address fell into.
+    returns after one SELECT while the eligible one goes on to a commit, and
+    that gap is measurable enough to narrow down which case a given address
+    fell into. The mail send itself is handed to ``background_tasks`` rather
+    than awaited, for the same reason: an awaited SMTP round-trip on the
+    eligible path alone would reopen the gap the bcrypt-equivalent cost above
+    exists to close.
     """
     mailer = Mailer(config)
     mailer.require_ready()
@@ -397,7 +409,8 @@ async def resend_verification_email(db: AsyncSession, config: GatewayConfig, *, 
     db.add(identity)
     await db.commit()
 
-    await mailer.send(
+    background_tasks.add_task(
+        mailer.send,
         to=address,
         message=render_verification_email(
             verify_link=mailer.link(f"/#/verify-email?token={token}"),
@@ -406,15 +419,17 @@ async def resend_verification_email(db: AsyncSession, config: GatewayConfig, *, 
     )
 
 
-async def request_password_reset(db: AsyncSession, config: GatewayConfig, *, email: str) -> None:
+async def request_password_reset(
+    db: AsyncSession, config: GatewayConfig, *, background_tasks: BackgroundTasks, email: str
+) -> None:
     """Mail a password-reset link, or do nothing: the caller cannot tell which.
 
     Enumeration-safe the same way ``resend_verification_email`` is, including
-    paying the same timing-equalizing cost on the early return, and refusing a
-    deactivated identity for the same reason. Works on an unverified identity
-    too, deliberately: forgetting a password predates ever verifying it, so
-    gating this on ``email_verified_at`` would strand exactly the caller it
-    exists to help.
+    paying the same timing-equalizing cost on the early return, backgrounding
+    the mail send the same way, and refusing a deactivated identity for the
+    same reason. Works on an unverified identity too, deliberately: forgetting
+    a password predates ever verifying it, so gating this on
+    ``email_verified_at`` would strand exactly the caller it exists to help.
     """
     mailer = Mailer(config)
     mailer.require_ready()
@@ -431,7 +446,8 @@ async def request_password_reset(db: AsyncSession, config: GatewayConfig, *, ema
     db.add(identity)
     await db.commit()
 
-    await mailer.send(
+    background_tasks.add_task(
+        mailer.send,
         to=address,
         message=render_password_reset_email(
             reset_link=mailer.link(f"/#/reset-password?token={token}"),

--- a/tests/unit/test_signup_mail_backgrounding.py
+++ b/tests/unit/test_signup_mail_backgrounding.py
@@ -1,0 +1,155 @@
+"""Signup, resend-verification and password-reset each hand their mail send to
+``BackgroundTasks`` instead of awaiting it inline in the request path.
+
+Enumeration-safety on these three endpoints depends on the eligible and
+ineligible branches taking indistinguishable wall-clock time (see each
+service function's own docstring in ``user_service.py``). An awaited SMTP
+round-trip on the eligible branch alone reopens that gap; a real wall-clock
+assertion would be flaky, so this intercepts ``BackgroundTasks.add_task``
+instead and checks that the send is scheduled, never run inline, by asserting
+the console transport has not logged anything by the time the response comes
+back.
+"""
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from fastapi import BackgroundTasks
+from fastapi.testclient import TestClient
+from httpx2 import Response
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger as gateway_logger
+from gateway.main import create_app
+from gateway.services.mail import Mailer
+
+MASTER_KEY = "sk-test-master"
+PASSWORD = "a-real-password"  # pragma: allowlist secret
+
+
+def _config(tmp_path: Path) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=f"sqlite:///{tmp_path / 'signup-bg-test.db'}",
+        master_key=MASTER_KEY,
+        require_pricing=False,
+        mail_transport="console",
+        public_base_url="https://gw.example.com",
+    )
+
+
+def _client(tmp_path: Path) -> TestClient:
+    return TestClient(create_app(_config(tmp_path)))
+
+
+def _add_member(client: TestClient, *, email: str) -> None:
+    response = client.post(
+        "/v1/organizations/me/members",
+        json={"email": email, "role": "member"},
+        headers={"Otari-Key": MASTER_KEY},
+    )
+    assert response.status_code == 201, response.text
+
+
+def _intercept_add_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[object, tuple[object, ...], dict[str, object]]]:
+    """Capture every scheduled task without running it.
+
+    Not calling through to the real ``add_task`` is deliberate: if a send were
+    still awaited inline, the console transport would already have logged by
+    the time this spy is even reached, so the request-time log check below
+    would fail regardless of whether this spy also runs the task.
+    """
+    scheduled: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    def spy(self: BackgroundTasks, func: object, *args: object, **kwargs: object) -> None:
+        scheduled.append((func, args, kwargs))
+
+    monkeypatch.setattr(BackgroundTasks, "add_task", spy)
+    return scheduled
+
+
+def _post_with_logs(
+    client: TestClient, caplog: pytest.LogCaptureFixture, call: Callable[[], Response]
+) -> Response:
+    gateway_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.INFO, logger="gateway")
+    caplog.clear()
+    try:
+        return call()
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+
+
+def _assert_mail_scheduled_not_sent(
+    scheduled: list[tuple[object, tuple[object, ...], dict[str, object]]],
+    caplog: pytest.LogCaptureFixture,
+    *,
+    to: str,
+) -> None:
+    assert not any("[mail:console]" in record.message for record in caplog.records), (
+        "mail was logged during the request instead of being scheduled for after it"
+    )
+    assert len(scheduled) == 1, scheduled
+    func, _args, kwargs = scheduled[0]
+    assert func.__func__ is Mailer.send  # type: ignore[attr-defined]
+    assert kwargs["to"] == to
+
+
+def test_signup_schedules_verification_mail_instead_of_awaiting_it(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scheduled = _intercept_add_task(monkeypatch)
+    with _client(tmp_path) as client:
+        _add_member(client, email="ada@example.com")
+
+        response = _post_with_logs(
+            client,
+            caplog,
+            lambda: client.post("/v1/auth/signup", json={"email": "ada@example.com", "password": PASSWORD}),
+        )
+
+    assert response.status_code == 200, response.text
+    _assert_mail_scheduled_not_sent(scheduled, caplog, to="ada@example.com")
+
+
+def test_resend_verification_schedules_mail_instead_of_awaiting_it(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with _client(tmp_path) as client:
+        _add_member(client, email="grace@example.com")
+        # Claim the identity first (unverified after this), unrelated to the
+        # backgrounding under test, so the send here is not intercepted.
+        signup = client.post("/v1/auth/signup", json={"email": "grace@example.com", "password": PASSWORD})
+        assert signup.status_code == 200, signup.text
+
+        scheduled = _intercept_add_task(monkeypatch)
+        response = _post_with_logs(
+            client,
+            caplog,
+            lambda: client.post("/v1/auth/resend-verification", json={"email": "grace@example.com"}),
+        )
+
+    assert response.status_code == 200, response.text
+    _assert_mail_scheduled_not_sent(scheduled, caplog, to="grace@example.com")
+
+
+def test_password_reset_request_schedules_mail_instead_of_awaiting_it(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with _client(tmp_path) as client:
+        _add_member(client, email="hopper@example.com")
+        signup = client.post("/v1/auth/signup", json={"email": "hopper@example.com", "password": PASSWORD})
+        assert signup.status_code == 200, signup.text
+
+        scheduled = _intercept_add_task(monkeypatch)
+        response = _post_with_logs(
+            client,
+            caplog,
+            lambda: client.post("/v1/auth/password/reset", json={"email": "hopper@example.com"}),
+        )
+
+    assert response.status_code == 200, response.text
+    _assert_mail_scheduled_not_sent(scheduled, caplog, to="hopper@example.com")


### PR DESCRIPTION
## Description

Backgrounded the send, per your recommendation in the issue.

`create_user_for_signup`, `resend_verification_email`, and `request_password_reset` now take a `background_tasks: BackgroundTasks` (same shape `record_signup` already uses) and hand `mailer.send` to `background_tasks.add_task` after the commit instead of awaiting it. The mailer holds no db handle, so scheduling it once the request's session is otherwise done is safe.

The docs half looks already handled: `docs/access-control.md` no longer makes the enumeration-safe claim. It was trimmed by an unrelated doc simplification (#860) a couple weeks ago, so there's nothing left to soften there.

Added a test per function that intercepts `BackgroundTasks.add_task` and checks the console transport hasn't logged anything by the time the response comes back. A wall-clock assertion would be flaky; this one just checks the send got scheduled instead of run inline. All three are new failures on main, since the mail gets logged during the request there instead of after it.

Ran the full unit suite (2886 passed) and, for integration, the signup and password-reset files directly against a real Postgres rather than the full `tests/integration` directory, since most of it is unrelated to this change. `make lint` and `make typecheck` are both clean.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #720

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`background_tasks` is a dependency-injected parameter, not part of any request or response schema, so `make openapi-check` and `make postman-check` both pass unchanged (checked).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Sonnet 5, via an autonomous coding agent operating in a terminal.

**Any additional AI details you'd like to share:**

Written from your issue and its stated fix preference.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Verification and password-reset emails now send after the request completes. This prevents slow email delivery from delaying responses and reduces response-timing leaks.

## Technical notes

- Added `BackgroundTasks` to signup, verification-resend, and password-reset flows.
- Updated tests to verify that email delivery is scheduled instead of executed during the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->