### PR TITLE
fix(dashboard): stop the create-workspace modal rendering empty

### DIFF
--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -343,6 +343,22 @@ describe("the workspace half of the scope switcher", () => {
     ],
   }
 
+  // The form is shared with the Workspaces page, which frames it in a band.
+  // `.otari-bleed` sizes itself off `<main>`, and this modal is portalled out of
+  // `<main>`, so a band that travelled here measured a viewport wide and the
+  // dialog's `overflow-clip` cropped it to an empty modal (otari-ai#2107). jsdom
+  // computes no layout, so what is pinned is the class that causes it.
+  it("frames the create form without the page's bleeding band", async () => {
+    mockApi({ context: startedInAWorkspace })
+    const user = userEvent.setup()
+    await renderSwitcherOnAPage({})
+
+    const form = await fillCreateForm(user)
+
+    expect(form.querySelector(".otari-bleed")).toBeNull()
+    expect(within(form).getByLabelText(/^Name/)).toBeInTheDocument()
+  })
+
   it("enters the workspace it just created", async () => {
     mockApi({ context: startedInAWorkspace })
     const beat = pendingHold()

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -374,7 +374,11 @@ export function WorkspaceSwitcher({
             size="md"
             className="sm:w-[28rem]"
           >
-            <Modal.Dialog aria-label="Create workspace" className="p-0">
+            {/* The dialog's own padding, because the form inside it is
+                fields only: the page that also renders it supplies a band, and
+                a band cannot come in here (`.otari-bleed` measures `<main>`,
+                which a portalled modal is outside of). */}
+            <Modal.Dialog aria-label="Create workspace" className="p-5">
               <CreateWorkspaceForm
                 onClose={() => setCreating(false)}
                 // Creating from the scope switcher is a request to work in the

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -158,6 +158,23 @@ describe("WorkspacesPage", () => {
     })
   })
 
+  // The form itself carries no band, so that the scope switcher can put it in a
+  // modal (otari-ai#2107). The band belongs to this page, and it is pinned here
+  // because losing it is invisible in jsdom: the fields render either way.
+  it("frames the create form as a band of the page", async () => {
+    mockApi({})
+    const user = userEvent.setup()
+    const { container } = renderPage(<WorkspacesPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create workspace" }),
+    )
+
+    const band = container.querySelector("section.otari-bleed.border-y")
+    expect(band).not.toBeNull()
+    expect(band).toContainElement(screen.getByLabelText("Name"))
+  })
+
   it("puts a refused create on the name that caused it, not in a banner", async () => {
     // A banner above the form resizes whatever frames it, and every way this
     // endpoint refuses is about the name: taken, empty, too long.

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -164,15 +164,17 @@ describe("WorkspacesPage", () => {
   it("frames the create form as a band of the page", async () => {
     mockApi({})
     const user = userEvent.setup()
-    const { container } = renderPage(<WorkspacesPage />)
+    renderPage(<WorkspacesPage />)
 
     await user.click(
       await screen.findByRole("button", { name: "Create workspace" }),
     )
 
-    const band = container.querySelector("section.otari-bleed.border-y")
+    // Reached from the field rather than from the page, because a page is
+    // several bands and only this one frames the form.
+    const band = screen.getByLabelText("Name").closest("section.otari-bleed")
     expect(band).not.toBeNull()
-    expect(band).toContainElement(screen.getByLabelText("Name"))
+    expect(band).toHaveClass("border-y")
   })
 
   it("puts a refused create on the name that caused it, not in a banner", async () => {

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -248,6 +248,11 @@ const defaultHold = () =>
  * design puts "Create workspace" at the foot of that menu), and two forms over
  * one endpoint drift: one of them grows the description field, or the ownership
  * note, and the other does not.
+ *
+ * Fields only: the caller frames it. A band is not portable between the two
+ * callers, because `.otari-bleed` escapes to `100cqw`, which is `<main>`, and
+ * the switcher's modal is portalled out of it: the band came out a viewport
+ * wide there and the dialog clipped it away to an empty modal.
  */
 export function CreateWorkspaceForm({
   onClose,
@@ -328,10 +333,7 @@ export function CreateWorkspaceForm({
   // fails after the workspace already exists.
   const bannerError = createDefault.error ?? (nameRefusal ? null : create.error)
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
-    >
+    <div className="flex flex-col gap-4">
       <h2 className="text-title">Create workspace</h2>
       {/* A refusal about the name is carried by the name, not by a block above
           the form that resizes whatever frames it. What is left here is what
@@ -472,7 +474,7 @@ export function CreateWorkspaceForm({
           Cancel
         </Button>
       </div>
-    </Section>
+    </div>
   )
 }
 
@@ -824,7 +826,9 @@ export function WorkspacesPage() {
       )}
 
       {creating ? (
-        <CreateWorkspaceForm onClose={() => setCreating(false)} />
+        <Section className="border-y border-border py-5">
+          <CreateWorkspaceForm onClose={() => setCreating(false)} />
+        </Section>
       ) : null}
 
       {/* Keyed on the workspace so switching which one is edited remounts the


### PR DESCRIPTION
## Description

Clicking "Create workspace" in the scope switcher opened a blank modal.

`CreateWorkspaceForm` is shared by the Workspaces page and the switcher's modal, and it carried the page's band. `.otari-bleed` widens itself with `100cqw`, which resolves against `<main>`; the modal is portalled out of `<main>`, so the unit fell back to the viewport. The band came out 1512px wide, centered on the 448px dialog, and the dialog's `overflow-clip` cropped away everything except the empty middle of each full-width row. Measured in a browser: dialog at x=532..980, the band at x=0..1512, its `<h2>` at x=16.

The band now belongs to the page, the dialog supplies its own padding, and the form is fields only. This has been broken since the redesign (#934) swapped the form's `Card` for a `Section`; `CreateOrganizationForm` kept its `Card`, which is why the sibling modal still works.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes mozilla-ai/otari-ai#2107

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change: `pnpm --dir web run lint`, `typecheck` and `test` (4004 passed). No Python, no route, no schema.

Two regression tests, both checked by mutation: the switcher one fails without this fix, the page one fails if the band is dropped from the call site. jsdom computes no layout, so what they pin is the class that causes it.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

The geometry was reproduced and the fix confirmed in headless Chromium against the real CSS before either was written.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed the blank create-workspace modal in the scope switcher.
- Moved page-specific framing from `CreateWorkspaceForm` to `WorkspacesPage`.
- Added modal padding and regression tests for both entry points.

This keeps the shared form portable and prevents the dialog from being clipped.

## Validation

- Dashboard checks passed with 4,004 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->