### PR TITLE
fix(auth): check the OAuth state server-side and turn PKCE on

### DIFF
--- a/alembic/versions/f1c4a8e2d6b9_add_oauth_pending_state.py
+++ b/alembic/versions/f1c4a8e2d6b9_add_oauth_pending_state.py
@@ -1,0 +1,72 @@
+"""Add the pending-state table that gives OAuth sign-in PKCE and a server-side state check.
+
+The dashboard's Google and GitHub sign-in shipped in otari#765 with PKCE off and
+the CSRF ``state`` checked only in the browser, against a value in
+``sessionStorage`` that no server ever saw. The stated reason was that authorize
+and callback are independent requests with nothing kept between them, so a
+verifier minted at authorize time had nowhere to live. This table is that
+somewhere, and it is the only thing the flow was missing: apron-auth has carried
+a ``StateStore`` protocol and full PKCE support since the version otari#765
+pinned.
+
+One row per authorization in flight, deleted as it is consumed, so a replayed
+state matches nothing. Keyed by the SHA-256 of the state rather than the state
+itself, which is where it departs from ``webauthn_challenge``: that table stores
+its nonce in the clear because nothing is stored *under* it, while a row here
+holds the PKCE ``code_verifier``, and a reader of this table must not come away
+with a state they could present to the callback.
+
+Nothing cascades from ``user`` here, unlike the passkey tables. A pending state
+is minted before anybody is identified: whose sign-in it is is precisely what
+the flow has not established yet.
+
+Purely additive, so there is no data step and the downgrade is a drop.
+
+Revision ID: f1c4a8e2d6b9
+Revises: d5b7f9a1c3e6
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f1c4a8e2d6b9"
+down_revision: str | Sequence[str] | None = "d5b7f9a1c3e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "oauth_pending_state",
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        # SHA-256 as hex, so 64 characters exactly.
+        sa.Column("state_hash", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        # RFC 7636 caps a verifier at 128 characters. Nullable because
+        # apron-auth's pending state models it that way for providers that
+        # cannot do PKCE, not because either provider offered here needs it.
+        sa.Column("code_verifier", sa.String(length=128), nullable=True),
+        sa.Column("redirect_uri", sa.String(length=2048), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("state_hash"),
+    )
+    # The sweep's column: expired rows are pruned by range, and every consume
+    # reads one row by primary key, so this is the only scan the table takes.
+    op.create_index(
+        op.f("ix_oauth_pending_state_expires_at"),
+        "oauth_pending_state",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_oauth_pending_state_expires_at"), table_name="oauth_pending_state")
+    op.drop_table("oauth_pending_state")

--- a/alembic/versions/f1c4a8e2d6b9_add_oauth_pending_state.py
+++ b/alembic/versions/f1c4a8e2d6b9_add_oauth_pending_state.py
@@ -10,7 +10,9 @@ a ``StateStore`` protocol and full PKCE support since the version otari#765
 pinned.
 
 One row per authorization in flight, deleted as it is consumed, so a replayed
-state matches nothing. Keyed by the SHA-256 of the state rather than the state
+state matches nothing, and bound to the browser that started it through the
+digest of a cookie-held flow secret, so a redirect URL read out of an access log
+or a history entry cannot finish the sign-in from anywhere else. Keyed by the SHA-256 of the state rather than the state
 itself, which is where it departs from ``webauthn_challenge``: that table stores
 its nonce in the clear because nothing is stored *under* it, while a row here
 holds the PKCE ``code_verifier``, and a reader of this table must not come away
@@ -48,6 +50,8 @@ def upgrade() -> None:
         # SHA-256 as hex, so 64 characters exactly.
         sa.Column("state_hash", sa.String(length=64), nullable=False),
         sa.Column("provider", sa.String(length=32), nullable=False),
+        # SHA-256 as hex of the browser's flow-cookie secret.
+        sa.Column("flow_hash", sa.String(length=64), nullable=False),
         # RFC 7636 caps a verifier at 128 characters. Nullable because
         # apron-auth's pending state models it that way for providers that
         # cannot do PKCE, not because either provider offered here needs it.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1284,7 +1284,7 @@
             "type": "string"
           },
           "state": {
-            "description": "An opaque CSRF value to keep for the length of the redirect and compare against the 'state' the provider returns. It is not stored on this deployment, so a callback whose state does not match the one held by the browser that started the flow must be abandoned by the client rather than sent here.",
+            "description": "An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it.",
             "title": "State",
             "type": "string"
           }
@@ -5870,17 +5870,24 @@
         "type": "object"
       },
       "OAuthCallbackRequest": {
-        "description": "The authorization code a provider handed the browser.\n\nNo ``redirect_uri``: this deployment derives its own from ``public_base_url``\nso the URI used to build the authorization request and the one sent with the\nexchange are the same string by construction, and a browser cannot choose\nwhat this server sends to a provider.\n\nNo ``state`` either, and that is not an omission. The state is checked in the\nbrowser, against the value that browser stored when it started the flow;\nsending it here would let this deployment compare a value to itself, which\nproves nothing without somewhere to have kept the original.",
+        "description": "The authorization code a provider handed the browser.\n\nNo ``redirect_uri``: this deployment derives its own from ``public_base_url``\nso the URI used to build the authorization request and the one sent with the\nexchange are the same string by construction, and a browser cannot choose\nwhat this server sends to a provider.\n\n``state`` is required, and is what binds this callback to an authorization\nrequest this deployment actually made: it is claimed from\n``oauth_pending_state`` before the code is sent anywhere, and the row it\nclaims is what carries the PKCE verifier the exchange needs.",
         "properties": {
           "code": {
             "description": "The authorization code from the provider's redirect.",
             "maxLength": 2048,
             "title": "Code",
             "type": "string"
+          },
+          "state": {
+            "description": "The 'state' from the provider's redirect, as issued by /authorize.",
+            "maxLength": 512,
+            "title": "State",
+            "type": "string"
           }
         },
         "required": [
-          "code"
+          "code",
+          "state"
         ],
         "title": "OAuthCallbackRequest",
         "type": "object"
@@ -15645,7 +15652,7 @@
     },
     "/v1/auth/oauth/{provider}/authorize": {
       "get": {
-        "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET, and safe: it reads configuration and mints a random value, writing\nnothing. Repeating it simply produces another state, and only the one the\nbrowser kept is the one it will compare against.",
+        "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, and the PKCE verifier\nthe exchange will need) so the callback has something to check against, and\nthat record is the whole reason the callback can refuse a code this\ndeployment never asked for.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call.",
         "operationId": "authorize_v1_auth_oauth__provider__authorize_get",
         "parameters": [
           {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1284,7 +1284,7 @@
             "type": "string"
           },
           "state": {
-            "description": "An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it.",
+            "description": "An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it. The response also sets an HttpOnly cookie that the callback requires, so the exchange can only be completed from the browser this call was made from.",
             "title": "State",
             "type": "string"
           }
@@ -5870,7 +5870,7 @@
         "type": "object"
       },
       "OAuthCallbackRequest": {
-        "description": "The authorization code a provider handed the browser.\n\nNo ``redirect_uri``: this deployment derives its own from ``public_base_url``\nso the URI used to build the authorization request and the one sent with the\nexchange are the same string by construction, and a browser cannot choose\nwhat this server sends to a provider.\n\n``state`` is required, and is what binds this callback to an authorization\nrequest this deployment actually made: it is claimed from\n``oauth_pending_state`` before the code is sent anywhere, and the row it\nclaims is what carries the PKCE verifier the exchange needs.",
+        "description": "The authorization code a provider handed the browser.\n\nNo ``redirect_uri``: this deployment derives its own from ``public_base_url``\nso the URI used to build the authorization request and the one sent with the\nexchange are the same string by construction, and a browser cannot choose\nwhat this server sends to a provider.\n\n``state`` is required, and is what binds this callback to an authorization\nrequest this deployment actually made: it is claimed from\n``oauth_pending_state`` before the code is sent anywhere, and the row it\nclaims is what carries the PKCE verifier the exchange needs. The flow\ncookie ``/authorize`` set travels alongside and binds it to the browser.",
         "properties": {
           "code": {
             "description": "The authorization code from the provider's redirect.",
@@ -15652,7 +15652,7 @@
     },
     "/v1/auth/oauth/{provider}/authorize": {
       "get": {
-        "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, and the PKCE verifier\nthe exchange will need) so the callback has something to check against, and\nthat record is the whole reason the callback can refuse a code this\ndeployment never asked for.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call.",
+        "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, the PKCE verifier the\nexchange will need, and the digest of a flow secret it sets as an HttpOnly\ncookie) so the callback has something to check against, and that record is\nthe whole reason the callback can refuse a code this deployment never asked\nfor, or one presented from a browser other than the one that asked.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call. The cookie is reused when the\nbrowser already holds one, so a second tab does not break the first.",
         "operationId": "authorize_v1_auth_oauth__provider__authorize_get",
         "parameters": [
           {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -628,7 +628,7 @@
         {
           "name": "Authorize",
           "request": {
-            "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET, and safe: it reads configuration and mints a random value, writing\nnothing. Repeating it simply produces another state, and only the one the\nbrowser kept is the one it will compare against.",
+            "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, and the PKCE verifier\nthe exchange will need) so the callback has something to check against, and\nthat record is the whole reason the callback can refuse a code this\ndeployment never asked for.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call.",
             "header": [],
             "method": "GET",
             "url": {
@@ -663,7 +663,7 @@
                   "language": "json"
                 }
               },
-              "raw": "{\n  \"code\": \"string\"\n}"
+              "raw": "{\n  \"code\": \"string\",\n  \"state\": \"string\"\n}"
             },
             "description": "Exchange an authorization code and set the HttpOnly session cookie.\n\nThe session is bound to the identity the provider's account resolves to,\nexactly as a password sign-in binds one to the identity that authenticated,\nso every request it later authenticates resolves the same caller.\n\nA refusal is counted like the other sign-in failures\n(``record_auth_failure``) and rendered by the tenancy error handler. Like\nthe passkey route there is no separate post-failure throttle: this route is\nthrottled unconditionally on the way in, because there is no legitimate\ncaller here whose correct credential must never be blocked. An authorization\ncode is single-use and minted by a redirect, not something a person retries\nby hand.\n\n**Maintenance mode freezes this the way it freezes the other two sign-ins.**\nThe freeze is on starting a session, not on a credential, so an OAuth sign-in\nhas to answer to it or the switch is bypassable by anybody holding a Google\naccount. Refused before the exchange, so a frozen deployment makes no\noutbound call, spends nobody's authorization code, and counts no auth\nfailure: nobody failed to authenticate, the gateway declined to try.",
             "header": [

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -628,7 +628,7 @@
         {
           "name": "Authorize",
           "request": {
-            "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, and the PKCE verifier\nthe exchange will need) so the callback has something to check against, and\nthat record is the whole reason the callback can refuse a code this\ndeployment never asked for.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call.",
+            "description": "Start an OAuth sign-in: where to send the browser, and the state to keep.\n\nA GET that writes, which is the one thing to know about it. It records the\nauthorization it is about to start (the state's hash, the PKCE verifier the\nexchange will need, and the digest of a flow secret it sets as an HttpOnly\ncookie) so the callback has something to check against, and that record is\nthe whole reason the callback can refuse a code this deployment never asked\nfor, or one presented from a browser other than the one that asked.\n\nStill safe to repeat: each call mints its own state, and only the one the\nbrowser kept is the one it sends back. The rows the others leave expire on\ntheir own and are swept by the next call. The cookie is reused when the\nbrowser already holds one, so a second tab does not break the first.",
             "header": [],
             "method": "GET",
             "url": {

--- a/src/gateway/api/routes/auth_oauth.py
+++ b/src/gateway/api/routes/auth_oauth.py
@@ -22,7 +22,13 @@ compares the returned state against the stored one and, only then, posts the
 code and the state here, where the state is checked again against the row
 ``/authorize`` wrote. Two checks that fail in different directions: the
 browser's binds a callback to the tab that started the flow, and this one binds
-it to a flow this deployment started. See ``gateway.services.oauth_service``.
+it to a flow this deployment started.
+
+**And to the browser that started it.** ``/authorize`` also sets an HttpOnly
+flow cookie whose digest the row keeps, and the callback refuses without it.
+The code and the state share one redirect URL that the access log and browser
+history both record; the cookie is the half of the flow that neither does. See
+``gateway.services.oauth_service``.
 
 **What this route decides, and what it does not.** It proves the person holds
 the provider account. Who that makes them *here* is behind
@@ -35,7 +41,7 @@ import uuid
 from datetime import datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Path, Request, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -57,8 +63,11 @@ from gateway.services.dashboard_session_service import (
 )
 from gateway.services.maintenance_mode_service import is_maintenance_mode
 from gateway.services.oauth_service import (
+    FLOW_COOKIE_NAME,
+    apply_flow_cookie,
     authorization_url,
     exchange_code,
+    flow_secret_for,
     provider_label,
     require_configured,
 )
@@ -81,6 +90,12 @@ _MAX_SUBMITTED_STATE = 512
 # answers at all, so an unknown segment is the framework's own 422 rather than a
 # handler deciding what to do with it. Spelled from the config vocabulary so the
 # two cannot drift.
+# The browser's flow cookie, when it sent one. Bounded for the same reason the
+# state is: it is hashed before anything looks at it.
+FlowCookie = Annotated[
+    str | None, Cookie(alias=FLOW_COOKIE_NAME, max_length=_MAX_SUBMITTED_STATE, include_in_schema=False)
+]
+
 ProviderPath = Annotated[
     str,
     Path(
@@ -104,7 +119,9 @@ class AuthorizeResponse(BaseModel):
             "'state' the provider returns, and send back with the authorization code. A callback "
             "whose state does not match the one held by the browser that started the flow should "
             "be abandoned by the client rather than sent here; one that does is checked again "
-            "against this deployment's own record of it."
+            "against this deployment's own record of it. The response also sets an HttpOnly "
+            "cookie that the callback requires, so the exchange can only be completed from the "
+            "browser this call was made from."
         )
     )
 
@@ -120,7 +137,8 @@ class OAuthCallbackRequest(BaseModel):
     ``state`` is required, and is what binds this callback to an authorization
     request this deployment actually made: it is claimed from
     ``oauth_pending_state`` before the code is sent anywhere, and the row it
-    claims is what carries the PKCE verifier the exchange needs.
+    claims is what carries the PKCE verifier the exchange needs. The flow
+    cookie ``/authorize`` set travels alongside and binds it to the browser.
     """
 
     code: str = Field(
@@ -180,24 +198,29 @@ def require_oauth_provider(
 async def authorize(
     provider: ProviderPath,
     request: Request,
+    response: Response,
     config: Annotated[GatewayConfig, Depends(get_config)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    flow_cookie: FlowCookie = None,
 ) -> AuthorizeResponse:
     """Start an OAuth sign-in: where to send the browser, and the state to keep.
 
     A GET that writes, which is the one thing to know about it. It records the
-    authorization it is about to start (the state's hash, and the PKCE verifier
-    the exchange will need) so the callback has something to check against, and
-    that record is the whole reason the callback can refuse a code this
-    deployment never asked for.
+    authorization it is about to start (the state's hash, the PKCE verifier the
+    exchange will need, and the digest of a flow secret it sets as an HttpOnly
+    cookie) so the callback has something to check against, and that record is
+    the whole reason the callback can refuse a code this deployment never asked
+    for, or one presented from a browser other than the one that asked.
 
     Still safe to repeat: each call mints its own state, and only the one the
     browser kept is the one it sends back. The rows the others leave expire on
-    their own and are swept by the next call.
+    their own and are swept by the next call. The cookie is reused when the
+    browser already holds one, so a second tab does not break the first.
     """
     throttle_public_auth(request)
+    flow_secret = flow_secret_for(flow_cookie)
     try:
-        url, state = await authorization_url(config, provider, db=db)
+        url, state = await authorization_url(config, provider, db=db, flow_secret=flow_secret)
         await db.commit()
     except SQLAlchemyError:
         await db.rollback()
@@ -206,6 +229,7 @@ async def authorize(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
+    apply_flow_cookie(response, flow_secret, secure=request_is_https(request))
     return AuthorizeResponse(authorization_url=url, state=state)
 
 
@@ -222,6 +246,7 @@ async def callback(
     identity_provider: IdentityProviderPortDep,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    flow_cookie: FlowCookie = None,
 ) -> OAuthSessionResponse:
     """Exchange an authorization code and set the HttpOnly session cookie.
 
@@ -251,7 +276,9 @@ async def callback(
             detail=MAINTENANCE_MODE_REFUSAL,
         )
     try:
-        external = await exchange_code(config, provider, code=body.code, state=body.state, db=db)
+        external = await exchange_code(
+            config, provider, code=body.code, state=body.state, flow_secret=flow_cookie, db=db
+        )
         identity = await identity_provider.resolve(
             provider=external.provider,
             email=external.email,

--- a/src/gateway/api/routes/auth_oauth.py
+++ b/src/gateway/api/routes/auth_oauth.py
@@ -19,9 +19,10 @@ them to ``/auth/{provider}/callback``, an ordinary path (a redirect URI may not
 carry a fragment, so it cannot be the hash route directly) which
 ``gateway.main`` redirects into the dashboard's own callback page. That page
 compares the returned state against the stored one and, only then, posts the
-authorization code here. So the state round-trips through the browser that
-minted it and this deployment stores nothing between the two requests, which is
-the same reason PKCE stays off; see ``gateway.services.oauth_service``.
+code and the state here, where the state is checked again against the row
+``/authorize`` wrote. Two checks that fail in different directions: the
+browser's binds a callback to the tab that started the flow, and this one binds
+it to a flow this deployment started. See ``gateway.services.oauth_service``.
 
 **What this route decides, and what it does not.** It proves the person holds
 the provider account. Who that makes them *here* is behind
@@ -58,7 +59,6 @@ from gateway.services.maintenance_mode_service import is_maintenance_mode
 from gateway.services.oauth_service import (
     authorization_url,
     exchange_code,
-    new_state,
     provider_label,
     require_configured,
 )
@@ -71,6 +71,11 @@ router = APIRouter(prefix="/v1/auth/oauth", tags=["auth"])
 # this is a sanity ceiling on an unauthenticated request body rather than a
 # format, matching the bounds ``auth_session.CreateSessionRequest`` sets.
 _MAX_SUBMITTED_CODE = 2048
+# A state this deployment issued is 43 characters (``secrets.token_urlsafe(32)``).
+# The ceiling is loose rather than exact because the value is looked up by hash
+# and a wrong length is simply a state that matches nothing; what it bounds is
+# how much an unauthenticated caller can make this process hash.
+_MAX_SUBMITTED_STATE = 512
 
 # Only a provider this deployment could ever configure is a path this router
 # answers at all, so an unknown segment is the framework's own 422 rather than a
@@ -95,10 +100,11 @@ class AuthorizeResponse(BaseModel):
     authorization_url: str = Field(description="The provider consent screen to navigate to.")
     state: str = Field(
         description=(
-            "An opaque CSRF value to keep for the length of the redirect and compare against the "
-            "'state' the provider returns. It is not stored on this deployment, so a callback "
-            "whose state does not match the one held by the browser that started the flow must be "
-            "abandoned by the client rather than sent here."
+            "An opaque CSRF value to keep for the length of the redirect, compare against the "
+            "'state' the provider returns, and send back with the authorization code. A callback "
+            "whose state does not match the one held by the browser that started the flow should "
+            "be abandoned by the client rather than sent here; one that does is checked again "
+            "against this deployment's own record of it."
         )
     )
 
@@ -111,15 +117,19 @@ class OAuthCallbackRequest(BaseModel):
     exchange are the same string by construction, and a browser cannot choose
     what this server sends to a provider.
 
-    No ``state`` either, and that is not an omission. The state is checked in the
-    browser, against the value that browser stored when it started the flow;
-    sending it here would let this deployment compare a value to itself, which
-    proves nothing without somewhere to have kept the original.
+    ``state`` is required, and is what binds this callback to an authorization
+    request this deployment actually made: it is claimed from
+    ``oauth_pending_state`` before the code is sent anywhere, and the row it
+    claims is what carries the PKCE verifier the exchange needs.
     """
 
     code: str = Field(
         max_length=_MAX_SUBMITTED_CODE,
         description="The authorization code from the provider's redirect.",
+    )
+    state: str = Field(
+        max_length=_MAX_SUBMITTED_STATE,
+        description="The 'state' from the provider's redirect, as issued by /authorize.",
     )
 
 
@@ -171,18 +181,32 @@ async def authorize(
     provider: ProviderPath,
     request: Request,
     config: Annotated[GatewayConfig, Depends(get_config)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AuthorizeResponse:
     """Start an OAuth sign-in: where to send the browser, and the state to keep.
 
-    A GET, and safe: it reads configuration and mints a random value, writing
-    nothing. Repeating it simply produces another state, and only the one the
-    browser kept is the one it will compare against.
+    A GET that writes, which is the one thing to know about it. It records the
+    authorization it is about to start (the state's hash, and the PKCE verifier
+    the exchange will need) so the callback has something to check against, and
+    that record is the whole reason the callback can refuse a code this
+    deployment never asked for.
+
+    Still safe to repeat: each call mints its own state, and only the one the
+    browser kept is the one it sends back. The rows the others leave expire on
+    their own and are swept by the next call.
     """
     throttle_public_auth(request)
-    state = new_state()
-    return AuthorizeResponse(
-        authorization_url=authorization_url(config, provider, state=state), state=state
-    )
+    try:
+        url, state = await authorization_url(config, provider, db=db)
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        logger.warning("Failed to record a pending %s sign-in", provider, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None
+    return AuthorizeResponse(authorization_url=url, state=state)
 
 
 @router.post(
@@ -227,7 +251,7 @@ async def callback(
             detail=MAINTENANCE_MODE_REFUSAL,
         )
     try:
-        external = await exchange_code(config, provider, code=body.code)
+        external = await exchange_code(config, provider, code=body.code, state=body.state, db=db)
         identity = await identity_provider.resolve(
             provider=external.provider,
             email=external.email,
@@ -254,9 +278,7 @@ async def callback(
         # racing, which the service settles on its own, and a database that
         # cannot stage this cannot stage the session row either.
         await OrganizationDomainService(db).auto_join_for_user(identity)
-        token, expires_at = await create_dashboard_session(
-            db, config.dashboard_session_ttl_hours, user_id=identity.id
-        )
+        token, expires_at = await create_dashboard_session(db, config.dashboard_session_ttl_hours, user_id=identity.id)
         await db.commit()
     except SQLAlchemyError:
         await db.rollback()

--- a/src/gateway/models/tenancy.py
+++ b/src/gateway/models/tenancy.py
@@ -1265,6 +1265,11 @@ WEBAUTHN_CHALLENGE_TTL_SECONDS = 300
 # the ~20 bytes real authenticators emit: a row that cannot be written is a
 # passkey that cannot be registered, and the column is text either way.
 MAX_CREDENTIAL_ID_LENGTH = 1364
+# How long a pending OAuth authorization stays consumable: the window between
+# the browser leaving for a consent screen and coming back with a code. Long
+# enough for somebody to read the screen and pick an account, and no longer,
+# because until this expires the row is a live half of an in-flight sign-in.
+OAUTH_STATE_TTL_SECONDS = 600
 
 WebAuthnCeremony = Literal["registration", "authentication"]
 WEBAUTHN_CEREMONIES: set[str] = {"registration", "authentication"}
@@ -1431,6 +1436,51 @@ class WebAuthnChallenge(SQLModel, table=True):
         return _validate_membership(value, allowed=WEBAUTHN_CEREMONIES, kind="WebAuthn ceremony")
 
 
+class OAuthPendingState(SQLModel, table=True):
+    """One in-flight OAuth authorization, from consent-screen redirect to code exchange.
+
+    In the database for the reason ``WebAuthnChallenge`` is: a deployment runs
+    more than one worker, and the request that mints a state is rarely the one
+    that spends it. apron-auth ships a ``MemoryStateStore`` whose own docstring
+    says a multi-process deployment needs a shared store instead, and this is
+    that store.
+
+    **Keyed by the hash, not the value.** This differs from
+    ``WebAuthnChallenge``, which stores its challenge in the clear, and the
+    difference is that something *is* stored under this key: the PKCE
+    ``code_verifier``. A challenge row gives a reader of the database nothing
+    they could not already see in the browser, while a row here is half of a
+    live sign-in. Hashing means a reader of this table cannot present a state
+    back to the callback, because what they hold is the digest and the wire
+    carries the preimage.
+
+    ``code_verifier`` is nullable only because apron-auth's pending state models
+    it that way for providers that cannot do PKCE. Both providers this
+    deployment offers can, so in practice every row carries one.
+
+    The row is deleted as it is consumed, so a replayed state matches nothing.
+    """
+
+    __tablename__ = "oauth_pending_state"
+
+    state_hash: str = Field(primary_key=True, max_length=64)
+    # Compared after the row is claimed rather than added to the WHERE clause,
+    # the way ``WebAuthnChallenge.ceremony`` is: a state minted for Google and
+    # returned to GitHub's callback is a refusal that should say so, not one
+    # that collapses into "unknown state".
+    provider: str = Field(max_length=32)
+    code_verifier: str | None = Field(default=None, max_length=128)
+    # Kept rather than re-derived at exchange time so the URI sent with the
+    # exchange is the one the authorization request was actually built with,
+    # even across a ``public_base_url`` change mid-flight.
+    redirect_uri: str = Field(max_length=2048)
+    created_at: datetime = _timestamp_field(
+        default_factory=lambda: datetime.now(UTC),
+        column_kwargs={"server_default": func.now()},
+    )
+    expires_at: datetime = Field(sa_type=UtcDateTime(), index=True)  # type: ignore[call-overload]
+
+
 __all__ = [
     "DeploymentAdminAccessPublic",
     "DeploymentUserOrganizationPublic",
@@ -1442,6 +1492,7 @@ __all__ = [
     "INVITATION_STATUSES",
     "MAX_CREDENTIAL_ID_LENGTH",
     "MAX_WEBAUTHN_CREDENTIAL_NAME",
+    "OAUTH_STATE_TTL_SECONDS",
     "MANAGEMENT_ROLES",
     "MAX_ORGANIZATION_DOMAINS",
     "MAX_WORKSPACE_ASSIGNMENTS",
@@ -1470,6 +1521,7 @@ __all__ = [
     "InvitationUpdate",
     "InviteOrganizationMemberRequest",
     "InviteOrganizationMemberResultPublic",
+    "OAuthPendingState",
     "Organization",
     "OrganizationCreate",
     "OrganizationCreateRequest",

--- a/src/gateway/models/tenancy.py
+++ b/src/gateway/models/tenancy.py
@@ -1469,6 +1469,10 @@ class OAuthPendingState(SQLModel, table=True):
     # returned to GitHub's callback is a refusal that should say so, not one
     # that collapses into "unknown state".
     provider: str = Field(max_length=32)
+    # SHA-256 of the flow secret the browser holds in its cookie, so a row
+    # answers only to the browser that started it (RFC 9700, section 4.7.1).
+    # Hashed for the reason ``state_hash`` is.
+    flow_hash: str = Field(max_length=64)
     code_verifier: str | None = Field(default=None, max_length=128)
     # Kept rather than re-derived at exchange time so the URI sent with the
     # exchange is the one the authorization request was actually built with,

--- a/src/gateway/services/oauth_service.py
+++ b/src/gateway/services/oauth_service.py
@@ -14,76 +14,69 @@ resolves an identity against its roster and an overlay may provision instead.
 This module stops at "the provider says this is who they are", and the sign-in
 route hands that across the seam.
 
-**PKCE is deliberately off, and the authorization URLs are built by hand.**
-Authorize and callback are two independent HTTP requests with nothing kept
-server-side between them, so a verifier minted while building the authorization
-URL has nowhere to live until the exchange. That is why ``_without_pkce``
-clears the flag and why ``authorization_url`` assembles the query itself rather
-than calling ``OAuthClient.get_authorization_url``, which is the method that
-reads the flag and would start sending a code challenge this flow cannot
-answer. Turning PKCE on is a real change with a real prerequisite (somewhere for
-the verifier to live), not a default to restore.
+**PKCE is on, and the ``state`` is checked here.** Both rest on one thing: a
+``models.tenancy.OAuthPendingState`` row per authorization in flight, written
+when the authorization URL is built and consumed by the exchange. apron-auth's
+``StateStore`` protocol is the seam it plugs into, so ``get_authorization_url``
+mints the verifier and ``exchange_code`` reads it back, and neither the code
+challenge nor the state comparison is this module's own arithmetic.
 
-The CSRF ``state`` is minted here and checked in the browser, which is the same
-split for the same reason: the dashboard puts it in ``sessionStorage`` when it
-sends somebody to the provider and compares it when the provider sends them
-back, so the value survives the round trip without this deployment storing
-anything. See ``web/src/features/auth/OAuthCallbackPage.tsx``.
+What is this module's own is the two overrides in ``_provider_config``: the
+presets widen scopes and, for Google, ask for offline access, and neither is
+wanted here. See that function.
+
+The browser keeps its ``sessionStorage`` copy of the state and still compares
+it, which is not redundant. That check binds a callback to the *tab* that
+started the flow, which a server-side row cannot do; this one binds it to a
+flow this deployment actually started, which the browser cannot do. They fail
+in different directions. See ``web/src/features/auth/OAuthCallbackPage.tsx``.
 """
 
-import secrets
+import hashlib
 from dataclasses import dataclass
-from urllib.parse import quote, urlencode
+from datetime import UTC, datetime, timedelta
+from urllib.parse import quote
 
 from apron_auth import OAuthClient, ProviderConfig
+from apron_auth.errors import StateError
+from apron_auth.models import OAuthPendingState as PendingState
 from apron_auth.providers import github as apron_github
 from apron_auth.providers import google as apron_google
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from gateway.core.config import OAUTH_PROVIDERS, GatewayConfig
 from gateway.log_config import logger
-from gateway.services.tenancy.errors import OAuthExchangeError, OAuthNotConfiguredError
+from gateway.models.tenancy import OAUTH_STATE_TTL_SECONDS, OAuthPendingState
+from gateway.services.tenancy.errors import (
+    OAuthExchangeError,
+    OAuthNotConfiguredError,
+    OAuthStateError,
+)
 
-# Where each provider's consent screen lives, and which scopes to ask it for.
+# Which scopes each provider is asked for, and what it calls itself.
 #
 # The scope sets must cover what the matching apron-auth identity handler reads
 # back at callback time: Google's OIDC userinfo endpoint, and GitHub's ``/user``
-# plus ``/user/emails``. Each preset merges its own base scopes on top of these,
-# so a provider config's scope set is a superset of what the authorization URL
-# asks for.
+# plus ``/user/emails``. They are the exact set the authorization request asks
+# for, which ``_as_configured_here`` is what makes true: a preset would
+# otherwise merge its own base scopes over them.
 #
-# **No ``access_type=offline``**, and no other extra parameter. The platform's
-# own hand-built URL sends it and apron-auth's Google preset sets
-# ``{"access_type": "offline", "prompt": "consent"}``, so this is a deliberate
-# departure from both rather than an oversight. Offline access exists to obtain
-# a refresh token, and nothing here stores one: a sign-in reads an identity once
-# and mints Otari's own session, so a refresh token would be a durable
-# credential Google issued, this deployment discarded, and nobody ever revoked.
-# Not asking for it also keeps the consent screen from telling a person about
-# access this gateway does not want.
-_GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
-_GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+# The consent-screen endpoints are the presets' own and are not restated here.
 
 
 @dataclass(frozen=True)
 class _Provider:
-    """One provider's authorization endpoint, scopes, and apron-auth wiring."""
+    """One provider's scopes, and the name it writes itself under."""
 
     label: str
-    authorize_url: str
     scopes: tuple[str, ...]
 
 
 _PROVIDERS: dict[str, _Provider] = {
-    "google": _Provider(
-        label="Google",
-        authorize_url=_GOOGLE_AUTHORIZE_URL,
-        scopes=("openid", "email", "profile"),
-    ),
-    "github": _Provider(
-        label="GitHub",
-        authorize_url=_GITHUB_AUTHORIZE_URL,
-        scopes=("read:user", "user:email"),
-    ),
+    "google": _Provider(label="Google", scopes=("openid", "email", "profile")),
+    "github": _Provider(label="GitHub", scopes=("read:user", "user:email")),
 }
 # Kept honest by a unit test as well, but asserted at import so a provider added
 # to one of the two lists and not the other fails on the way up rather than on
@@ -163,50 +156,142 @@ def callback_landing_target(config: GatewayConfig, provider: str, query: str) ->
     return f"{target}?{query}" if query else target
 
 
-def new_state() -> str:
-    """A fresh CSRF ``state`` for one authorization request."""
-    return secrets.token_urlsafe(32)
+class _DatabaseStateStore:
+    """apron-auth's ``StateStore``, backed by ``oauth_pending_state``.
+
+    Two methods and no repository, because it is not the shape a repository
+    serves: apron-auth calls these, and both are a single statement against one
+    table that nothing else reads.
+
+    Rows are staged on the caller's transaction and never committed here. The
+    route owns the commit boundary, which is what lets a callback that fails
+    after consuming a state roll the consumption back and leave the person a
+    flow to retry.
+    """
+
+    def __init__(self, db: AsyncSession, provider: str) -> None:
+        self._db = db
+        self._provider = provider
+
+    async def save(self, state: PendingState) -> None:
+        """Stage one pending authorization, and sweep whatever has expired."""
+        now = datetime.now(UTC)
+        # The sweep rides here rather than on a scheduler because this is the
+        # only write the table takes, so it is the only place that can grow it.
+        # Same reason ``create_dashboard_session`` prunes on the way in.
+        await self._db.execute(delete(OAuthPendingState).where(col(OAuthPendingState.expires_at) <= now))
+        self._db.add(
+            OAuthPendingState(
+                state_hash=_state_hash(state.state),
+                provider=self._provider,
+                code_verifier=state.code_verifier,
+                redirect_uri=state.redirect_uri,
+                expires_at=now + timedelta(seconds=OAUTH_STATE_TTL_SECONDS),
+            )
+        )
+        await self._db.flush()
+
+    async def consume(self, state_key: str) -> PendingState | None:
+        """Claim one pending authorization, or answer ``None``.
+
+        **One conditional DELETE, not a SELECT and then a delete**, the rule
+        ``webauthn_service.consume_challenge`` states at length and for the same
+        reason: single use is the property, and a read-then-write cannot provide
+        it. Two callbacks replaying one state would both find the row; deleting
+        by primary key and reading what came back means exactly one of them
+        does.
+
+        ``provider`` is compared after the row is claimed rather than added to
+        the WHERE clause, so a state minted for one provider and returned to
+        another is refused as itself rather than as an unknown state. It is
+        still claimed, because a state that arrived at the wrong callback is
+        spent either way.
+        """
+        row = (
+            await self._db.execute(
+                delete(OAuthPendingState)
+                .where(col(OAuthPendingState.state_hash) == _state_hash(state_key))
+                .returning(
+                    col(OAuthPendingState.provider),
+                    col(OAuthPendingState.code_verifier),
+                    col(OAuthPendingState.redirect_uri),
+                    col(OAuthPendingState.expires_at),
+                )
+            )
+        ).first()
+        if row is None:
+            return None
+        provider, code_verifier, redirect_uri, expires_at = row
+        if provider != self._provider:
+            logger.warning("OAuth state minted for %s was returned to %s", provider, self._provider)
+            return None
+        if expires_at <= datetime.now(UTC):
+            return None
+        return PendingState(
+            state=state_key,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
+            created_at=(expires_at - timedelta(seconds=OAUTH_STATE_TTL_SECONDS)).timestamp(),
+        )
 
 
-def authorization_url(config: GatewayConfig, provider: str, *, state: str) -> str:
-    """The provider consent screen to send the browser to.
+def _state_hash(state: str) -> str:
+    """The key a state is stored under: its SHA-256, hex.
 
-    Assembled here rather than by ``OAuthClient.get_authorization_url``; see the
-    module docstring on PKCE for why that matters.
+    The state is a 256-bit random value from ``secrets``, so this is a lookup
+    key and not a password hash; a single round is right and a KDF would be
+    theater. What it buys is that a reader of the table holds digests, and the
+    callback compares against the preimage.
+    """
+    return hashlib.sha256(state.encode()).hexdigest()
+
+
+async def authorization_url(config: GatewayConfig, provider: str, *, db: AsyncSession) -> tuple[str, str]:
+    """The provider consent screen to send the browser to, and the state to keep.
+
+    Staged, not committed: the caller commits, so an authorization URL is never
+    handed back over a row that failed to write.
 
     Raises:
         OAuthNotConfiguredError: If this deployment configured no client
             credentials for ``provider``, or does not know its own address.
 
     """
-    client_id, _ = _credentials(config, provider)
-    known = _PROVIDERS[provider]
-    params = {
-        "client_id": client_id,
-        "redirect_uri": redirect_uri(config, provider),
-        "response_type": "code",
-        "scope": " ".join(known.scopes),
-        "state": state,
-    }
-    return f"{known.authorize_url}?{urlencode(params)}"
+    client = _client(config, provider, db)
+    url, pending = await client.get_authorization_url(redirect_uri=redirect_uri(config, provider))
+    return url, pending.state
 
 
-async def exchange_code(config: GatewayConfig, provider: str, *, code: str) -> OAuthIdentity:
+async def exchange_code(
+    config: GatewayConfig, provider: str, *, code: str, state: str, db: AsyncSession
+) -> OAuthIdentity:
     """Trade an authorization code for the identity the provider vouches for.
+
+    ``state`` is claimed before the code is sent anywhere, so a callback this
+    deployment never started costs one indexed delete and no outbound call. The
+    claim also yields the PKCE verifier and the redirect URI the authorization
+    request was built with, which is why neither is passed here.
 
     Raises:
         OAuthNotConfiguredError: If this deployment configured no client
             credentials for ``provider``, or does not know its own address.
+        OAuthStateError: If ``state`` names no authorization this deployment is
+            still waiting on, for ``provider``.
         OAuthExchangeError: If the exchange or the identity fetch fails, for any
             reason. The provider's own words stay on the traceback and out of
             the response; see that error's docstring.
 
     """
-    client = _client(config, provider)
-    uri = redirect_uri(config, provider)
+    client = _client(config, provider, db)
     try:
-        tokens = await client.exchange_code(code=code, redirect_uri=uri)
+        tokens = await client.exchange_code(code=code, state=state)
         profile = await client.fetch_identity(tokens)
+    except StateError as error:
+        # Ahead of the catch-all below, which would otherwise render a refused
+        # state as "the provider did not complete the sign-in" and send an
+        # operator looking at a provider that was never contacted.
+        logger.warning("Refused a %s callback whose state matched no pending sign-in", provider)
+        raise OAuthStateError from error
     except Exception as error:
         # Logged with the exception so an operator can see the provider's own
         # error and description, which the response deliberately does not carry.
@@ -257,10 +342,9 @@ def _credentials(config: GatewayConfig, provider: str) -> tuple[str, str]:
     return credentials
 
 
-def _client(config: GatewayConfig, provider: str) -> OAuthClient:
-    """The apron-auth client that performs ``provider``'s code exchange."""
+def _client(config: GatewayConfig, provider: str, db: AsyncSession) -> OAuthClient:
+    """The apron-auth client that builds ``provider``'s authorization URL and spends its code."""
     client_id, client_secret = _credentials(config, provider)
-    known = _PROVIDERS[provider]
     preset = apron_google.preset if provider == "google" else apron_github.preset
     identity_handler = (
         apron_google.GoogleIdentityHandler() if provider == "google" else apron_github.GitHubIdentityHandler()
@@ -268,23 +352,41 @@ def _client(config: GatewayConfig, provider: str) -> OAuthClient:
     provider_config, _revocation_handler = preset(
         client_id=client_id,
         client_secret=client_secret,
-        scopes=list(known.scopes),
+        scopes=list(_PROVIDERS[provider].scopes),
         redirect_uri=redirect_uri(config, provider),
     )
-    return OAuthClient(_without_pkce(provider_config), identity_handler=identity_handler)
+    return OAuthClient(
+        _as_configured_here(provider_config, provider),
+        state_store=_DatabaseStateStore(db, provider),
+        identity_handler=identity_handler,
+    )
 
 
-def _without_pkce(provider_config: ProviderConfig) -> ProviderConfig:
-    """Clear PKCE on a config this flow uses.
+def _as_configured_here(provider_config: ProviderConfig, provider: str) -> ProviderConfig:
+    """Undo the two preset defaults this deployment does not want.
 
-    apron-auth reads ``use_pkce`` only inside ``get_authorization_url``, which
-    this module does not call, so clearing it changes nothing about the exchange
-    today. It is cleared so that adopting the library's URL builder, once
-    somewhere exists for a verifier to live, is a deliberate step rather than
-    one that silently starts sending a code challenge this flow cannot answer.
-    See the module docstring.
+    Both matter only because the authorization URL is apron-auth's to build
+    now. While it was assembled by hand, neither field was ever read, so both
+    departures were invisible; adopting ``get_authorization_url`` is what makes
+    them settings rather than omissions.
+
+    **Scopes are pinned to the exact set in ``_PROVIDERS``.** Each preset merges
+    its own ``BASE_SCOPES`` over what it is given, which for Google adds the
+    long-form ``userinfo.email`` alongside the ``email`` already asked for. It
+    grants nothing new, and it is one more line on the consent screen naming a
+    scope this gateway did not choose.
+
+    **Google's ``extra_params`` are cleared.** The preset sets
+    ``access_type=offline`` and ``prompt=consent``, and the preset's own
+    ``extra_params`` argument merges *over* those rather than replacing them, so
+    this is the only place to drop them. Offline access exists to obtain a
+    refresh token; a sign-in here reads an identity once and mints Otari's own
+    session, so a refresh token would be a durable credential Google issued,
+    this deployment discarded, and nobody ever revoked. ``prompt=consent`` goes
+    with it: re-consenting on every sign-in is what asking for offline access
+    obliges, and nothing here needs it.
     """
-    return provider_config.model_copy(update={"use_pkce": False})
+    return provider_config.model_copy(update={"scopes": list(_PROVIDERS[provider].scopes), "extra_params": {}})
 
 
 __all__ = [
@@ -293,7 +395,6 @@ __all__ = [
     "base_url",
     "callback_landing_target",
     "exchange_code",
-    "new_state",
     "provider_label",
     "redirect_uri",
     "require_configured",

--- a/src/gateway/services/oauth_service.py
+++ b/src/gateway/services/oauth_service.py
@@ -203,9 +203,10 @@ class _DatabaseStateStore:
 
         ``provider`` is compared after the row is claimed rather than added to
         the WHERE clause, so a state minted for one provider and returned to
-        another is refused as itself rather than as an unknown state. It is
-        still claimed, because a state that arrived at the wrong callback is
-        spent either way.
+        another is refused as itself rather than as an unknown state. The
+        delete is staged on the request's transaction and the refusal keeps
+        that transaction from committing, so the row survives for the
+        callback it was minted for.
         """
         row = (
             await self._db.execute(

--- a/src/gateway/services/oauth_service.py
+++ b/src/gateway/services/oauth_service.py
@@ -21,6 +21,15 @@ when the authorization URL is built and consumed by the exchange. apron-auth's
 mints the verifier and ``exchange_code`` reads it back, and neither the code
 challenge nor the state comparison is this module's own arithmetic.
 
+**The row is bound to the browser as well as to the flow.** A ``code`` and a
+``state`` travel together in one redirect URL, and that URL is written to the
+access log and to browser history, so a row keyed on the state alone would let
+whoever reads either finish the sign-in for the full TTL. So ``/authorize``
+also sets an HttpOnly cookie carrying a random flow secret, the row keeps that
+secret's digest, and the callback must present the cookie (RFC 9700, section
+4.7.1). One secret per browser rather than per flow: a second tab starting a
+sign-in reuses the cookie it finds, so neither tab's callback breaks the other.
+
 What is this module's own is the two overrides in ``_provider_config``: the
 presets widen scopes and, for Google, ask for offline access, and neither is
 wanted here. See that function.
@@ -33,6 +42,8 @@ in different directions. See ``web/src/features/auth/OAuthCallbackPage.tsx``.
 """
 
 import hashlib
+import hmac
+import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from urllib.parse import quote
@@ -42,6 +53,7 @@ from apron_auth.errors import StateError
 from apron_auth.models import OAuthPendingState as PendingState
 from apron_auth.providers import github as apron_github
 from apron_auth.providers import google as apron_google
+from fastapi import Response
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -73,6 +85,14 @@ class _Provider:
     label: str
     scopes: tuple[str, ...]
 
+
+# The cookie that binds a pending authorization to the browser that started it.
+# Scoped to the OAuth routes, which are the only ones that read it.
+FLOW_COOKIE_NAME = "otari_oauth_flow"
+_FLOW_COOKIE_PATH = "/v1/auth/oauth"
+# What ``secrets.token_urlsafe(32)`` produces; anything else in the cookie is
+# not ours and is replaced rather than reused.
+_FLOW_SECRET_LENGTH = 43
 
 _PROVIDERS: dict[str, _Provider] = {
     "google": _Provider(label="Google", scopes=("openid", "email", "profile")),
@@ -169,12 +189,19 @@ class _DatabaseStateStore:
     flow to retry.
     """
 
-    def __init__(self, db: AsyncSession, provider: str) -> None:
+    def __init__(self, db: AsyncSession, provider: str, flow_hash: str) -> None:
         self._db = db
         self._provider = provider
+        self._flow_hash = flow_hash
 
     async def save(self, state: PendingState) -> None:
         """Stage one pending authorization, and sweep whatever has expired."""
+        if state.metadata:
+            # The row has no column for it, so a caller that starts relying on
+            # apron-auth's save/consume round trip finds out at the write rather
+            # than by reading an empty ``TokenSet.context`` later.
+            msg = "oauth_pending_state does not carry apron-auth state metadata"
+            raise ValueError(msg)
         now = datetime.now(UTC)
         # The sweep rides here rather than on a scheduler because this is the
         # only write the table takes, so it is the only place that can grow it.
@@ -184,6 +211,7 @@ class _DatabaseStateStore:
             OAuthPendingState(
                 state_hash=_state_hash(state.state),
                 provider=self._provider,
+                flow_hash=self._flow_hash,
                 code_verifier=state.code_verifier,
                 redirect_uri=state.redirect_uri,
                 expires_at=now + timedelta(seconds=OAUTH_STATE_TTL_SECONDS),
@@ -201,12 +229,13 @@ class _DatabaseStateStore:
         by primary key and reading what came back means exactly one of them
         does.
 
-        ``provider`` is compared after the row is claimed rather than added to
-        the WHERE clause, so a state minted for one provider and returned to
-        another is refused as itself rather than as an unknown state. The
-        delete is staged on the request's transaction and the refusal keeps
-        that transaction from committing, so the row survives for the
-        callback it was minted for.
+        ``provider`` and the flow secret are compared after the row is claimed
+        rather than added to the WHERE clause, so a state minted for one
+        provider and returned to another, or presented from a browser other
+        than the one that started it, is refused as itself rather than as an
+        unknown state. The delete is staged on the request's transaction and
+        the refusal keeps that transaction from committing, so the row survives
+        for the callback it was minted for.
         """
         row = (
             await self._db.execute(
@@ -214,17 +243,22 @@ class _DatabaseStateStore:
                 .where(col(OAuthPendingState.state_hash) == _state_hash(state_key))
                 .returning(
                     col(OAuthPendingState.provider),
+                    col(OAuthPendingState.flow_hash),
                     col(OAuthPendingState.code_verifier),
                     col(OAuthPendingState.redirect_uri),
+                    col(OAuthPendingState.created_at),
                     col(OAuthPendingState.expires_at),
                 )
             )
         ).first()
         if row is None:
             return None
-        provider, code_verifier, redirect_uri, expires_at = row
+        provider, flow_hash, code_verifier, redirect_uri, created_at, expires_at = row
         if provider != self._provider:
             logger.warning("OAuth state minted for %s was returned to %s", provider, self._provider)
+            return None
+        if not hmac.compare_digest(flow_hash, self._flow_hash):
+            logger.warning("OAuth %s callback came from a browser other than the one that started it", provider)
             return None
         if expires_at <= datetime.now(UTC):
             return None
@@ -232,8 +266,13 @@ class _DatabaseStateStore:
             state=state_key,
             redirect_uri=redirect_uri,
             code_verifier=code_verifier,
-            created_at=(expires_at - timedelta(seconds=OAUTH_STATE_TTL_SECONDS)).timestamp(),
+            created_at=created_at.timestamp(),
         )
+
+
+def _flow_hash(flow_secret: str) -> str:
+    """The digest a row keeps of the browser's flow secret; same reasoning as ``_state_hash``."""
+    return hashlib.sha256(flow_secret.encode()).hexdigest()
 
 
 def _state_hash(state: str) -> str:
@@ -247,24 +286,68 @@ def _state_hash(state: str) -> str:
     return hashlib.sha256(state.encode()).hexdigest()
 
 
-async def authorization_url(config: GatewayConfig, provider: str, *, db: AsyncSession) -> tuple[str, str]:
+def flow_secret_for(existing: str | None) -> str:
+    """The flow secret this browser's authorizations are bound under.
+
+    Reused when the browser already holds one of ours, so a second tab starting
+    a sign-in does not invalidate the first tab's; minted otherwise. A cookie
+    that is not the shape this module issues is somebody else's and is replaced.
+    """
+    if existing and len(existing) == _FLOW_SECRET_LENGTH and _is_urlsafe(existing):
+        return existing
+    return secrets.token_urlsafe(32)
+
+
+def _is_urlsafe(value: str) -> bool:
+    return all(character.isalnum() or character in "-_" for character in value)
+
+
+def apply_flow_cookie(response: Response, secret: str, *, secure: bool) -> None:
+    """Set (or refresh) the flow cookie with the attributes the session cookie uses.
+
+    ``Lax`` rather than ``Strict`` because the request that spends it is a
+    same-origin POST from the dashboard, which either setting carries; ``Lax``
+    just does not depend on that staying true. The path keeps it off every
+    request that is not an OAuth one.
+    """
+    response.set_cookie(
+        FLOW_COOKIE_NAME,
+        secret,
+        max_age=OAUTH_STATE_TTL_SECONDS,
+        httponly=True,
+        secure=secure,
+        samesite="lax",
+        path=_FLOW_COOKIE_PATH,
+    )
+
+
+async def authorization_url(
+    config: GatewayConfig, provider: str, *, db: AsyncSession, flow_secret: str
+) -> tuple[str, str]:
     """The provider consent screen to send the browser to, and the state to keep.
 
     Staged, not committed: the caller commits, so an authorization URL is never
-    handed back over a row that failed to write.
+    handed back over a row that failed to write. ``flow_secret`` is the value
+    the browser will hold in ``FLOW_COOKIE_NAME``; only its digest is stored.
 
     Raises:
         OAuthNotConfiguredError: If this deployment configured no client
             credentials for ``provider``, or does not know its own address.
 
     """
-    client = _client(config, provider, db)
+    client = _client(config, provider, db, flow_secret)
     url, pending = await client.get_authorization_url(redirect_uri=redirect_uri(config, provider))
     return url, pending.state
 
 
 async def exchange_code(
-    config: GatewayConfig, provider: str, *, code: str, state: str, db: AsyncSession
+    config: GatewayConfig,
+    provider: str,
+    *,
+    code: str,
+    state: str,
+    flow_secret: str | None,
+    db: AsyncSession,
 ) -> OAuthIdentity:
     """Trade an authorization code for the identity the provider vouches for.
 
@@ -273,17 +356,24 @@ async def exchange_code(
     claim also yields the PKCE verifier and the redirect URI the authorization
     request was built with, which is why neither is passed here.
 
+    ``flow_secret`` is the browser's ``FLOW_COOKIE_NAME`` cookie, or ``None``
+    when it sent none. A callback without it is refused before the database is
+    touched: there is no row it could match.
+
     Raises:
         OAuthNotConfiguredError: If this deployment configured no client
             credentials for ``provider``, or does not know its own address.
         OAuthStateError: If ``state`` names no authorization this deployment is
-            still waiting on, for ``provider``.
+            still waiting on, for ``provider``, from this browser.
         OAuthExchangeError: If the exchange or the identity fetch fails, for any
             reason. The provider's own words stay on the traceback and out of
             the response; see that error's docstring.
 
     """
-    client = _client(config, provider, db)
+    if flow_secret is None:
+        logger.warning("Refused a %s callback that carried no flow cookie", provider)
+        raise OAuthStateError
+    client = _client(config, provider, db, flow_secret)
     try:
         tokens = await client.exchange_code(code=code, state=state)
         profile = await client.fetch_identity(tokens)
@@ -343,7 +433,7 @@ def _credentials(config: GatewayConfig, provider: str) -> tuple[str, str]:
     return credentials
 
 
-def _client(config: GatewayConfig, provider: str, db: AsyncSession) -> OAuthClient:
+def _client(config: GatewayConfig, provider: str, db: AsyncSession, flow_secret: str) -> OAuthClient:
     """The apron-auth client that builds ``provider``'s authorization URL and spends its code."""
     client_id, client_secret = _credentials(config, provider)
     preset = apron_google.preset if provider == "google" else apron_github.preset
@@ -358,7 +448,7 @@ def _client(config: GatewayConfig, provider: str, db: AsyncSession) -> OAuthClie
     )
     return OAuthClient(
         _as_configured_here(provider_config, provider),
-        state_store=_DatabaseStateStore(db, provider),
+        state_store=_DatabaseStateStore(db, provider, _flow_hash(flow_secret)),
         identity_handler=identity_handler,
     )
 
@@ -391,11 +481,14 @@ def _as_configured_here(provider_config: ProviderConfig, provider: str) -> Provi
 
 
 __all__ = [
+    "FLOW_COOKIE_NAME",
     "OAuthIdentity",
+    "apply_flow_cookie",
     "authorization_url",
     "base_url",
     "callback_landing_target",
     "exchange_code",
+    "flow_secret_for",
     "provider_label",
     "redirect_uri",
     "require_configured",

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -417,6 +417,22 @@ class OAuthExchangeError(TenancyValidationError):
         super().__init__(f"{provider} did not complete the sign-in. Try again.")
 
 
+class OAuthStateError(TenancyValidationError):
+    """The callback did not carry a ``state`` this deployment is still waiting on.
+
+    Covers every way that can be true (never minted here, already spent,
+    expired, or minted for a different provider), because they are one answer to
+    the caller: start the sign-in again. Which of them it was stays in the log.
+
+    Deliberately indistinguishable from the outside. Telling an attacker that a
+    state existed but had expired, as against never existing at all, tells them
+    their guess was in the right shape.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("That sign-in did not start here, or it expired. Start again.")
+
+
 class OAuthEmailNotVerifiedError(TenancyError):
     """The provider returned an address it will not vouch for.
 
@@ -794,6 +810,8 @@ class OrganizationPricingOverlapError(TenancyConflictError):
             f"An override for '{model_key}' already covers part of that period ({existing_period}). "
             "Change this period, or edit the existing override instead."
         )
+
+
 class InvitationNotFoundError(TenancyNotFoundError):
     """No invitation matches the token or id given.
 
@@ -1199,6 +1217,7 @@ __all__ = [
     "OAuthExchangeError",
     "OAuthIdentityUnknownError",
     "OAuthNotConfiguredError",
+    "OAuthStateError",
     "OrganizationNotFoundError",
     "OrganizationPricingNotFoundError",
     "OrganizationScopeNotFoundError",

--- a/tests/integration/test_email_domain_auto_join_routes.py
+++ b/tests/integration/test_email_domain_auto_join_routes.py
@@ -205,7 +205,9 @@ def test_an_oauth_sign_in_joins_the_organization_that_proved_the_domain(
     monkeypatch.setattr(test_config, "oauth_google_client_id", "google-id")
     monkeypatch.setattr(test_config, "oauth_google_client_secret", "google-secret")
 
-    async def _exchange(_config: GatewayConfig, provider: str, *, code: str) -> OAuthIdentity:
+    async def _exchange(
+        _config: GatewayConfig, provider: str, *, code: str, state: str, flow_secret: str | None, db: Any
+    ) -> OAuthIdentity:
         return OAuthIdentity(provider=provider, email=ADDRESS, full_name="Ada", email_verified=True)
 
     monkeypatch.setattr("gateway.api.routes.auth_oauth.exchange_code", _exchange)
@@ -213,7 +215,7 @@ def test_an_oauth_sign_in_joins_the_organization_that_proved_the_domain(
     _rostered_identity(client, master_key_header, not_in=claiming_organization)
     client.cookies.clear()
 
-    signed_in = client.post("/v1/auth/oauth/google/callback", json={"code": "the-code"})
+    signed_in = client.post("/v1/auth/oauth/google/callback", json={"code": "the-code", "state": "s"})
 
     _assert_joined(client, signed_in, beta=claiming_organization, home=home)
 
@@ -290,12 +292,16 @@ def test_a_membership_does_not_survive_a_sign_in_that_fails_after_it_is_staged(
 
     # Read on a connection of its own, so what is asserted is what committed
     # rather than anything the request's own session still held.
-    stranded = test_db.execute(
-        select(OrganizationMember).where(
-            col(OrganizationMember.user_id) == uuid.UUID(user_id),
-            col(OrganizationMember.organization_id) == uuid.UUID(claiming_organization),
+    stranded = (
+        test_db.execute(
+            select(OrganizationMember).where(
+                col(OrganizationMember.user_id) == uuid.UUID(user_id),
+                col(OrganizationMember.organization_id) == uuid.UUID(claiming_organization),
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert list(stranded) == [], "the failed sign-in left a membership behind"
 
     # And the same sign-in, once it can complete, does create it: the assertion

--- a/tests/integration/test_oauth_api.py
+++ b/tests/integration/test_oauth_api.py
@@ -11,10 +11,14 @@ the request shape apron-auth actually sends is one Google and GitHub accept, and
 nothing here can stand in for it.
 """
 
+from base64 import urlsafe_b64encode
+from hashlib import sha256
+from types import SimpleNamespace
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
+from apron_auth import OAuthClient
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -54,7 +58,7 @@ def stub_exchange(
     """
     spent: list[str] = []
 
-    async def _exchange(_config: GatewayConfig, provider: str, *, code: str) -> OAuthIdentity:
+    async def _exchange(_config: GatewayConfig, provider: str, *, code: str, state: str, db: Any) -> OAuthIdentity:
         spent.append(code)
         return OAuthIdentity(
             provider=provider,
@@ -97,9 +101,7 @@ def test_the_bootstrap_offers_no_provider_until_one_is_configured(client: TestCl
     assert bootstrap.json()["oauth_providers"] == []
 
 
-def test_the_bootstrap_names_the_providers_an_operator_configured(
-    client: TestClient, oauth_configured: None
-) -> None:
+def test_the_bootstrap_names_the_providers_an_operator_configured(client: TestClient, oauth_configured: None) -> None:
     assert client.get("/v1/bootstrap").json()["oauth_providers"] == ["github", "google"]
 
 
@@ -166,7 +168,7 @@ def test_a_rostered_member_signs_in_and_gets_the_same_session_a_password_would(
     user_id = add_member(client, master_key_header, email="ada@example.com")
     spent = stub_exchange(monkeypatch)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "the-code"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "the-code", "state": "s"})
 
     assert response.status_code == 200, response.text
     body = response.json()
@@ -199,7 +201,7 @@ def test_the_provider_is_recorded_on_the_identity_it_signed_in(
     add_member(client, master_key_header, email="ada@example.com")
     stub_exchange(monkeypatch)
 
-    signed_in = client.post("/v1/auth/oauth/github/callback", json={"code": "c"})
+    signed_in = client.post("/v1/auth/oauth/github/callback", json={"code": "c", "state": "s"})
     assert signed_in.status_code == 200, signed_in.text
 
     identity = _identity(db_session, "ada@example.com")
@@ -221,7 +223,7 @@ def test_a_verified_provider_address_lifts_the_local_verification_gate(
     add_member(client, master_key_header, email="ada@example.com")
     stub_exchange(monkeypatch)
 
-    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c"}).status_code == 200
+    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"}).status_code == 200
 
 
 def test_an_address_nobody_put_on_the_roster_is_refused_rather_than_provisioned(
@@ -233,7 +235,7 @@ def test_an_address_nobody_put_on_the_roster_is_refused_rather_than_provisioned(
     # Google account into a self-hosted gateway.
     stub_exchange(monkeypatch, email="stranger@example.com")
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 401
     assert "not registered on this gateway" in response.json()["detail"]
@@ -249,7 +251,7 @@ def test_an_unverified_provider_address_is_refused_even_when_it_is_on_the_roster
     add_member(client, master_key_header, email="ada@example.com")
     stub_exchange(monkeypatch, email_verified=False)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 401
     assert "did not confirm that address is yours" in response.json()["detail"]
@@ -261,7 +263,7 @@ def test_a_provider_that_returns_no_address_at_all_is_refused(
 ) -> None:
     stub_exchange(monkeypatch, email=None)
 
-    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c"}).status_code == 401
+    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"}).status_code == 401
 
 
 def test_a_deactivated_identity_cannot_sign_in_with_a_provider_either(
@@ -282,7 +284,7 @@ def test_a_deactivated_identity_cannot_sign_in_with_a_provider_either(
     db_session.commit()
     stub_exchange(monkeypatch)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 401
     # Collapsed into the unknown-identity refusal rather than saying "switched
@@ -300,7 +302,7 @@ def test_a_differently_cased_provider_address_still_finds_its_roster_row(
     add_member(client, master_key_header, email="ada@example.com")
     stub_exchange(monkeypatch, email="Ada@Example.COM")
 
-    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c"}).status_code == 200
+    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"}).status_code == 200
 
 
 def test_the_callback_refuses_an_unconfigured_provider_before_spending_anything(
@@ -312,7 +314,7 @@ def test_the_callback_refuses_an_unconfigured_provider_before_spending_anything(
     # provider this deployment never configured.
     spent = stub_exchange(monkeypatch)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 503
     assert "oauth_google_client_id" in response.json()["detail"]
@@ -330,13 +332,11 @@ def test_maintenance_mode_freezes_an_oauth_sign_in_before_the_exchange(
     # a Google account. Refused before the exchange, so a frozen deployment
     # spends nobody's single-use authorization code.
     add_member(client, master_key_header, email="ada@example.com")
-    frozen = client.patch(
-        "/v1/settings/maintenance-mode", json={"enabled": True}, headers=master_key_header
-    )
+    frozen = client.patch("/v1/settings/maintenance-mode", json={"enabled": True}, headers=master_key_header)
     assert frozen.status_code == 200, frozen.text
     spent = stub_exchange(monkeypatch)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 503
     assert spent == []
@@ -350,9 +350,9 @@ def test_the_callback_body_carries_the_code_and_nothing_else_the_server_trusts(
     oauth_configured: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # No redirect_uri and no state: the URI is derived from public_base_url so a
-    # browser cannot choose what this server sends to a provider, and the state
-    # is checked in the browser against the value it stored.
+    # No redirect_uri: it is derived from public_base_url, so a browser cannot
+    # choose what this server sends to a provider. (``state`` is a real field
+    # now and is honored; this asserts only that ``redirect_uri`` is not.)
     add_member(client, master_key_header, email="ada@example.com")
     stub_exchange(monkeypatch)
 
@@ -376,7 +376,7 @@ def test_an_oversized_code_is_refused_before_any_outbound_call(
 ) -> None:
     spent = stub_exchange(monkeypatch)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "x" * 4096})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "x" * 4096, "state": "s"})
 
     assert response.status_code == 422
     assert spent == []
@@ -403,7 +403,7 @@ def test_a_database_failure_while_staging_the_session_rolls_back_and_says_nothin
 
     monkeypatch.setattr("gateway.api.routes.auth_oauth.create_dashboard_session", _explode)
 
-    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c"})
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "s"})
 
     assert response.status_code == 500
     # The generic wording, not the exception: the error-detail boundary holds on
@@ -413,32 +413,193 @@ def test_a_database_failure_while_staging_the_session_rolls_back_and_says_nothin
     assert SESSION_COOKIE_NAME not in response.cookies
 
 
+# ---------- the state check, with nothing stubbed but the token endpoint ----------
+
+
+def stub_token_endpoint(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
+    """Replace the outbound HTTP only, and return the form each exchange posted.
+
+    Patched at ``_token_request`` rather than at ``exchange_code``, which is the
+    point of these tests: consuming the pending state happens *inside*
+    ``exchange_code``, so stubbing that method removes the very check being
+    asserted on. ``stub_exchange`` above patches even higher, at the route's own
+    reference, so nothing using it can say anything about state at all.
+
+    The returned list holds the form fields sent to the token endpoint, which is
+    where ``code_verifier`` shows up.
+    """
+    posted: list[dict[str, str]] = []
+
+    async def _token_request(self: Any, data: dict[str, str]) -> dict[str, Any]:
+        posted.append(data)
+        return {"access_token": "an-access-token", "token_type": "Bearer"}
+
+    async def _fetch_identity(self: Any, _tokens: Any) -> Any:
+        return SimpleNamespace(email="ada@example.com", name="Ada Lovelace", email_verified=True)
+
+    monkeypatch.setattr(OAuthClient, "_token_request", _token_request)
+    monkeypatch.setattr(OAuthClient, "fetch_identity", _fetch_identity)
+    return posted
+
+
+def test_a_code_with_no_authorize_behind_it_is_refused(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The finding this table exists for: a leaked code, spent by whoever holds it.
+
+    Before the pending-state row, the callback exchanged any well-formed code it
+    was handed, so anybody who obtained a victim's unspent code could post it
+    here and be handed the victim's session. There is nothing to bind it to
+    unless the deployment kept a record of the flow it started.
+    """
+    add_member(client, master_key_header, email="ada@example.com")
+    posted = stub_token_endpoint(monkeypatch)
+
+    response = client.post(
+        "/v1/auth/oauth/google/callback",
+        json={"code": "a-leaked-code", "state": "never-minted-here"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert SESSION_COOKIE_NAME not in response.cookies
+    # Refused before the code went anywhere: no token request, and a code that
+    # is still the victim's to spend.
+    assert posted == []
+
+
+def test_a_state_is_single_use(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    add_member(client, master_key_header, email="ada@example.com")
+    stub_token_endpoint(monkeypatch)
+    state = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+
+    first = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    replayed = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+
+    assert first.status_code == 200, first.text
+    # The row was deleted as it was claimed, so the replay matches nothing.
+    assert replayed.status_code == 400
+
+
+def test_a_state_minted_for_one_provider_does_not_answer_the_other(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    add_member(client, master_key_header, email="ada@example.com")
+    stub_token_endpoint(monkeypatch)
+    state = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+
+    response = client.post("/v1/auth/oauth/github/callback", json={"code": "c", "state": state})
+
+    assert response.status_code == 400
+
+
+def test_the_exchange_sends_the_verifier_the_authorize_call_minted(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PKCE end to end: the challenge on the consent URL answers to the verifier sent here."""
+    add_member(client, master_key_header, email="ada@example.com")
+    posted = stub_token_endpoint(monkeypatch)
+    started = client.get("/v1/auth/oauth/google/authorize").json()
+    query = parse_qs(urlsplit(started["authorization_url"]).query)
+
+    response = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": started["state"]})
+
+    assert response.status_code == 200, response.text
+    (form,) = posted
+    verifier = form["code_verifier"]
+    assert verifier
+    # The challenge the provider was given is the SHA-256 of what the exchange
+    # sent, which is what makes a code useless to anyone who did not start this.
+    expected = urlsafe_b64encode(sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    assert query["code_challenge"] == [expected]
+    assert query["code_challenge_method"] == ["S256"]
+
+
+def test_a_refused_exchange_leaves_the_state_spendable_for_the_retry(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The claim is staged on the request's transaction, so a rollback restores it.
+
+    Same rule ``webauthn_service.consume_challenge`` documents: only a flow that
+    completes retires a nonce. The code is spent at the provider either way, so
+    what survives is a state the person's own retry can use, not a replayable
+    one.
+    """
+    add_member(client, master_key_header, email="ada@example.com")
+    state = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+
+    async def _boom(self: Any, _data: dict[str, str]) -> Any:
+        raise RuntimeError("the provider was unreachable")
+
+    monkeypatch.setattr(OAuthClient, "_token_request", _boom)
+    failed = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+
+    assert failed.status_code == 400
+    stub_token_endpoint(monkeypatch)
+    retried = client.post("/v1/auth/oauth/google/callback", json={"code": "c2", "state": state})
+
+    assert retried.status_code == 200, retried.text
+
+
+def test_the_refusal_does_not_say_which_way_the_state_was_wrong(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Never minted and already spent answer identically: telling them apart
+    # tells an attacker their guess was in the right shape.
+    #
+    # The sign-in that spends the state has to succeed, which is why this puts
+    # an address on the roster first: a refused identity rolls the whole
+    # transaction back, and the state it claimed with it.
+    add_member(client, master_key_header, email="ada@example.com")
+    stub_token_endpoint(monkeypatch)
+    state = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+    signed_in = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    assert signed_in.status_code == 200, signed_in.text
+
+    spent = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    unknown = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "nope"})
+
+    assert spent.status_code == unknown.status_code
+    assert spent.json()["detail"] == unknown.json()["detail"]
+
+
 # ---------- the redirect a provider actually lands on ----------
 
 
 @pytest.mark.parametrize("provider", ["google", "github"])
-def test_the_provider_redirect_path_bounces_into_the_dashboard_hash_route(
-    client: TestClient, provider: str
-) -> None:
+def test_the_provider_redirect_path_bounces_into_the_dashboard_hash_route(client: TestClient, provider: str) -> None:
     # A redirect URI may not carry a fragment, so the provider is pointed at an
     # ordinary path and this is what turns it into the hash route the dashboard
     # renders ahead of its auth gate.
-    response = client.get(
-        f"/auth/{provider}/callback?code=the-code&state=the-state", follow_redirects=False
-    )
+    response = client.get(f"/auth/{provider}/callback?code=the-code&state=the-state", follow_redirects=False)
 
     assert response.status_code == 303
-    assert response.headers["location"] == (
-        f"/#/auth/{provider}/callback?code=the-code&state=the-state"
-    )
+    assert response.headers["location"] == (f"/#/auth/{provider}/callback?code=the-code&state=the-state")
 
 
 def test_the_provider_redirect_path_carries_an_error_query_through_too(
     client: TestClient,
 ) -> None:
-    response = client.get(
-        "/auth/google/callback?error=access_denied&state=s", follow_redirects=False
-    )
+    response = client.get("/auth/google/callback?error=access_denied&state=s", follow_redirects=False)
 
     assert response.status_code == 303
     assert response.headers["location"] == "/#/auth/google/callback?error=access_denied&state=s"

--- a/tests/integration/test_oauth_api.py
+++ b/tests/integration/test_oauth_api.py
@@ -501,6 +501,10 @@ def test_a_state_minted_for_one_provider_does_not_answer_the_other(
     response = client.post("/v1/auth/oauth/github/callback", json={"code": "c", "state": state})
 
     assert response.status_code == 400
+    # The refusal rolled the claim back with the rest of the request, so the
+    # callback the state was minted for still has a flow to finish.
+    finished = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    assert finished.status_code == 200, finished.text
 
 
 def test_the_exchange_sends_the_verifier_the_authorize_call_minted(

--- a/tests/integration/test_oauth_api.py
+++ b/tests/integration/test_oauth_api.py
@@ -28,7 +28,7 @@ from gateway.core.config import GatewayConfig
 from gateway.models.tenancy import User
 from gateway.services import oauth_service
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME
-from gateway.services.oauth_service import OAuthIdentity
+from gateway.services.oauth_service import FLOW_COOKIE_NAME, OAuthIdentity
 
 ORIGIN = "http://testserver"
 PASSWORD = "a-real-password"  # pragma: allowlist secret
@@ -58,7 +58,9 @@ def stub_exchange(
     """
     spent: list[str] = []
 
-    async def _exchange(_config: GatewayConfig, provider: str, *, code: str, state: str, db: Any) -> OAuthIdentity:
+    async def _exchange(
+        _config: GatewayConfig, provider: str, *, code: str, state: str, flow_secret: str | None, db: Any
+    ) -> OAuthIdentity:
         spent.append(code)
         return OAuthIdentity(
             provider=provider,
@@ -561,6 +563,73 @@ def test_a_refused_exchange_leaves_the_state_spendable_for_the_retry(
     assert retried.status_code == 200, retried.text
 
 
+def test_authorize_sets_the_flow_cookie_the_callback_requires(
+    client: TestClient,
+    oauth_configured: None,
+) -> None:
+    started = client.get("/v1/auth/oauth/google/authorize")
+
+    assert started.status_code == 200, started.text
+    cookie = started.headers["set-cookie"]
+    assert cookie.startswith(f"{FLOW_COOKIE_NAME}=")
+    assert "HttpOnly" in cookie
+    assert "Path=/v1/auth/oauth" in cookie
+    assert "samesite=lax" in cookie.lower()
+
+
+def test_a_callback_from_a_browser_that_did_not_start_the_flow_is_refused(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reviewer's vector: the redirect URL, code and state both, read out of a log.
+
+    Holding the whole redirect query is not enough, because the flow cookie
+    never left the browser that called ``/authorize``. Without it the callback
+    is refused before any outbound call; with a different browser's cookie it is
+    refused too.
+    """
+    add_member(client, master_key_header, email="ada@example.com")
+    posted = stub_token_endpoint(monkeypatch)
+    state = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+    victims_cookie = client.cookies[FLOW_COOKIE_NAME]
+
+    client.cookies.clear()
+    without = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    assert without.status_code == 400, without.text
+    assert posted == []
+
+    client.get("/v1/auth/oauth/google/authorize")  # a different browser's own cookie
+    assert client.cookies[FLOW_COOKIE_NAME] != victims_cookie
+    other = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    assert other.status_code == 400, other.text
+    assert posted == []
+
+    # The refusals rolled the claim back, so the browser that started it can still finish.
+    client.cookies.set(FLOW_COOKIE_NAME, victims_cookie)
+    finished = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
+    assert finished.status_code == 200, finished.text
+
+
+def test_two_tabs_in_one_browser_share_the_cookie_and_both_finish(
+    client: TestClient,
+    oauth_configured: None,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    add_member(client, master_key_header, email="ada@example.com")
+    stub_token_endpoint(monkeypatch)
+    first = client.get("/v1/auth/oauth/google/authorize").json()["state"]
+    cookie = client.cookies[FLOW_COOKIE_NAME]
+    second = client.get("/v1/auth/oauth/github/authorize").json()["state"]
+
+    # The second call reused the cookie instead of rotating it out from under the first tab.
+    assert client.cookies[FLOW_COOKIE_NAME] == cookie
+    assert client.post("/v1/auth/oauth/google/callback", json={"code": "c1", "state": first}).status_code == 200
+    assert client.post("/v1/auth/oauth/github/callback", json={"code": "c2", "state": second}).status_code == 200
+
+
 def test_the_refusal_does_not_say_which_way_the_state_was_wrong(
     client: TestClient,
     oauth_configured: None,
@@ -581,9 +650,11 @@ def test_the_refusal_does_not_say_which_way_the_state_was_wrong(
 
     spent = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
     unknown = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": "nope"})
+    client.cookies.clear()
+    no_cookie = client.post("/v1/auth/oauth/google/callback", json={"code": "c", "state": state})
 
-    assert spent.status_code == unknown.status_code
-    assert spent.json()["detail"] == unknown.json()["detail"]
+    assert spent.status_code == unknown.status_code == no_cookie.status_code
+    assert spent.json()["detail"] == unknown.json()["detail"] == no_cookie.json()["detail"]
 
 
 # ---------- the redirect a provider actually lands on ----------

--- a/tests/integration/test_oauth_live_provider.py
+++ b/tests/integration/test_oauth_live_provider.py
@@ -9,8 +9,15 @@ This module is that check, and it is the gate for turning a provider on.
 
 Skipped unless ``OTARI_OAUTH_LIVE_TESTS=1`` and the provider's variables are
 set, because an authorization code is single-use and only a person completing a
-consent screen can produce one. Nothing here touches a database, so it needs no
-PostgreSQL either.
+consent screen can produce one.
+
+**It runs against the gateway's own database**, which the rest of this module's
+history did not. The exchange now sends a PKCE ``code_verifier``, and the only
+copy of it is the ``oauth_pending_state`` row the ``/authorize`` call wrote, so
+the test has to read the row the running gateway left rather than mint anything
+of its own. That is also what makes it a real check: a verifier this test
+invented would prove the provider accepts *a* verifier, not the one this
+deployment would have sent.
 
 To run it for Google::
 
@@ -20,15 +27,20 @@ To run it for Google::
     #      OTARI_PUBLIC_BASE_URL=http://localhost:8000
     #      OTARI_OAUTH_GOOGLE_CLIENT_ID=...
     #      OTARI_OAUTH_GOOGLE_CLIENT_SECRET=...
+    #      OTARI_DATABASE_URL=...   (the same one this test will read)
     # 2. Open the URL that GET /v1/auth/oauth/google/authorize returns and
     #    complete the consent screen. The browser lands on
-    #    /#/auth/google/callback?code=...; copy that code out of the address bar.
-    # 3. Run immediately, since the code expires in minutes and is single-use.
+    #    /#/auth/google/callback?code=...&state=...; copy both out of the
+    #    address bar. The state is what finds the verifier.
+    # 3. Run immediately, since the code expires in minutes and is single-use,
+    #    and the pending state expires in ten.
     OTARI_OAUTH_LIVE_TESTS=1 \\
     OTARI_PUBLIC_BASE_URL=http://localhost:8000 \\
+    OTARI_DATABASE_URL=... \\
     OTARI_OAUTH_GOOGLE_CLIENT_ID=... \\
     OTARI_OAUTH_GOOGLE_CLIENT_SECRET=... \\
     OTARI_OAUTH_LIVE_GOOGLE_CODE='4/0Ax...' \\
+    OTARI_OAUTH_LIVE_GOOGLE_STATE='...' \\
     uv run pytest tests/integration/test_oauth_live_provider.py -k google -v
 
 GitHub is the same with ``GITHUB`` in place of ``GOOGLE``. The redirect URI is
@@ -43,6 +55,7 @@ import os
 import pytest
 
 from gateway.core.config import GatewayConfig
+from gateway.core.database import create_session, init_db
 from gateway.services import oauth_service
 
 pytestmark = pytest.mark.skipif(
@@ -57,6 +70,18 @@ def _live_code(provider: str) -> str:
     if not code:
         pytest.skip(f"OTARI_OAUTH_LIVE_{provider.upper()}_CODE is required")
     return code
+
+
+def _live_state(provider: str) -> str:
+    """The ``state`` the provider redirected back with, or skip.
+
+    It is the key to the pending row holding the PKCE verifier, so without it
+    there is nothing to exchange with even though the code itself is valid.
+    """
+    state = os.environ.get(f"OTARI_OAUTH_LIVE_{provider.upper()}_STATE", "")
+    if not state:
+        pytest.skip(f"OTARI_OAUTH_LIVE_{provider.upper()}_STATE is required")
+    return state
 
 
 def _live_config(provider: str) -> GatewayConfig:
@@ -84,8 +109,16 @@ async def test_a_real_authorization_code_exchanges_for_an_identity(provider: str
     """
     config = _live_config(provider)
     code = _live_code(provider)
+    state = _live_state(provider)
 
-    identity = await oauth_service.exchange_code(config, provider, code=code)
+    init_db(config)
+    async with create_session() as db:
+        identity = await oauth_service.exchange_code(
+            config, provider, code=code, state=state, db=db
+        )
+        # Committed, because the state was consumed for real: leaving it
+        # spendable would contradict what this module is checking.
+        await db.commit()
 
     assert identity.provider == provider
     assert identity.email, "the provider returned no address, so nothing here could sign in"

--- a/tests/integration/test_oauth_live_provider.py
+++ b/tests/integration/test_oauth_live_provider.py
@@ -28,10 +28,12 @@ To run it for Google::
     #      OTARI_OAUTH_GOOGLE_CLIENT_ID=...
     #      OTARI_OAUTH_GOOGLE_CLIENT_SECRET=...
     #      OTARI_DATABASE_URL=...   (the same one this test will read)
-    # 2. Open the URL that GET /v1/auth/oauth/google/authorize returns and
+    # 2. Call GET /v1/auth/oauth/google/authorize with curl -c so the flow
+    #    cookie (otari_oauth_flow) it sets is kept, open the URL it returns and
     #    complete the consent screen. The browser lands on
     #    /#/auth/google/callback?code=...&state=...; copy both out of the
-    #    address bar. The state is what finds the verifier.
+    #    address bar, and the cookie value out of the jar. The state finds the
+    #    verifier; the cookie is what the row is bound to.
     # 3. Run immediately, since the code expires in minutes and is single-use,
     #    and the pending state expires in ten.
     OTARI_OAUTH_LIVE_TESTS=1 \\
@@ -41,6 +43,7 @@ To run it for Google::
     OTARI_OAUTH_GOOGLE_CLIENT_SECRET=... \\
     OTARI_OAUTH_LIVE_GOOGLE_CODE='4/0Ax...' \\
     OTARI_OAUTH_LIVE_GOOGLE_STATE='...' \\
+    OTARI_OAUTH_LIVE_GOOGLE_FLOW_SECRET='...' \\
     uv run pytest tests/integration/test_oauth_live_provider.py -k google -v
 
 GitHub is the same with ``GITHUB`` in place of ``GOOGLE``. The redirect URI is
@@ -84,6 +87,14 @@ def _live_state(provider: str) -> str:
     return state
 
 
+def _live_flow_secret(provider: str) -> str:
+    """The flow cookie ``/authorize`` set, or skip: the row answers to nothing else."""
+    secret = os.environ.get(f"OTARI_OAUTH_LIVE_{provider.upper()}_FLOW_SECRET", "")
+    if not secret:
+        pytest.skip(f"OTARI_OAUTH_LIVE_{provider.upper()}_FLOW_SECRET is required")
+    return secret
+
+
 def _live_config(provider: str) -> GatewayConfig:
     """The deployment's own configuration, or skip if it does not offer ``provider``."""
     config = GatewayConfig()
@@ -110,11 +121,12 @@ async def test_a_real_authorization_code_exchanges_for_an_identity(provider: str
     config = _live_config(provider)
     code = _live_code(provider)
     state = _live_state(provider)
+    flow_secret = _live_flow_secret(provider)
 
     init_db(config)
     async with create_session() as db:
         identity = await oauth_service.exchange_code(
-            config, provider, code=code, state=state, db=db
+            config, provider, code=code, state=state, flow_secret=flow_secret, db=db
         )
         # Committed, because the state was consumed for real: leaving it
         # spendable would contradict what this module is checking.

--- a/tests/unit/test_oauth_service.py
+++ b/tests/unit/test_oauth_service.py
@@ -33,7 +33,7 @@ class FakeSession:
     """Enough ``AsyncSession`` for the state store to stage a row against.
 
     The store's two statements are exercised for real against PostgreSQL in
-    ``tests/integration/test_oauth_state.py``; what these tests need is a
+    ``tests/integration/test_oauth_api.py``; what these tests need is a
     session that accepts them, so that building an authorization URL can be
     asserted on without a database.
     """

--- a/tests/unit/test_oauth_service.py
+++ b/tests/unit/test_oauth_service.py
@@ -3,8 +3,9 @@
 Covers what this deployment owns, which is what ``services/oauth_service.py``
 kept when the protocol mechanics moved onto apron-auth: which providers are
 configured, which scopes are asked for, where the provider is told to send the
-browser back to, and the two carry-overs that must survive the port (PKCE stays
-off, and a tri-state ``email_verified`` collapses on the unverified side).
+browser back to, the PKCE and ``state`` binding the flow rests on, and the
+carry-over that must survive the port (a tri-state ``email_verified`` collapses
+on the unverified side).
 
 The live exchange itself is not here and cannot be: a green suite that stubs
 apron-auth proves wiring and never that the request shape it sends is one a
@@ -26,6 +27,33 @@ from gateway.core.config import OAUTH_PROVIDERS, GatewayConfig
 from gateway.log_config import logger as gateway_logger
 from gateway.services import oauth_service
 from gateway.services.tenancy.errors import OAuthExchangeError, OAuthNotConfiguredError
+
+
+class FakeSession:
+    """Enough ``AsyncSession`` for the state store to stage a row against.
+
+    The store's two statements are exercised for real against PostgreSQL in
+    ``tests/integration/test_oauth_state.py``; what these tests need is a
+    session that accepts them, so that building an authorization URL can be
+    asserted on without a database.
+    """
+
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(first=lambda: None)
+
+    def add(self, instance: Any) -> None:
+        self.added.append(instance)
+
+    async def flush(self) -> None:
+        return None
+
+
+async def authorize(config: GatewayConfig, provider: str) -> tuple[str, str]:
+    """``authorization_url`` over a throwaway session, for the URL assertions."""
+    return await oauth_service.authorization_url(config, provider, db=FakeSession())  # type: ignore[arg-type]
 
 
 def configured(**overrides: Any) -> GatewayConfig:
@@ -127,9 +155,7 @@ class TestHalfConfiguredOAuthIsAnnounced:
 
         assert "oauth_github_client_secret" in caplog.text
 
-    def test_a_deployment_that_configured_nothing_says_nothing(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_a_deployment_that_configured_nothing_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
         # The ordinary state, not a mistake: warning here would put a line in
         # every default deployment's startup log.
         with caplog.at_level(logging.WARNING, logger="gateway"):
@@ -137,9 +163,7 @@ class TestHalfConfiguredOAuthIsAnnounced:
 
         assert caplog.text == ""
 
-    def test_a_fully_configured_deployment_says_nothing(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_a_fully_configured_deployment_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level(logging.WARNING, logger="gateway"):
             configured().warn_about_half_configured_oauth()
 
@@ -157,14 +181,8 @@ class TestRedirectUri:
         assert "#" not in uri
 
     def test_names_the_provider_so_two_clients_do_not_share_one_uri(self) -> None:
-        assert (
-            oauth_service.redirect_uri(configured(), "google")
-            == "https://otari.example.com/auth/google/callback"
-        )
-        assert (
-            oauth_service.redirect_uri(configured(), "github")
-            == "https://otari.example.com/auth/github/callback"
-        )
+        assert oauth_service.redirect_uri(configured(), "google") == "https://otari.example.com/auth/google/callback"
+        assert oauth_service.redirect_uri(configured(), "github") == "https://otari.example.com/auth/github/callback"
 
     def test_a_path_prefix_on_the_base_url_is_kept(self) -> None:
         # A gateway served under a prefix is a supported shape (``Mailer.link``
@@ -172,10 +190,7 @@ class TestRedirectUri:
         # the callback to the wrong path on the right origin.
         config = configured(public_base_url="https://example.com/otari")
 
-        assert (
-            oauth_service.redirect_uri(config, "google")
-            == "https://example.com/otari/auth/google/callback"
-        )
+        assert oauth_service.redirect_uri(config, "google") == "https://example.com/otari/auth/google/callback"
         assert oauth_service.callback_landing_target(config, "google", "code=x") == (
             "https://example.com/otari/#/auth/google/callback?code=x"
         )
@@ -190,15 +205,13 @@ class TestRedirectUri:
     def test_a_trailing_slash_on_the_base_url_does_not_double_up(self) -> None:
         config = configured(public_base_url="https://otari.example.com/")
 
-        assert (
-            oauth_service.redirect_uri(config, "google")
-            == "https://otari.example.com/auth/google/callback"
-        )
+        assert oauth_service.redirect_uri(config, "google") == "https://otari.example.com/auth/google/callback"
 
 
 class TestAuthorizationUrl:
-    def test_google_asks_for_the_scopes_its_identity_handler_reads_back(self) -> None:
-        url = oauth_service.authorization_url(configured(), "google", state="s")
+    @pytest.mark.asyncio
+    async def test_google_asks_for_the_scopes_its_identity_handler_reads_back(self) -> None:
+        url, state = await authorize(configured(), "google")
         query = parse_qs(urlsplit(url).query)
 
         assert urlsplit(url).netloc == "accounts.google.com"
@@ -206,26 +219,42 @@ class TestAuthorizationUrl:
         assert query["response_type"] == ["code"]
         assert query["client_id"] == ["google-id"]
         assert query["redirect_uri"] == ["https://otari.example.com/auth/google/callback"]
-        assert query["state"] == ["s"]
+        assert query["state"] == [state]
 
-    def test_github_asks_for_the_scopes_its_identity_handler_reads_back(self) -> None:
+    @pytest.mark.asyncio
+    async def test_github_asks_for_the_scopes_its_identity_handler_reads_back(self) -> None:
         # /user plus /user/emails, which is what makes a verified address
         # available at callback time.
-        url = oauth_service.authorization_url(configured(), "github", state="s")
+        url, _ = await authorize(configured(), "github")
         query = parse_qs(urlsplit(url).query)
 
         assert urlsplit(url).netloc == "github.com"
         assert query["scope"] == ["read:user user:email"]
         assert query["client_id"] == ["github-id"]
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
-    def test_no_offline_access_is_requested(self, provider: str) -> None:
+    async def test_the_preset_does_not_widen_the_scopes(self, provider: str) -> None:
+        # Each preset merges its own BASE_SCOPES over what it is given, which
+        # for Google adds the long-form userinfo.email next to the `email`
+        # already asked for. It grants nothing new and names a scope this
+        # gateway did not choose on the consent screen, so `_as_configured_here`
+        # pins the set. Nothing read this field while the URL was hand-built.
+        url, _ = await authorize(configured(), provider)
+        query = parse_qs(urlsplit(url).query)
+
+        assert query["scope"] == [" ".join(oauth_service._PROVIDERS[provider].scopes)]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
+    async def test_no_offline_access_is_requested(self, provider: str) -> None:
         # Offline access exists to obtain a refresh token and nothing here
         # stores one, so asking would have Google mint a durable credential
         # this deployment discards and nobody revokes. A deliberate departure
         # from both the platform's URL and apron-auth's own preset, which set
         # access_type=offline (and the preset prompt=consent too).
-        query = parse_qs(urlsplit(oauth_service.authorization_url(configured(), provider, state="s")).query)
+        url, _ = await authorize(configured(), provider)
+        query = parse_qs(urlsplit(url).query)
 
         assert "access_type" not in query
         assert "prompt" not in query
@@ -243,46 +272,67 @@ class TestAuthorizationUrl:
 
         assert provider_config.extra_params.get("access_type") == "offline"
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
-    def test_no_code_challenge_is_sent(self, provider: str) -> None:
-        # PKCE is deliberately off: authorize and callback are independent
-        # requests with no store between them, so a verifier minted here would
-        # have nowhere to live until the exchange. A challenge this flow cannot
-        # answer would break every sign-in.
-        query = parse_qs(urlsplit(oauth_service.authorization_url(configured(), provider, state="s")).query)
+    async def test_a_code_challenge_is_sent(self, provider: str) -> None:
+        # The whole point of the pending-state row: a verifier minted here now
+        # has somewhere to live until the exchange, so the authorization request
+        # can be bound to it. Without this an authorization code is spendable by
+        # whoever holds it, which is what shipped in otari#765.
+        url, _ = await authorize(configured(), provider)
+        query = parse_qs(urlsplit(url).query)
 
-        assert "code_challenge" not in query
-        assert "code_challenge_method" not in query
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["code_challenge"]
 
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
-    def test_an_unconfigured_provider_refuses_and_names_the_settings(self, provider: str) -> None:
+    async def test_the_verifier_is_staged_and_never_the_challenge(self, provider: str) -> None:
+        # A row that stored the challenge would prove nothing at exchange time:
+        # the challenge is the public half and travels in the URL above.
+        session = FakeSession()
+        url, state = await oauth_service.authorization_url(configured(), provider, db=session)  # type: ignore[arg-type]
+        query = parse_qs(urlsplit(url).query)
+        (row,) = session.added
+
+        assert row.code_verifier is not None
+        assert row.code_verifier not in url
+        assert row.provider == provider
+        # Keyed by the digest, so a reader of the table cannot present the value.
+        assert row.state_hash != state
+        assert query["code_challenge"] != [row.code_verifier]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
+    async def test_an_unconfigured_provider_refuses_and_names_the_settings(self, provider: str) -> None:
         with pytest.raises(OAuthNotConfiguredError) as caught:
-            oauth_service.authorization_url(GatewayConfig(), provider, state="s")
+            await authorize(GatewayConfig(), provider)
 
         assert caught.value.status_code == 503
         assert f"oauth_{provider}_client_id" in caught.value.message
         assert "public_base_url" in caught.value.message
 
-    def test_a_provider_this_build_never_named_is_refused(self) -> None:
+    @pytest.mark.asyncio
+    async def test_a_provider_this_build_never_named_is_refused(self) -> None:
         with pytest.raises(OAuthNotConfiguredError):
-            oauth_service.authorization_url(configured(), "not-a-provider", state="s")
+            await authorize(configured(), "not-a-provider")
 
 
 class TestState:
-    def test_is_unguessable_and_fresh_each_time(self) -> None:
-        values = {oauth_service.new_state() for _ in range(50)}
+    @pytest.mark.asyncio
+    async def test_is_unguessable_and_fresh_each_time(self) -> None:
+        values = {(await authorize(configured(), "google"))[1] for _ in range(50)}
 
         assert len(values) == 50
         assert all(len(value) >= 32 for value in values)
 
 
-class TestPkceStaysOff:
+class TestPkce:
     @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
-    def test_the_preset_would_have_asked_for_pkce(self, provider: str) -> None:
-        # The half of the guard that makes the other half meaningful. If a
-        # preset ever shipped with use_pkce already false, the assertion below
-        # would pass while proving nothing, and a later apron-auth release
-        # flipping the default back would go unnoticed.
+    def test_the_preset_asks_for_it_and_this_flow_leaves_that_alone(self, provider: str) -> None:
+        # apron-auth's own default, which otari#765 cleared and this restores.
+        # Asserted against the preset rather than the URL so a later release
+        # flipping the default cannot pass unnoticed behind a green suite.
         preset = apron_google.preset if provider == "google" else apron_github.preset
         provider_config, _ = preset(
             client_id="id",
@@ -291,21 +341,7 @@ class TestPkceStaysOff:
         )
 
         assert provider_config.use_pkce is True
-
-    @pytest.mark.parametrize("provider", OAUTH_PROVIDERS)
-    def test_this_flow_clears_it(self, provider: str) -> None:
-        # apron-auth reads use_pkce only inside get_authorization_url, which
-        # this module does not call, so clearing it changes nothing today. It is
-        # the guard that keeps adopting that method later from silently starting
-        # to send a challenge this flow cannot answer; see the module docstring.
-        preset = apron_google.preset if provider == "google" else apron_github.preset
-        provider_config, _ = preset(
-            client_id="id",
-            client_secret="secret",  # noqa: S106
-            scopes=["openid"],
-        )
-
-        assert oauth_service._without_pkce(provider_config).use_pkce is False
+        assert oauth_service._as_configured_here(provider_config, provider).use_pkce is True
 
 
 class TestExchange:
@@ -332,12 +368,10 @@ class TestExchange:
         return SimpleNamespace(**(fields | overrides))
 
     @pytest.mark.asyncio
-    async def test_returns_the_identity_the_provider_vouches_for(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_returns_the_identity_the_provider_vouches_for(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._stub_client(monkeypatch, self._profile())
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c")
+        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
 
         assert identity.provider == "google"
         assert identity.email == "member@example.com"
@@ -345,16 +379,14 @@ class TestExchange:
         assert identity.email_verified is True
 
     @pytest.mark.asyncio
-    async def test_an_unasserted_email_verified_collapses_to_unverified(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_an_unasserted_email_verified_collapses_to_unverified(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # apron-auth reports email_verified as tri-state. This edition resolves
         # on a bool, and silence is not an assertion: it must not be laundered
         # into a verified identity. otari-ai#1551 moves resolution onto the
         # tri-state model, once, on the platform.
         self._stub_client(monkeypatch, self._profile(email_verified=None))
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c")
+        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
 
         assert identity.email_verified is False
 
@@ -362,7 +394,7 @@ class TestExchange:
     async def test_an_explicit_false_is_unverified_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._stub_client(monkeypatch, self._profile(email_verified=False))
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c")
+        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
 
         assert identity.email_verified is False
 
@@ -385,7 +417,7 @@ class TestExchange:
         monkeypatch.setattr(oauth_service, "_client", lambda *_a, **_k: _Client())
 
         with pytest.raises(OAuthExchangeError) as caught:
-            await oauth_service.exchange_code(configured(), "google", code="c")
+            await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
 
         assert secret not in caught.value.message
         assert caught.value.message == "Google did not complete the sign-in. Try again."
@@ -393,9 +425,7 @@ class TestExchange:
         assert secret in str(caught.value.__cause__)
 
     @pytest.mark.asyncio
-    async def test_a_failed_identity_fetch_is_the_same_refusal(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_a_failed_identity_fetch_is_the_same_refusal(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class _Client:
             async def exchange_code(self, **_: Any) -> object:
                 return object()
@@ -406,12 +436,24 @@ class TestExchange:
         monkeypatch.setattr(oauth_service, "_client", lambda *_a, **_k: _Client())
 
         with pytest.raises(OAuthExchangeError):
-            await oauth_service.exchange_code(configured(), "github", code="c")
+            await oauth_service.exchange_code(
+                configured(),
+                "github",
+                code="c",
+                state="s",
+                db=FakeSession(),  # type: ignore[arg-type]
+            )
 
     @pytest.mark.asyncio
     async def test_an_unconfigured_provider_refuses_before_any_outbound_call(self) -> None:
         with pytest.raises(OAuthNotConfiguredError):
-            await oauth_service.exchange_code(GatewayConfig(), "google", code="c")
+            await oauth_service.exchange_code(
+                GatewayConfig(),
+                "google",
+                code="c",
+                state="s",
+                db=FakeSession(),  # type: ignore[arg-type]
+            )
 
 
 class TestProviderLabel:

--- a/tests/unit/test_oauth_service.py
+++ b/tests/unit/test_oauth_service.py
@@ -16,17 +16,18 @@ check, behind an opt-in flag.
 import logging
 from collections.abc import Generator
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from apron_auth.providers import github as apron_github
 from apron_auth.providers import google as apron_google
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import OAUTH_PROVIDERS, GatewayConfig
 from gateway.log_config import logger as gateway_logger
 from gateway.services import oauth_service
-from gateway.services.tenancy.errors import OAuthExchangeError, OAuthNotConfiguredError
+from gateway.services.tenancy.errors import OAuthExchangeError, OAuthNotConfiguredError, OAuthStateError
 
 
 class FakeSession:
@@ -51,9 +52,21 @@ class FakeSession:
         return None
 
 
+def fake_db() -> AsyncSession:
+    return cast("AsyncSession", FakeSession())
+
+
+FLOW_SECRET = "a-flow-secret"
+
+
 async def authorize(config: GatewayConfig, provider: str) -> tuple[str, str]:
     """``authorization_url`` over a throwaway session, for the URL assertions."""
-    return await oauth_service.authorization_url(config, provider, db=FakeSession())  # type: ignore[arg-type]
+    return await oauth_service.authorization_url(
+        config,
+        provider,
+        db=fake_db(),
+        flow_secret=FLOW_SECRET,
+    )
 
 
 def configured(**overrides: Any) -> GatewayConfig:
@@ -291,7 +304,12 @@ class TestAuthorizationUrl:
         # A row that stored the challenge would prove nothing at exchange time:
         # the challenge is the public half and travels in the URL above.
         session = FakeSession()
-        url, state = await oauth_service.authorization_url(configured(), provider, db=session)  # type: ignore[arg-type]
+        url, state = await oauth_service.authorization_url(
+            configured(),
+            provider,
+            db=cast("AsyncSession", session),
+            flow_secret=FLOW_SECRET,
+        )
         query = parse_qs(urlsplit(url).query)
         (row,) = session.added
 
@@ -300,6 +318,9 @@ class TestAuthorizationUrl:
         assert row.provider == provider
         # Keyed by the digest, so a reader of the table cannot present the value.
         assert row.state_hash != state
+        # The browser's flow secret is kept the same way.
+        assert row.flow_hash != FLOW_SECRET
+        assert FLOW_SECRET not in url
         assert query["code_challenge"] != [row.code_verifier]
 
     @pytest.mark.asyncio
@@ -316,6 +337,37 @@ class TestAuthorizationUrl:
     async def test_a_provider_this_build_never_named_is_refused(self) -> None:
         with pytest.raises(OAuthNotConfiguredError):
             await authorize(configured(), "not-a-provider")
+
+
+class TestFlowSecret:
+    def test_a_missing_or_foreign_cookie_is_replaced(self) -> None:
+        minted = oauth_service.flow_secret_for(None)
+
+        assert len(minted) == 43
+        assert oauth_service.flow_secret_for("") != ""
+        assert oauth_service.flow_secret_for("not ours") != "not ours"
+        assert oauth_service.flow_secret_for("x" * 43 + "!") != "x" * 43 + "!"
+
+    def test_one_of_ours_is_reused_so_a_second_tab_does_not_break_the_first(self) -> None:
+        existing = oauth_service.flow_secret_for(None)
+
+        assert oauth_service.flow_secret_for(existing) == existing
+
+    @pytest.mark.asyncio
+    async def test_a_callback_without_the_cookie_is_refused_before_the_database(self) -> None:
+        class _NoSession:
+            async def execute(self, *_a: Any, **_k: Any) -> Any:
+                raise AssertionError("the database must not be touched")
+
+        with pytest.raises(OAuthStateError):
+            await oauth_service.exchange_code(
+                configured(),
+                "google",
+                code="c",
+                state="s",
+                flow_secret=None,
+                db=cast("AsyncSession", _NoSession()),
+            )
 
 
 class TestState:
@@ -371,7 +423,9 @@ class TestExchange:
     async def test_returns_the_identity_the_provider_vouches_for(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._stub_client(monkeypatch, self._profile())
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
+        identity = await oauth_service.exchange_code(
+            configured(), "google", code="c", state="s", flow_secret=FLOW_SECRET, db=fake_db()
+        )
 
         assert identity.provider == "google"
         assert identity.email == "member@example.com"
@@ -386,7 +440,9 @@ class TestExchange:
         # tri-state model, once, on the platform.
         self._stub_client(monkeypatch, self._profile(email_verified=None))
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
+        identity = await oauth_service.exchange_code(
+            configured(), "google", code="c", state="s", flow_secret=FLOW_SECRET, db=fake_db()
+        )
 
         assert identity.email_verified is False
 
@@ -394,7 +450,9 @@ class TestExchange:
     async def test_an_explicit_false_is_unverified_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._stub_client(monkeypatch, self._profile(email_verified=False))
 
-        identity = await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
+        identity = await oauth_service.exchange_code(
+            configured(), "google", code="c", state="s", flow_secret=FLOW_SECRET, db=fake_db()
+        )
 
         assert identity.email_verified is False
 
@@ -417,7 +475,9 @@ class TestExchange:
         monkeypatch.setattr(oauth_service, "_client", lambda *_a, **_k: _Client())
 
         with pytest.raises(OAuthExchangeError) as caught:
-            await oauth_service.exchange_code(configured(), "google", code="c", state="s", db=FakeSession())  # type: ignore[arg-type]
+            await oauth_service.exchange_code(
+                configured(), "google", code="c", state="s", flow_secret=FLOW_SECRET, db=fake_db()
+            )
 
         assert secret not in caught.value.message
         assert caught.value.message == "Google did not complete the sign-in. Try again."
@@ -441,7 +501,8 @@ class TestExchange:
                 "github",
                 code="c",
                 state="s",
-                db=FakeSession(),  # type: ignore[arg-type]
+                flow_secret=FLOW_SECRET,
+                db=fake_db(),
             )
 
     @pytest.mark.asyncio
@@ -452,7 +513,8 @@ class TestExchange:
                 "google",
                 code="c",
                 state="s",
-                db=FakeSession(),  # type: ignore[arg-type]
+                flow_secret=FLOW_SECRET,
+                db=fake_db(),
             )
 
 

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -392,9 +392,15 @@ export interface paths {
          * Authorize
          * @description Start an OAuth sign-in: where to send the browser, and the state to keep.
          *
-         *     A GET, and safe: it reads configuration and mints a random value, writing
-         *     nothing. Repeating it simply produces another state, and only the one the
-         *     browser kept is the one it will compare against.
+         *     A GET that writes, which is the one thing to know about it. It records the
+         *     authorization it is about to start (the state's hash, and the PKCE verifier
+         *     the exchange will need) so the callback has something to check against, and
+         *     that record is the whole reason the callback can refuse a code this
+         *     deployment never asked for.
+         *
+         *     Still safe to repeat: each call mints its own state, and only the one the
+         *     browser kept is the one it sends back. The rows the others leave expire on
+         *     their own and are swept by the next call.
          */
         get: operations["authorize_v1_auth_oauth__provider__authorize_get"];
         put?: never;
@@ -4989,7 +4995,7 @@ export interface components {
             authorization_url: string;
             /**
              * State
-             * @description An opaque CSRF value to keep for the length of the redirect and compare against the 'state' the provider returns. It is not stored on this deployment, so a callback whose state does not match the one held by the browser that started the flow must be abandoned by the client rather than sent here.
+             * @description An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it.
              */
             state: string;
         };
@@ -7045,10 +7051,10 @@ export interface components {
          *     exchange are the same string by construction, and a browser cannot choose
          *     what this server sends to a provider.
          *
-         *     No ``state`` either, and that is not an omission. The state is checked in the
-         *     browser, against the value that browser stored when it started the flow;
-         *     sending it here would let this deployment compare a value to itself, which
-         *     proves nothing without somewhere to have kept the original.
+         *     ``state`` is required, and is what binds this callback to an authorization
+         *     request this deployment actually made: it is claimed from
+         *     ``oauth_pending_state`` before the code is sent anywhere, and the row it
+         *     claims is what carries the PKCE verifier the exchange needs.
          */
         OAuthCallbackRequest: {
             /**
@@ -7056,6 +7062,11 @@ export interface components {
              * @description The authorization code from the provider's redirect.
              */
             code: string;
+            /**
+             * State
+             * @description The 'state' from the provider's redirect, as issued by /authorize.
+             */
+            state: string;
         };
         /**
          * OAuthSessionResponse

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -393,14 +393,16 @@ export interface paths {
          * @description Start an OAuth sign-in: where to send the browser, and the state to keep.
          *
          *     A GET that writes, which is the one thing to know about it. It records the
-         *     authorization it is about to start (the state's hash, and the PKCE verifier
-         *     the exchange will need) so the callback has something to check against, and
-         *     that record is the whole reason the callback can refuse a code this
-         *     deployment never asked for.
+         *     authorization it is about to start (the state's hash, the PKCE verifier the
+         *     exchange will need, and the digest of a flow secret it sets as an HttpOnly
+         *     cookie) so the callback has something to check against, and that record is
+         *     the whole reason the callback can refuse a code this deployment never asked
+         *     for, or one presented from a browser other than the one that asked.
          *
          *     Still safe to repeat: each call mints its own state, and only the one the
          *     browser kept is the one it sends back. The rows the others leave expire on
-         *     their own and are swept by the next call.
+         *     their own and are swept by the next call. The cookie is reused when the
+         *     browser already holds one, so a second tab does not break the first.
          */
         get: operations["authorize_v1_auth_oauth__provider__authorize_get"];
         put?: never;
@@ -4995,7 +4997,7 @@ export interface components {
             authorization_url: string;
             /**
              * State
-             * @description An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it.
+             * @description An opaque CSRF value to keep for the length of the redirect, compare against the 'state' the provider returns, and send back with the authorization code. A callback whose state does not match the one held by the browser that started the flow should be abandoned by the client rather than sent here; one that does is checked again against this deployment's own record of it. The response also sets an HttpOnly cookie that the callback requires, so the exchange can only be completed from the browser this call was made from.
              */
             state: string;
         };
@@ -7054,7 +7056,8 @@ export interface components {
          *     ``state`` is required, and is what binds this callback to an authorization
          *     request this deployment actually made: it is claimed from
          *     ``oauth_pending_state`` before the code is sent anywhere, and the row it
-         *     claims is what carries the PKCE verifier the exchange needs.
+         *     claims is what carries the PKCE verifier the exchange needs. The flow
+         *     cookie ``/authorize`` set travels alongside and binds it to the browser.
          */
         OAuthCallbackRequest: {
             /**

--- a/web/src/features/auth/OAuthCallbackPage.test.tsx
+++ b/web/src/features/auth/OAuthCallbackPage.test.tsx
@@ -88,9 +88,13 @@ describe("OAuthCallbackPage", () => {
     expect(await screen.findByText("SIGNED IN")).toBeInTheDocument()
     const [url, init] = fetchMock.mock.calls[0] ?? []
     expect(url).toBe("/v1/auth/oauth/google/callback")
-    // The code alone: the redirect URI is the gateway's own, and the state was
-    // already checked here against the value this tab stored.
-    expect(JSON.parse(String(init?.body))).toEqual({ code: "the-code" })
+    // The code and the state, and no redirect URI: that one is the gateway's
+    // own. The state goes back so the gateway can check it against the pending
+    // authorization it recorded, which is the half this tab cannot do.
+    expect(JSON.parse(String(init?.body))).toEqual({
+      code: "the-code",
+      state: "the-state",
+    })
     await waitFor(() =>
       expect(recordEvent).toHaveBeenCalledWith(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
         authentication_method: "google",

--- a/web/src/features/auth/OAuthCallbackPage.tsx
+++ b/web/src/features/auth/OAuthCallbackPage.tsx
@@ -53,9 +53,12 @@ function takeOAuthState(): string | null {
  *
  * - The provider says the person declined, or it refused. Nothing was proven,
  *   so nothing is sent.
- * - The `state` does not match the one this tab stored. That is the CSRF check,
- *   and the whole reason the value made the round trip; a mismatch means this
- *   redirect did not come from a flow this tab started.
+ * - The `state` does not match the one this tab stored. That is the CSRF check
+ *   this tab can make, and the only one that can tell a callback apart by which
+ *   tab began it; a mismatch means this redirect did not come from a flow this
+ *   tab started. The gateway checks the same value against its own record, so a
+ *   state that never came from an `/authorize` here is refused there even when
+ *   no tab is involved.
  * - There is no code. A callback without one has nothing to spend.
  * - Otherwise the code is posted to the gateway, which exchanges it and sets
  *   the session cookie. On success this signs in exactly the way the password
@@ -138,7 +141,7 @@ export function OAuthCallbackPage({
 
     void (async () => {
       try {
-        const result = await completeOAuthSignIn(provider, code)
+        const result = await completeOAuthSignIn(provider, code, state)
         if (result.ok) {
           recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
             authentication_method: provider,

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -233,8 +233,9 @@ export async function startOAuthSignIn(
 export async function completeOAuthSignIn(
   provider: string,
   code: string,
+  state: string,
 ): Promise<SignInResult> {
-  const payload: OAuthCallbackRequest = { code }
+  const payload: OAuthCallbackRequest = { code, state }
   const finished = await publicPost(
     `/v1/auth/oauth/${encodeURIComponent(provider)}/callback`,
     payload,


### PR DESCRIPTION
## What

The dashboard's Google and GitHub sign-in exchanged any authorization code posted to `POST /v1/auth/oauth/{provider}/callback`. The CSRF `state` was compared only in the browser, against a value in `sessionStorage` that no server ever saw, so the gateway could not tell a callback belonging to a flow it started from a forged or replayed one. No PKCE, and no OIDC nonce.

Reported privately by @pepunfold, who audited it before sending. Thank you.

## Why it was off

#765 cleared PKCE on the grounds that authorize and callback are independent requests with no store between them, so a verifier minted at authorize time had nowhere to live.

That was not accurate:

- apron-auth 0.15.1, the version #765 pinned and the one still installed, ships a `StateStore` protocol, generates the verifier and challenge inside `get_authorization_url`, reads them back in `exchange_code`, and defaults `use_pkce` to `True`. The flag was cleared, not absent.
- #751 had merged `webauthn_challenge` the day before: a single-use row for a value minted in one request and consumed by the next, across workers, with a migration and a docstring explaining why a process dictionary will not do.

The hand-built authorization URL followed from the same premise and was not needed either. `get_authorization_url` only emits a challenge when `use_pkce` is true, which #765 had already cleared.

## What this does

**`oauth_pending_state`**, one row per authorization in flight. Written by `/authorize`, consumed by the callback.

- Keyed by the SHA-256 of the state, not the state. This departs from `webauthn_challenge`, which stores its nonce in the clear: nothing is stored *under* that key, while a row here holds the PKCE `code_verifier`. A reader of this table gets digests; the wire carries the preimage.
- Claimed with one conditional `DELETE ... RETURNING`, the rule `webauthn_service.consume_challenge` documents. A read-then-write cannot provide single use.
- Staged on the request's transaction, so an exchange that fails afterwards rolls the claim back and the person can retry.
- Provider is compared after the row is claimed, so a state minted for Google and returned to GitHub's callback is refused as itself. The refusal keeps the request from committing, so the claim rolls back and the Google callback it was minted for still works.
- Swept on write, on an indexed column. `/authorize` is the only thing that grows the table.
- Bound to the browser, not only to the flow. `/authorize` sets an HttpOnly, SameSite=Lax cookie scoped to `/v1/auth/oauth` carrying a random flow secret; the row keeps its SHA-256; the callback refuses without a matching one, before any outbound call (RFC 9700, section 4.7.1). One secret per browser rather than per flow: a second tab reuses the cookie it finds, so neither tab's callback breaks the other.

**The callback requires `state` and the flow cookie** and refuses before any outbound call when either matches no pending row. Never minted, already spent, expired, wrong-provider and wrong-browser all answer identically.

**Two preset defaults are now pinned explicitly.** While the URL was built by hand neither field was read, so both departures were invisible:

- Scopes are held to the exact set in `_PROVIDERS`. Each preset merges its own `BASE_SCOPES` over what it is given, which for Google adds the long-form `userinfo.email` beside the `email` already asked for.
- Google's `access_type=offline` and `prompt=consent` are cleared. The preset's own `extra_params` argument merges *over* those rather than replacing them, so `model_copy` is the only place to drop them.

**The browser keeps its `sessionStorage` check.** It binds a callback to the tab that started the flow, which the server cannot do. The row binds it to a flow this deployment started, which the browser cannot do.

## Notes for review

- **Both providers verify the challenge.** [GitHub shipped PKCE support in July 2025](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/), a year before #765.
- **`/authorize` now writes**, and it is unauthenticated. Bounded rather than unbounded: `throttle_public_auth` limits per IP, rows expire in 600s, and every save sweeps. Steady state is capped at roughly request rate x TTL. Worth a second opinion.
- **A slow sign-in can now fail.** Ten minutes from consent screen to callback and the state is gone. New failure mode; 600s matches apron-auth's own default.
- **No OIDC nonce.** apron-auth has no support for it, and PKCE covers the same threat for a confidential client. It belongs with #879, which @pepunfold is taking.
- `test_oauth_live_provider.py` now needs the deployment's database and the `state` from the redirect, because the verifier lives in the row `/authorize` wrote. A verifier the test invented would prove the provider accepts *a* verifier, not the one we would have sent.

## Severity

Medium. Before this PR an attacker needed a victim's redirect URL, code and state together, which the access log and browser history both record, and a window in which the victim's browser had not spent it; the `sessionStorage` check blocks the tab from posting whenever the state is not the one it stored, which leaves that window open for the full TTL. The `sessionStorage` check already blocked naive forced-login. Not the account-takeover-of-any-identity the original report framed, and worth saying plainly if we publish an advisory. With the flow cookie, the redirect URL alone no longer completes a sign-in from anywhere but the browser that started it.

Separately: `SECURITY.md` links to `/security/advisories/new` and private advisories are not enabled on this repo, so our stated primary reporting channel 404s. Not fixed here.

## Checks

`make lint`, mypy over 569 files, 42 unit and 32 integration tests, Biome, `pnpm typecheck`, and the web suite. OpenAPI, Postman and `schema.ts` regenerated; `make openapi-check` and `make postman-check` clean.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follows up on #765 and #751. Reported privately by @pepunfold.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added server-side OAuth state validation for Google and GitHub sign-in.
- Added PKCE and browser-bound, HttpOnly flow cookies.
- Rejected missing, expired, replayed, wrong-provider, and wrong-browser callbacks.
- Updated API schemas, frontend callback handling, documentation, and database migrations.
- Added unit and integration tests for the new OAuth flow.

## Benefits

These changes reduce CSRF risk and prevent unauthorized or replayed OAuth callbacks while preserving safe retries after failed exchanges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->