### PR TITLE
refactor(usage): name the endpoint labels so a path sweep cannot reach them

### DIFF
--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -21,6 +21,10 @@ from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["audio"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT_TRANSCRIPTIONS = "/v1/audio/transcriptions"
+USAGE_ENDPOINT_SPEECH = "/v1/audio/speech"
+
 # Maximum upload size for audio files (25 MB, matching OpenAI's limit)
 _MAX_AUDIO_UPLOAD_BYTES = 25 * 1024 * 1024
 
@@ -103,7 +107,7 @@ async def create_transcription(
     # as gpt-4o-transcribe per million tokens, which this per-request convention
     # would misread as a per-million-request rate.
     outcome = await run_passthrough(
-        endpoint="/v1/audio/transcriptions",
+        endpoint=USAGE_ENDPOINT_TRANSCRIPTIONS,
         raw_request=raw_request,
         response=response,
         auth_result=auth_result,
@@ -205,7 +209,7 @@ async def create_speech(
     # tokens, which this per-request convention would misread as a
     # per-million-request rate.
     outcome = await run_passthrough(
-        endpoint="/v1/audio/speech",
+        endpoint=USAGE_ENDPOINT_SPEECH,
         raw_request=raw_request,
         response=None,
         auth_result=auth_result,

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -52,6 +52,10 @@ from gateway.services.workspace_scope import (
 
 router = APIRouter(prefix="/v1/batches", tags=["batches"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/batches"
+USAGE_ENDPOINT_RESULTS = "/v1/batches/results"
+
 # Metadata key stamped on provider batches at creation time so ownership can be
 # checked on retrieve/cancel/results. The gateway stores no batch table, so the
 # provider-side metadata is the ownership anchor.
@@ -455,7 +459,7 @@ async def create_batch(
             api_key_id=api_key_id,
             model=model,
             provider=resolved.instance,
-            endpoint="/v1/batches",
+            endpoint=USAGE_ENDPOINT,
             user_id=user_id,
             error=str(e),
             status_code=failure_status_code(e),
@@ -479,7 +483,7 @@ async def create_batch(
         api_key_id=api_key_id,
         model=model,
         provider=resolved.instance,
-        endpoint="/v1/batches",
+        endpoint=USAGE_ENDPOINT,
         user_id=user_id,
         prompt_tokens=0,
         completion_tokens=0,
@@ -827,7 +831,7 @@ async def retrieve_batch_results(
             api_key_id=api_key_id,
             model=batch_model,
             provider=provider,
-            endpoint="/v1/batches/results",
+            endpoint=USAGE_ENDPOINT_RESULTS,
             user_id=user_id,
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -57,6 +57,10 @@ from gateway.types.attempt import Attempt
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
 
+# The label written to a usage-log row. An identifier, not a URL: it stays as
+# it is so new rows compare with old ones.
+USAGE_ENDPOINT = "/v1/chat/completions"
+
 __all__ = [
     "ChatCompletionRequest",
     "chat_completions",
@@ -151,7 +155,7 @@ class _ChatAdapter:
     """
 
     name = "chat"
-    endpoint = "/v1/chat/completions"
+    endpoint = USAGE_ENDPOINT
     stream_format: StreamFormat = OPENAI_STREAM_FORMAT
     log_success_without_usage = True
 

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -20,6 +20,9 @@ from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/embeddings"
+
 
 class EmbeddingRequest(BaseModel):
     """OpenAI-compatible embedding request."""
@@ -94,7 +97,7 @@ async def create_embedding(
         return await aembedding(**embedding_kwargs)
 
     outcome = await run_passthrough(
-        endpoint="/v1/embeddings",
+        endpoint=USAGE_ENDPOINT,
         raw_request=raw_request,
         response=response,
         auth_result=auth_result,

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -20,6 +20,9 @@ from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["images"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/images/generations"
+
 
 class ImageGenerationRequest(derive_request_base(ImageGenerationParams)):  # type: ignore[misc]
     """OpenAI-compatible image generation request.
@@ -102,7 +105,7 @@ async def create_image(
     # dataset at 5.0, which would bill $5.00 for one image and, because this route
     # reserves its estimate, hold that $5.00 against the budget before the call.
     outcome = await run_passthrough(
-        endpoint="/v1/images/generations",
+        endpoint=USAGE_ENDPOINT,
         raw_request=raw_request,
         response=response,
         auth_result=auth_result,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -74,6 +74,9 @@ from gateway.types.attempt import Attempt
 
 router = APIRouter(prefix="/v1", tags=["messages"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/messages"
+
 
 def _merge_anthropic_betas(body_betas: list[str] | None, raw_request: Request) -> list[str] | None:
     """Combine legacy body betas with Anthropic's standard beta header."""
@@ -404,7 +407,7 @@ class _MessagesAdapter:
     """
 
     name = "messages"
-    endpoint = "/v1/messages"
+    endpoint = USAGE_ENDPOINT
     stream_format: StreamFormat = ANTHROPIC_STREAM_FORMAT
     # A successful non-streaming call without provider usage data skips the
     # usage-log row (only the reservation is settled), matching the wire

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -22,6 +22,9 @@ UNSUPPORTED_MODERATION_SUBSTRING = "does not support moderation"
 
 router = APIRouter(prefix="/v1", tags=["moderations"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/moderations"
+
 
 class ModerationRequest(BaseModel):
     """OpenAI-compatible moderation request."""
@@ -92,7 +95,7 @@ async def create_moderation(
         return await amoderation(**moderation_kwargs)
 
     outcome = await run_passthrough(
-        endpoint="/v1/moderations",
+        endpoint=USAGE_ENDPOINT,
         raw_request=raw_request,
         response=response,
         auth_result=auth_result,

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -20,6 +20,9 @@ from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["rerank"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/rerank"
+
 
 class RerankRequest(BaseModel):
     """Rerank request."""
@@ -94,7 +97,7 @@ async def create_rerank(
     # carry ``model``, which would echo the target an alias exists to hide. The
     # relabeling is a no-op on results without the field.
     outcome = await run_passthrough(
-        endpoint="/v1/rerank",
+        endpoint=USAGE_ENDPOINT,
         raw_request=raw_request,
         response=response,
         auth_result=auth_result,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -57,6 +57,9 @@ from gateway.types.attempt import Attempt
 
 router = APIRouter(prefix="/v1", tags=["responses"])
 
+# See chat.USAGE_ENDPOINT.
+USAGE_ENDPOINT = "/v1/responses"
+
 _MASTER_KEY_USER_REQUIRED = "When using master key, 'user' field is required in request body"
 _USER_FORBIDDEN = "'user' field does not match the authenticated API key's user"
 _CODEX_CLIENT_METADATA_FIELD = "client_metadata"
@@ -254,7 +257,7 @@ class _ResponsesAdapter:
     """
 
     name = "responses"
-    endpoint = "/v1/responses"
+    endpoint = USAGE_ENDPOINT
     stream_format: StreamFormat = RESPONSES_STREAM_FORMAT
     log_success_without_usage = True
 

--- a/tests/unit/test_usage_endpoint_labels.py
+++ b/tests/unit/test_usage_endpoint_labels.py
@@ -1,0 +1,33 @@
+"""The endpoint label on a usage-log row is an identifier, not a URL.
+
+These values are written to the database and grouped, filtered and
+displayed by string equality. They were copied from route paths when the
+routes lived at /v1 and they stay as they are: rewriting them would make new
+rows incomparable with old ones. The routes moved; the labels did not.
+"""
+
+from gateway.api.routes import (
+    audio,
+    batches,
+    chat,
+    embeddings,
+    images,
+    messages,
+    moderations,
+    rerank,
+    responses,
+)
+
+
+def test_labels_keep_their_historical_values() -> None:
+    assert chat.USAGE_ENDPOINT == "/v1/chat/completions"
+    assert messages.USAGE_ENDPOINT == "/v1/messages"
+    assert responses.USAGE_ENDPOINT == "/v1/responses"
+    assert embeddings.USAGE_ENDPOINT == "/v1/embeddings"
+    assert audio.USAGE_ENDPOINT_TRANSCRIPTIONS == "/v1/audio/transcriptions"
+    assert audio.USAGE_ENDPOINT_SPEECH == "/v1/audio/speech"
+    assert rerank.USAGE_ENDPOINT == "/v1/rerank"
+    assert moderations.USAGE_ENDPOINT == "/v1/moderations"
+    assert images.USAGE_ENDPOINT == "/v1/images/generations"
+    assert batches.USAGE_ENDPOINT == "/v1/batches"
+    assert batches.USAGE_ENDPOINT_RESULTS == "/v1/batches/results"


### PR DESCRIPTION
## Description

The `endpoint=` value on a usage-log row is an identifier, not a URL. These values were copied from route paths back when the routes lived at `/v1`. They are written to the database and then grouped, filtered and displayed by string equality, so rewriting them would make new rows incomparable with old ones.

Otari is about to move its REST API from `/v1/*` to `/api/v1/*`. That sweep touches a lot of path literals, and a usage-log label looks exactly like a route path. This PR lifts each label to a named module-level constant and pins the values in a unit test. The labels are then visibly not routes, and a later sweep that reaches one fails with a message naming the label instead of looking like a stale route somebody should "fix".

No value changes. This is a rename of literals to constants.

### What gained a name

| Module | Constant | Value |
| --- | --- | --- |
| `chat.py` | `USAGE_ENDPOINT` | `/v1/chat/completions` |
| `messages.py` | `USAGE_ENDPOINT` | `/v1/messages` |
| `responses.py` | `USAGE_ENDPOINT` | `/v1/responses` |
| `embeddings.py` | `USAGE_ENDPOINT` | `/v1/embeddings` |
| `audio.py` | `USAGE_ENDPOINT_TRANSCRIPTIONS` | `/v1/audio/transcriptions` |
| `audio.py` | `USAGE_ENDPOINT_SPEECH` | `/v1/audio/speech` |
| `rerank.py` | `USAGE_ENDPOINT` | `/v1/rerank` |
| `moderations.py` | `USAGE_ENDPOINT` | `/v1/moderations` |
| `images.py` | `USAGE_ENDPOINT` | `/v1/images/generations` |
| `batches.py` | `USAGE_ENDPOINT` | `/v1/batches` |
| `batches.py` | `USAGE_ENDPOINT_RESULTS` | `/v1/batches/results` |

`search.py` already had `SEARCH_ENDPOINT`, and the new constants follow its placement and naming.

### What deliberately stays inline

Two `/v1/chat/completions` literals in `batches.py` are not labels. Both belong to the provider's Batch API contract:

- the `"url"` on each line of the generated JSONL input file
- the `endpoint=` argument passed to `acreate_batch()`

Naming either of those `USAGE_ENDPOINT` would put a label name on a wire value, so they keep their literals.

### Note for the prefix move

The pinning test guards the route modules, not the test tree. Around 106 lines under `tests/` build a label inline, for example `UsageLog(endpoint="/v1/chat/completions", ...)`. Those do not import the new constants, and each checks its own value against itself, so a blanket path sweep would rewrite them silently. They need handling in the PR that moves the prefix.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Preparatory work for the `/api/v1` prefix move.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary. (None needed: no user-facing or wire behavior changes.)
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (Contract unchanged; `make openapi-check` and `make postman-check` both pass on this branch.)

### Verification

- `make lint`, `make typecheck` (mypy, 574 files): clean.
- `make test-unit`: 2972 passed, 9 skipped, 2 failed. Both failures are in `tests/unit/test_claude_code_import.py`, reproduce on unmodified `origin/main`, and are local only: they read the developer's own environment. Both pass in CI.
- Route integration tests (audio, batches, embeddings, images, messages, moderations, rerank, responses, usage tracking, usage endpoint, log usage commit scope): 193 passed, 2 skipped.
- The new guard was mutation-checked. Changing `batches.USAGE_ENDPOINT_RESULTS` to `/api/v1/batches/results` makes it fail and name the label.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**

The design, the plan and the review are human. The plan specified the constants, their names and the pinning test. AI carried out the mechanical lift of the literals, wrote the test to that specification, ran the checks, and drafted this description. AI also flagged two inaccuracies in the plan's file list, which a human then confirmed and decided on: one named site was a provider contract value rather than a label, and four genuine labels were missing from it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced inline usage-log endpoint labels with module-level constants across the supported API route modules.
- Preserved all existing `/v1/...` label values for database and filtering compatibility.
- Added a unit test to protect these historical values from accidental changes.
- Kept provider Batch API contract values inline because they are not usage-log labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->