### PR TITLE
feat(config): name the API and OTLP mount roots once

### DIFF
--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -62,6 +62,9 @@ CONVERSATION_HEADER = "Otari-Conversation-Id"
 # pass-through until that partition alone is warm; records from other tasks never
 # influence it. Submit the matching label via the /rank task_id.
 ROUTER_TASK_HEADER = "Otari-Router-Task"
+API_ROOT = "/api/v1"
+# Base only: OTel exporters append /v1/traces and the other signal paths.
+OTLP_ROOT = "/otlp"
 DEFAULT_PLATFORM_BASE_URL = "https://api.otari.ai/api/v1"
 # Where a hybrid gateway's control plane lives for a person, as opposed to
 # DEFAULT_PLATFORM_BASE_URL above, which is where it lives for the gateway. The

--- a/tests/unit/test_api_root.py
+++ b/tests/unit/test_api_root.py
@@ -1,0 +1,19 @@
+"""The API root is one constant, and it has the shape a mount prefix needs."""
+
+from gateway.core.config import API_ROOT, OTLP_ROOT
+
+
+def test_api_root_is_the_documented_value() -> None:
+    assert API_ROOT == "/api/v1"
+
+
+def test_otlp_root_is_a_sibling_not_a_child() -> None:
+    assert OTLP_ROOT == "/otlp"
+    assert not OTLP_ROOT.startswith(API_ROOT)
+
+
+def test_roots_are_valid_fastapi_prefixes() -> None:
+    # FastAPI rejects a prefix that ends with "/" or does not start with one.
+    for root in (API_ROOT, OTLP_ROOT):
+        assert root.startswith("/")
+        assert not root.endswith("/")


### PR DESCRIPTION
## Description

Otari's REST API moves from `/v1/*` to `/api/v1/*`. Health probes move with it. OTLP ingest becomes a sibling namespace at `/otlp/v1/*`.

The prefix is hardcoded in 60 router declarations across 53 files, which is how three conventions drifted apart. It becomes one constant applied once at the mount point, so route files declare only their resource. The dashboard gets the same treatment through an `API_ROOT` in `client.ts`.

`/v1/*` stops being served. There is no compatibility layer.

Base URLs to update:

| Client | Set to |
| --- | --- |
| OpenAI-compatible | `{origin}/api/v1` |
| Anthropic-compatible | `{origin}/api` |
| OTLP exporters | `{origin}/otlp` |

Anthropic SDKs append `/v1/messages` themselves, so their base URL stops one segment earlier.

Two paths deliberately stay at the root: `/auth/{provider}/callback`, which is registered at OAuth providers, and `/metrics`, which is a scrape target.

Usage-log `endpoint` labels keep their current values. They are identifiers rather than URLs, and old rows have to stay comparable with new ones.

**Draft, landing one task at a time.** Opened early so CI runs on each step.

The title tracks what is actually on the branch. It becomes `feat(api)!: mount the API under /api/v1 and OTLP ingest under /otlp` when the move lands, since squash-merge makes it the commit message git-cliff reads.

- [x] Name the API and OTLP mount roots
- [ ] Mount every router through one aggregate
- [ ] Freeze the usage-log endpoint labels
- [ ] Move the API to `/api/v1` and OTLP to `/otlp`
- [ ] `data_plane_url` refuses a base URL carrying the API root
- [ ] Docstrings and comments in `src/`
- [ ] Dashboard
- [ ] Documentation

## PR Type

- [x] New Feature
- [x] Refactor

## Relevant issues

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**

Worked from a written plan, one task per commit, each reviewed before the next.

- [x] I am an AI Agent filling out this form (check box if true)
