### PR TITLE
fix(pipeline): map status-less InvalidRequestError to HTTP 400

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -50,7 +50,7 @@ from typing import Any, Generic, Literal, NamedTuple, NoReturn, Protocol, TypeVa
 from urllib.parse import ParseResult, urlparse
 
 from any_llm import LLMProvider
-from any_llm.exceptions import AnyLLMError, UnsupportedParameterError
+from any_llm.exceptions import AnyLLMError, InvalidRequestError, UnsupportedParameterError
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -495,6 +495,16 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     # provider's SDK has no parameter for.
     if (param := _rejected_param(exc)) is not None:
         return ProviderErrorMapping(status.HTTP_400_BAD_REQUEST, _provider_rejected_param_detail(param))
+    # A status-less InvalidRequestError means the provider (gemini, bedrock,
+    # anthropic) rejected the request shape before assigning an HTTP status.
+    # Mirror the UnsupportedParameterError / NotImplementedError branches: the
+    # exception type is the whole signal, and the provider's own message names
+    # what was wrong.
+    if any(
+        isinstance(candidate, InvalidRequestError) and candidate.status_code is None
+        for candidate in upstream_exception_chain(exc)
+    ):
+        return ProviderErrorMapping(status.HTTP_400_BAD_REQUEST, _caller_fault_detail(exc, PROVIDER_BAD_REQUEST_DETAIL))
     if status_code is None:
         return None
     # Account billing exhaustion, which several providers report as a 400/422

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -16,7 +16,7 @@ import asyncio
 import httpx
 import pytest
 from anthropic import APITimeoutError as AnthropicAPITimeoutError
-from any_llm.exceptions import UnsupportedParameterError
+from any_llm.exceptions import InvalidRequestError, UnsupportedParameterError
 from openai import APITimeoutError as OpenAIAPITimeoutError
 
 from gateway.api.routes._pipeline import (
@@ -619,3 +619,47 @@ def test_failure_status_code_keeps_the_upstream_status_for_billing() -> None:
     of my error rate is an empty wallet" stays answerable even though the caller
     saw a 502."""
     assert failure_status_code(_ParamError(400, None, _ANTHROPIC_BILLING_MSG)) == 400
+
+
+# ---------------------------------------------------------------------------
+# InvalidRequestError with no HTTP status maps to 400 (Fixes #989)
+# ---------------------------------------------------------------------------
+
+
+def test_status_less_invalid_request_error_maps_to_400() -> None:
+    """A bare InvalidRequestError with no HTTP status (as raised by gemini,
+    bedrock, and anthropic for bad request shapes) must map to HTTP 400 with
+    the provider's own explanation, not fall through to the generic 502."""
+    exc = InvalidRequestError("max_tokens exceeds context window for this model")
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.status_code == 400
+    assert "max_tokens" in mapping.detail
+
+
+def test_status_less_invalid_request_error_survives_wrapped_error() -> None:
+    """The InvalidRequestError type check fires when it lives on
+    ``original_exception`` (the ANY_LLM_UNIFIED_EXCEPTIONS=1 shape)."""
+    original = InvalidRequestError("invalid message role: 'system'")
+    wrapped = _WrappedError(500, original)
+    mapping = classify_provider_error(wrapped)
+    assert mapping is not None
+    assert mapping.status_code == 400
+    assert "invalid message role" in mapping.detail
+
+
+def test_status_less_invalid_request_error_is_recorded_as_400() -> None:
+    """failure_status_code records 400 for a status-less InvalidRequestError so
+    the usage log reflects the real classification, not the generic 502."""
+    exc = InvalidRequestError("unknown parameter 'response_format'")
+    assert failure_status_code(exc) == 400
+
+
+def test_invalid_request_error_with_status_is_classified_by_status() -> None:
+    """An InvalidRequestError that already carries an HTTP status must not be
+    rerouted by the type-based branch; the status branch handles it as usual."""
+    exc = InvalidRequestError("bad request shape")
+    exc.status_code = 400
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.status_code == 400


### PR DESCRIPTION
## Description

`classify_provider_error` in `src/gateway/api/routes/_pipeline.py` returned `None` for any exception with no HTTP status. A status-less `any_llm.exceptions.InvalidRequestError` — raised by gemini, bedrock, and anthropic for bad request shapes — therefore fell through to a 502 "LLM provider error". It should instead map to `HTTP_400_BAD_REQUEST` with the provider's own explanation passed through `_caller_fault_detail`.

This PR adds a branch immediately before the `if status_code is None: return None` early exit that checks whether any exception in `upstream_exception_chain(exc)` is an `InvalidRequestError` with `status_code is None`, and maps it to 400. The pattern mirrors `_is_unsupported_feature_error` and the `_rejected_param` branches which handle the same "no HTTP status, but the exception type is the whole signal" shape.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #989

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

**Any additional AI details you'd like to share:**

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Classify status-less `InvalidRequestError` exceptions as HTTP 400 caller errors.
- Preserve provider explanations with existing redaction and length limits.
- Preserve status-based classification when an error already has an HTTP status.
- Add coverage for wrapped errors, status preservation, and usage status reporting.
- Replace opaque provider errors with actionable caller errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->