### PR TITLE
fix(dashboard): stop the tenant Overview's Refresh from asking for an absent roster

### DIFF
--- a/web/design/metrics.md
+++ b/web/design/metrics.md
@@ -21,7 +21,7 @@ Is it a part-to-whole with ordered segments?
 ## KpiStrip and KpiCell
 
 ```ts
-KpiStrip: { empty: boolean, children }
+KpiStrip: { empty: boolean, columns?: 4 | 5, children }
 KpiCell: { label: string, value: string, severity?: Severity, subline?: string,
   delta?: ReactNode, graphic?: ReactNode }
 Severity: { status: "ok" | "warn" | "alert", word: string }
@@ -41,10 +41,13 @@ A cell may carry `severity`, `delta` and `subline` at once: the meta line drops 
 subline first, because its facts also live in the breakdown table below while a delta
 lives nowhere else.
 
-**Five cells.** The strip's grid is a fixed 2 / 3 / 5 columns by breakpoint, so four
-cells leave one empty track on a wide viewport and three leave two. Both call sites
-in the product pass five. If a page has fewer than five things worth leading with,
-it does not want this band: put the one number in the `PageIntro` sentence instead.
+**Cell count.** The strip's grid is 2 / 3 / `columns` by breakpoint, and `columns`
+(4 or 5, default 5) is the number of cells the caller passes, not a layout
+preference: a track count that outruns its children leaves a blank column at the end
+of the row. Two of the three call sites in the product pass five; the tenant Overview
+passes four where it withholds its budget cell from a member. If a page has fewer
+than four things worth leading with, it does not want this band: put the one number
+in the `PageIntro` sentence instead.
 
 A cell has four rows and **always four**, in this order:
 

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -1118,6 +1118,30 @@ describe("the tenant Overview's budget signal", () => {
     ).toBe(false)
   })
 
+  it("does not ask for a roster on Refresh when no workspace is selected", async () => {
+    // `refetch` runs a disabled query, and the roster's is disabled precisely
+    // because there is no workspace to name: firing it interpolates the id as
+    // `null`, which `GET /v1/workspaces/{workspace_id}/members` refuses as a
+    // 422, and `members.error` feeds the page's own banner. A caller who
+    // belongs to no workspace is the one this page is for, so Refresh must not
+    // be what tells them the page is broken.
+    const user = userEvent.setup()
+    const requested = mockScopedApi({
+      context: { role: "admin" },
+      period: { cost: 200, request_count: 2000 },
+    })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    await user.click(screen.getByRole("button", { name: /refresh/i }))
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /refresh/i })).toBeEnabled(),
+    )
+
+    expect(requested.some((url) => url.includes("/v1/workspaces/"))).toBe(false)
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
   it("reads a failed ceiling query as unknown, not as zero spend", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input)

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -444,11 +444,14 @@ function OrganizationOverview() {
     void previous.refetch()
     void recent.refetch()
     void keys.refetch()
-    void members.refetch()
-    // Both guarded because `refetch` runs a disabled query: the catalog would be
-    // asked with no workspace to use it, and the ceilings with a role the server
-    // refuses.
-    if (scope !== undefined) void models.refetch()
+    // All three guarded because `refetch` runs a disabled query: the roster
+    // would be asked for a caller who is in no workspace (and its id
+    // interpolates as `null`, which the route refuses), the catalog with no
+    // workspace to use it, and the ceilings with a role the server refuses.
+    if (scope !== undefined) {
+      void members.refetch()
+      void models.refetch()
+    }
     if (managesSpend) void ceilings.refetch()
   }
   const isRefreshing =
@@ -513,9 +516,8 @@ function OrganizationOverview() {
                   ? noCeilingReason
                   : "no data"
             }
-            // `SpendMeter`, not the plain accent `Meter`, and the same
-            // component the Spend page's own rows use, so the two cannot say
-            // different things about one ceiling.
+            // `SpendMeter`, not the plain accent `Meter`: a one-color bar
+            // draws over and under a limit identically.
             graphic={
               ceilings.data && ceilingHealth.worst ? (
                 <SpendMeter


### PR DESCRIPTION
## Description

Three fixes from a cross-review of #986, all inside what it touched.

**The defect.** `refetch` runs a disabled query, so the tenant Overview's Refresh
asked the workspace roster for a caller who has no workspace. The id interpolates as
`null`, the route refuses it as a 422, and `members.error` feeds the page's banner:
clean first paint, then "Unprocessable Entity" on the first press. A member who
belongs to no workspace yet is the caller this page is for. Now behind the `scope`
guard the catalog already had, with a test that fails without it.

**Two false comments.** `design/metrics.md` still specified `KpiStrip` as a fixed
five-track grid with two call sites; it takes `columns` now and has three. And the
budget cell claimed `SpendMeter` is what the Spend page's ceiling rows use, "so the
two cannot say different things about one ceiling": those rows render text.

Not included: the same unguarded call on the operator page, which predates #986 and
is far less reachable there.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #986.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only, so no backend contract moved and no generated artifact changed.
`pnpm --dir web run lint`, `pnpm --dir web run typecheck` and `pnpm --dir web test`
(142 files, 4,003 passing) were run locally. The new test was confirmed red against
the unguarded refetch before the guard went in. `make lint` and the Python suites
are not implicated: no file outside `web/` changed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code, at @njbrake's request.

**Any additional AI details you'd like to share:**

The three findings came out of a two-model cross-review of #986 that finished after
that PR had merged. Each was re-verified against the source before being written up:
the refetch behavior by rendering the real page with an empty
`workspace_memberships` and pressing Refresh, and the two comment claims by grepping
for the call sites they name.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented tenant Overview refreshes from requesting the workspace roster without workspace membership.
- Added a regression test for the unscoped refresh flow.
- Corrected `KpiStrip` and spend ceiling documentation in `design/metrics.md`.

## Benefits

- Prevents invalid workspace requests and the resulting “Unprocessable Entity” banner.
- Keeps design documentation aligned with the current interface and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->