### PR TITLE
fix(tests): accept an unexported card constant in the ceiling mirror checks

### DIFF
--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -8,6 +8,8 @@ on:
       - 'alembic/**'
       - 'tests/integration/**'
       - 'tests/unit/**'
+      # Two unit tests read the tool cards to pin the UI ceilings to the server's.
+      - 'web/src/features/tools/**'
       - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
@@ -19,6 +21,8 @@ on:
       - 'alembic/**'
       - 'tests/integration/**'
       - 'tests/unit/**'
+      # Two unit tests read the tool cards to pin the UI ceilings to the server's.
+      - 'web/src/features/tools/**'
       - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'

--- a/tests/unit/test_code_execution_policy_limits.py
+++ b/tests/unit/test_code_execution_policy_limits.py
@@ -33,7 +33,8 @@ _CARD = (
 
 
 def _card_constant(name: str) -> int:
-    match = re.search(rf"^export const {name} = (\d+)$", _CARD.read_text(), re.MULTILINE)
+    """Read the constant whether or not the card exports it: only the number is mirrored here."""
+    match = re.search(rf"^(?:export )?const {name} = (\d+)$", _CARD.read_text(), re.MULTILINE)
     assert match is not None, f"{name} is no longer declared in {_CARD.name}; update this test with it"
     return int(match.group(1))
 

--- a/tests/unit/test_web_search_narrowing.py
+++ b/tests/unit/test_web_search_narrowing.py
@@ -219,7 +219,8 @@ _CARD = Path(__file__).resolve().parents[2] / "web" / "src" / "features" / "tool
 
 
 def _card_constant(name: str) -> int:
-    match = re.search(rf"^export const {name} = (\d+)$", _CARD.read_text(), re.MULTILINE)
+    """Read the constant whether or not the card exports it: only the number is mirrored here."""
+    match = re.search(rf"^(?:export )?const {name} = (\d+)$", _CARD.read_text(), re.MULTILINE)
     assert match is not None, f"{name} is no longer declared in {_CARD.name}; update this test with it"
     return int(match.group(1))
 


### PR DESCRIPTION
## Description

`test_web_search_narrowing.py::test_the_card_repeats_the_ceiling_the_server_enforces[MAX_DOMAINS-100]` fails on `main`. The mirror tests grep the tool cards for `^export const NAME = <n>$`; #985 rewrote the Web search card and dropped the `export` from `MAX_DOMAINS`, whose last cross-file consumer had gone away. These tests pin the number, not the module's export surface, so both now accept `const` or `export const` rather than forcing a constant to be exported for a reader outside TypeScript. Re-adding the `export` would leave one with no consumer.

`otari-tests.yml` filters on paths that exclude `web/**`, so #985 skipped the suite and read green. `web/src/features/tools/**`, which holds both mirrored cards, joins the filter list; `web/**` would run the whole backend suite on every dashboard change.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

None filed.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally: `make lint`, `make typecheck`, and `tests/unit` (2941 passed, 8 skipped). Integration tests were not run; this change touches no runtime code.
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Failure reproduced on a clean checkout of `origin/main` before any edit.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
