### PR TITLE
fix(keys): conceal an issued key until the operator asks to see it

### DIFF
--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -112,3 +112,4 @@ hides.
 | `ConfirmRowAction` | `confirmLabel`, `onConfirm`, `isPending?`, children | The same two-step inside a row. It supplies its own `isDanger` and its own Cancel |
 | `RefreshButton` | `onRefresh`, `isFetching?`, `updatedAt?`, `label?` | A refetch, with its own freshness caption. Pass `updatedAt` or the caption reads nothing |
 | `CopyButton` | `value`, `label` | Copy one value. Icon-only, 44x44 hit area |
+| `CopyField` | `label`, `value`, `multiline?`, `concealed?`, `action?` | A readonly field of a value to paste elsewhere. `concealed` is what it shows until the operator asks for the value, for a credential: Copy copies the real one either way, so a key is handed over without being read off the screen |

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -10,7 +10,8 @@ border is what makes it an object. HeroUI defaults `--field-border-width` to 0;
 ```
 Is it free text, a number, or a date?
  ├── Is the value a secret (a provider key, a password)?
- │    └── Yes -> SecretField        (masked, revealable, copyable, autofill off)
+ │    ├── Collecting one -> SecretField   (masked, never prefilled, autofill off)
+ │    └── Handing one out -> CopyField, `concealed` (see actions.md)
  └── No -> Field
 Is it a boolean?
  ├── Does it take effect on its own, without a Save?

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -56,7 +56,10 @@ test.describe("dashboard core flows", () => {
     await expect(guide).toBeVisible()
 
     await page.getByRole("button", { name: "Create a setup key" }).click()
-    // Shown once, in a labeled field an operator can select and copy.
+    // Shown once, in a labeled field an operator can select and copy, and
+    // concealed there until they ask for it (otari-ai#2111).
+    await expect(page.getByLabel("API key")).not.toHaveValue(/^gw-/)
+    await page.getByRole("button", { name: "Show API key" }).click()
     await expect(page.getByLabel("API key")).toHaveValue(/^gw-/)
 
     await page.getByRole("button", { name: "Skip this guide" }).click()

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -58,7 +58,9 @@ test.describe("dashboard core flows", () => {
     await page.getByRole("button", { name: "Create a setup key" }).click()
     // Shown once, in a labeled field an operator can select and copy, and
     // concealed there until they ask for it (otari-ai#2111).
-    const key = page.getByLabel("API key")
+    // By role, not by label: `getByLabel` matches a substring, so it also
+    // picks up the field's own "Show API key" toggle.
+    const key = page.getByRole("textbox", { name: "API key" })
     await expect(key).toBeVisible()
     await expect(key).not.toHaveValue(/^gw-/)
     await page.getByRole("button", { name: "Show API key" }).click()

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -58,9 +58,11 @@ test.describe("dashboard core flows", () => {
     await page.getByRole("button", { name: "Create a setup key" }).click()
     // Shown once, in a labeled field an operator can select and copy, and
     // concealed there until they ask for it (otari-ai#2111).
-    await expect(page.getByLabel("API key")).not.toHaveValue(/^gw-/)
+    const key = page.getByLabel("API key")
+    await expect(key).toBeVisible()
+    await expect(key).not.toHaveValue(/^gw-/)
     await page.getByRole("button", { name: "Show API key" }).click()
-    await expect(page.getByLabel("API key")).toHaveValue(/^gw-/)
+    await expect(key).toHaveValue(/^gw-/)
 
     await page.getByRole("button", { name: "Skip this guide" }).click()
     await expect(guide).toBeHidden()

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -249,11 +249,25 @@ describe("KeysPage", () => {
     await user.keyboard("{Escape}")
     await user.click(screen.getByRole("button", { name: "Create key" }))
 
-    // The reveal shows the secret and a runnable curl snippet with the key injected.
+    // The strip offers the secret and a runnable curl snippet with the key
+    // injected, both concealed until asked for: a key nobody has asked to see
+    // is not on screen, and neither is the snippet that carries it (otari-ai#2111).
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
+    expect(within(reveal).getByLabelText("Secret key")).not.toHaveValue(
+      NEW_SECRET,
+    )
+    const concealedCurl = within(reveal).getByLabelText(
+      "curl",
+    ) as HTMLTextAreaElement
+    expect(concealedCurl.value).not.toContain(NEW_SECRET)
+
+    await user.click(
+      within(reveal).getByRole("button", { name: "Show Secret key" }),
+    )
     expect(within(reveal).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
+    await user.click(within(reveal).getByRole("button", { name: "Show curl" }))
     const curl = within(reveal).getByDisplayValue(
       new RegExp(`Otari-Key: ${NEW_SECRET}`),
     )
@@ -309,11 +323,11 @@ describe("KeysPage", () => {
       }),
     )
 
-    const curl = dialog.getByDisplayValue(
-      new RegExp(`Otari-Key: ${NEW_SECRET}`),
-    ) as HTMLTextAreaElement
+    const curl = dialog.getByLabelText("curl") as HTMLTextAreaElement
     expect(curl.value).toContain("https://gateway.otari.ai/v1/chat/completions")
     expect(curl.value).not.toContain(window.location.origin)
+    // Concealed, so the address it names is readable while the key is not.
+    expect(curl.value).not.toContain(NEW_SECRET)
   })
 
   it("shows no snippet when a hosted deployment published no data plane", async () => {
@@ -323,10 +337,8 @@ describe("KeysPage", () => {
       bootstrap({ deployment_type: "hosted", data_plane_url: null }),
     )
 
-    expect(dialog.getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
-    expect(
-      dialog.queryByDisplayValue(new RegExp(`Otari-Key: ${NEW_SECRET}`)),
-    ).not.toBeInTheDocument()
+    expect(dialog.getByLabelText("Secret key")).toBeInTheDocument()
+    expect(dialog.queryByLabelText("curl")).not.toBeInTheDocument()
     expect(
       dialog.getByText(/has not published the gateway address/),
     ).toBeInTheDocument()
@@ -510,7 +522,12 @@ describe("KeysPage", () => {
     const copyButtons = within(reveal).getAllByRole("button", { name: "Copy" })
     await user.click(copyButtons[0])
 
+    // Copied without being read, which is the point of concealing it: the key
+    // reached the clipboard and never the screen (otari-ai#2111).
     expect(writeText).toHaveBeenCalledWith(NEW_SECRET)
+    expect(
+      within(reveal).queryByDisplayValue(NEW_SECRET),
+    ).not.toBeInTheDocument()
     expect(
       await within(reveal).findByText("Copied to clipboard."),
     ).toBeInTheDocument()
@@ -569,6 +586,9 @@ describe("KeysPage", () => {
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
+    await user.click(
+      within(reveal).getByRole("button", { name: "Show Secret key" }),
+    )
     expect(within(reveal).getByDisplayValue(REGEN_SECRET)).toBeInTheDocument()
   })
 
@@ -1116,6 +1136,9 @@ describe("KeysPage", () => {
       const reveal = await screen.findByRole("alert", {
         name: /API key created|New secret for/,
       })
+      await usr.click(
+        within(reveal).getByRole("button", { name: "Show Secret key" }),
+      )
       expect(within(reveal).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
 
       const post = fetchMock.mock.calls.find(

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -34,7 +34,10 @@ import {
 } from "@/shared/api/apiKeys"
 import { useUsers } from "@/shared/api/users"
 import { MissingGatewayAddressNotice } from "@/shared/components/access/MissingGatewayAddressNotice"
-import { CopyField } from "@/shared/components/actions/CopyField"
+import {
+  CONCEALED_SECRET,
+  CopyField,
+} from "@/shared/components/actions/CopyField"
 import { RowAction, RowActionRow } from "@/shared/components/actions/RowAction"
 import { BulkActionBar } from "@/shared/components/data/BulkActionBar"
 import {
@@ -143,10 +146,11 @@ function RevealSecretStrip({
   useEffect(() => {
     // The strip is above the fold only if the page is at the top, and a reveal
     // can arrive after a scroll. Move there first, then take focus, so the
-    // secret is selected somewhere the operator can see it.
+    // keyboard lands on the key and its two controls rather than wherever the
+    // operator was. Focus without a selection: the field is concealed, and
+    // selecting the stand-in would invite a Ctrl/Cmd-C that copies bullets.
     window.scrollTo({ top: 0 })
     secretRef.current?.focus()
-    secretRef.current?.select()
   }, [])
 
   useEffect(
@@ -172,6 +176,18 @@ function RevealSecretStrip({
     ? {
         curl: buildCurlSnippet({ baseUrl, apiKey: secret }),
         python: buildPythonSnippet({ baseUrl, apiKey: secret }),
+        // The same two commands around the stand-in, which is what the fields
+        // show until the operator asks for the key. Without them the snippets
+        // would print the plaintext key under a concealed key field and hand it
+        // to anyone reading the screen, which is what concealing it prevents.
+        concealedCurl: buildCurlSnippet({
+          baseUrl,
+          apiKey: CONCEALED_SECRET,
+        }),
+        concealedPython: buildPythonSnippet({
+          baseUrl,
+          apiKey: CONCEALED_SECRET,
+        }),
       }
     : undefined
 
@@ -197,7 +213,12 @@ function RevealSecretStrip({
           </p>
         </div>
       </div>
-      <CopyField label="Secret key" value={secret} fieldRef={secretRef} />
+      <CopyField
+        label="Secret key"
+        value={secret}
+        concealed={CONCEALED_SECRET}
+        fieldRef={secretRef}
+      />
       <div className="flex flex-col gap-2">
         <div>
           <div className="text-body">Make your first call</div>
@@ -212,10 +233,16 @@ function RevealSecretStrip({
         </div>
         {snippets !== undefined ? (
           <>
-            <CopyField label="curl" value={snippets.curl} multiline />
+            <CopyField
+              label="curl"
+              value={snippets.curl}
+              concealed={snippets.concealedCurl}
+              multiline
+            />
             <CopyField
               label="Python (OpenAI SDK)"
               value={snippets.python}
+              concealed={snippets.concealedPython}
               multiline
             />
           </>

--- a/web/src/features/onboarding/SetupGuideCard.test.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.test.tsx
@@ -188,7 +188,16 @@ describe("SetupGuideCard", () => {
 
     await user.click(screen.getByRole("button", { name: "Create a setup key" }))
 
-    expect(await screen.findByDisplayValue(KEY)).toBeInTheDocument()
+    // Concealed until it is asked for, and so is the snippet carrying it: a
+    // key nobody has asked to see is not on screen (otari-ai#2111).
+    expect(await screen.findByLabelText("API key")).not.toHaveValue(KEY)
+    expect(
+      (screen.getByLabelText("curl") as HTMLTextAreaElement).value,
+    ).not.toContain(KEY)
+
+    await user.click(screen.getByRole("button", { name: "Show API key" }))
+    expect(screen.getByDisplayValue(KEY)).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Show curl" }))
     const curl = screen.getByDisplayValue(
       new RegExp(`Otari-Key: ${KEY}`),
     ) as HTMLTextAreaElement
@@ -217,14 +226,14 @@ describe("SetupGuideCard", () => {
       await screen.findByRole("button", { name: "Create a setup key" }),
     )
 
-    const curl = (await screen.findByDisplayValue(
-      new RegExp(`Otari-Key: ${KEY}`),
-    )) as HTMLTextAreaElement
+    const curl = (await screen.findByLabelText("curl")) as HTMLTextAreaElement
     expect(curl.value).toContain("https://gateway.otari.ai/v1/chat/completions")
     expect(curl.value).not.toContain(window.location.origin)
+    // Concealed, so the address it names is readable while the key is not.
+    expect(curl.value).not.toContain(KEY)
   })
 
-  it("shows the key but no snippet when a hosted deployment published no data plane", async () => {
+  it("offers the key but no snippet when a hosted deployment published no data plane", async () => {
     // Withheld rather than aimed at this host: a placeholder would be a URL
     // nobody reading it could replace, and the origin would be the bug itself.
     mockApi()
@@ -238,10 +247,8 @@ describe("SetupGuideCard", () => {
       await screen.findByRole("button", { name: "Create a setup key" }),
     )
 
-    expect(await screen.findByDisplayValue(KEY)).toBeInTheDocument()
-    expect(
-      screen.queryByDisplayValue(new RegExp(`Otari-Key: ${KEY}`)),
-    ).not.toBeInTheDocument()
+    expect(await screen.findByLabelText("API key")).toBeInTheDocument()
+    expect(screen.queryByLabelText("curl")).not.toBeInTheDocument()
     expect(
       screen.getByText(/has not published the gateway address/),
     ).toBeInTheDocument()
@@ -351,6 +358,9 @@ describe("SetupGuideCard", () => {
     await user.click(
       await screen.findByRole("button", { name: "Create a setup key" }),
     )
+    await user.click(
+      await screen.findByRole("button", { name: "Show API key" }),
+    )
     expect(await screen.findByDisplayValue(KEY)).toBeInTheDocument()
 
     await user.click(screen.getByRole("button", { name: "switch to Research" }))
@@ -358,6 +368,9 @@ describe("SetupGuideCard", () => {
     expect(screen.queryByDisplayValue(KEY)).not.toBeInTheDocument()
     await user.click(
       await screen.findByRole("button", { name: "Create a setup key" }),
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Show API key" }),
     )
     expect(await screen.findByDisplayValue(OTHER_KEY)).toBeInTheDocument()
 

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -15,7 +15,10 @@ import {
 } from "@/shared/api/activation"
 import { useModels } from "@/shared/api/models"
 import { MissingGatewayAddressNotice } from "@/shared/components/access/MissingGatewayAddressNotice"
-import { CopyField } from "@/shared/components/actions/CopyField"
+import {
+  CONCEALED_SECRET,
+  CopyField,
+} from "@/shared/components/actions/CopyField"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { InfoBanner } from "@/shared/components/feedback/InfoBanner"
 import { formatCost, formatRelative } from "@/shared/helpers/format"
@@ -249,7 +252,11 @@ function IssuedKey({ issued }: { issued: ActivationApiKey }) {
         Copy this key now. It is shown once, and reopening this guide issues a
         new one in its place.
       </InfoBanner>
-      <CopyField label="API key" value={issued.key} />
+      <CopyField
+        label="API key"
+        value={issued.key}
+        concealed={CONCEALED_SECRET}
+      />
       {snippetInput === undefined ? <MissingGatewayAddressNotice /> : null}
       {snippetInput !== undefined && model === undefined ? (
         <p className="text-caption">
@@ -267,14 +274,25 @@ function IssuedKey({ issued }: { issued: ActivationApiKey }) {
       ) : null}
       {snippetInput !== undefined ? (
         <>
+          {/* Concealed around the stand-in rather than the key: a snippet
+              printing the plaintext would hand it to anyone reading the
+              screen, directly under a concealed key field. */}
           <CopyField
             label="curl"
             value={buildCurlSnippet(snippetInput)}
+            concealed={buildCurlSnippet({
+              ...snippetInput,
+              apiKey: CONCEALED_SECRET,
+            })}
             multiline
           />
           <CopyField
             label="Python (OpenAI SDK)"
             value={buildPythonSnippet(snippetInput)}
+            concealed={buildPythonSnippet({
+              ...snippetInput,
+              apiKey: CONCEALED_SECRET,
+            })}
             multiline
           />
         </>

--- a/web/src/features/settings/SettingsPage.test.tsx
+++ b/web/src/features/settings/SettingsPage.test.tsx
@@ -319,10 +319,18 @@ describe("SettingsPage", () => {
     ).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: "Regenerate key" }))
 
-    const revealedKey = await screen.findByDisplayValue("otari-mk-new")
-    expect(revealedKey).toHaveAttribute("autocomplete", "off")
-    expect(revealedKey).toHaveAttribute("data-1p-ignore")
-    expect(revealedKey).toHaveAttribute("data-lpignore", "true")
+    // Concealed until it is asked for, so the replacement key is not on screen
+    // for anyone who happens to be looking at it (otari-ai#2111).
+    const keyField = await screen.findByLabelText("New master key")
+    expect(keyField).not.toHaveValue("otari-mk-new")
+    expect(keyField).toHaveAttribute("autocomplete", "off")
+    expect(keyField).toHaveAttribute("data-1p-ignore")
+    expect(keyField).toHaveAttribute("data-lpignore", "true")
+
+    await user.click(
+      screen.getByRole("button", { name: "Show New master key" }),
+    )
+    expect(await screen.findByDisplayValue("otari-mk-new")).toBeInTheDocument()
     expect(
       screen.getByRole("alertdialog", { name: "Master key regenerated" }),
     ).toBeInTheDocument()

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -10,6 +10,10 @@ import {
   useStoredProviders,
 } from "@/shared/api/providers"
 import { useSettings, useUpdateSettings } from "@/shared/api/settings"
+import {
+  CONCEALED_SECRET,
+  CopyField,
+} from "@/shared/components/actions/CopyField"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { InfoBanner } from "@/shared/components/feedback/InfoBanner"
 import { PageLoading } from "@/shared/components/feedback/PageLoading"
@@ -290,67 +294,6 @@ function ConfigRow({
   )
 }
 
-function CopyField({
-  value,
-  fieldRef,
-}: {
-  value: string
-  fieldRef?: React.RefObject<HTMLInputElement | null>
-}) {
-  const internalRef = useRef<HTMLInputElement>(null)
-  const ref = fieldRef ?? internalRef
-  const [copied, setCopied] = useState(false)
-  const [selectHint, setSelectHint] = useState(false)
-
-  const copy = async () => {
-    ref.current?.focus()
-    ref.current?.select()
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(value)
-        setCopied(true)
-        setSelectHint(false)
-        window.setTimeout(() => setCopied(false), 2_000)
-        return
-      }
-    } catch {
-      // Fall through to the manual-copy hint.
-    }
-    setSelectHint(true)
-  }
-
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between">
-        <span className="text-caption">New master key</span>
-        <Button size="sm" variant="ghost" onPress={copy}>
-          {copied ? "Copied" : "Copy"}
-        </Button>
-      </div>
-      <input
-        ref={ref}
-        readOnly
-        value={value}
-        onFocus={(event) => event.currentTarget.select()}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        data-1p-ignore
-        data-lpignore="true"
-      />
-      <span aria-live="polite" className="text-xs text-success">
-        {copied ? "Copied to clipboard." : ""}
-      </span>
-      {selectHint ? (
-        <span className="text-caption">
-          Selected. Press Ctrl/Cmd-C to copy.
-        </span>
-      ) : null}
-    </div>
-  )
-}
-
 function MasterKeyRotationDialog({
   masterKey,
   error,
@@ -364,12 +307,13 @@ function MasterKeyRotationDialog({
   onRegenerate: () => void
   onClose: () => void
 }) {
-  const keyRef = useRef<HTMLInputElement>(null)
+  const keyRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
 
   useEffect(() => {
     if (masterKey === undefined) return
+    // Focus without a selection: the key is concealed until it is asked for,
+    // and selecting the stand-in would invite a Ctrl/Cmd-C that copies bullets.
     keyRef.current?.focus()
-    keyRef.current?.select()
   }, [masterKey])
 
   return (
@@ -394,7 +338,12 @@ function MasterKeyRotationDialog({
                   The previous master key has stopped working. This browser tab
                   now uses the new key.
                 </p>
-                <CopyField value={masterKey} fieldRef={keyRef} />
+                <CopyField
+                  label="New master key"
+                  value={masterKey}
+                  concealed={CONCEALED_SECRET}
+                  fieldRef={keyRef}
+                />
               </>
             ) : (
               <>

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -353,6 +353,45 @@ describe("CopyField, concealed", () => {
     expect(document.body.textContent).not.toContain("gw-second-secret")
   })
 
+  it("does not reveal a credential that arrived while a copy was failing", async () => {
+    const user = userEvent.setup()
+    // A copy left in flight, so the swap lands between the attempt and its
+    // failure. Both clipboard paths refuse, which is the branch that reveals.
+    let refuse: (reason: Error) => void = () => {}
+    vi.spyOn(navigator.clipboard, "writeText").mockReturnValue(
+      new Promise((_resolve, reject) => {
+        refuse = reject
+      }),
+    )
+    const { rerender } = render(
+      <CopyField
+        label="Secret key"
+        value="gw-first-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Copy" }))
+    rerender(
+      <CopyField
+        label="Secret key"
+        value="gw-second-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+    refuse(new Error("not a secure context"))
+
+    // The failure belongs to the key that is gone, so it reveals nothing and
+    // claims nothing: the replacement is a credential nobody has asked to see.
+    await waitFor(() => {
+      expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+    })
+    expect(document.body.textContent).not.toContain("gw-second-secret")
+    expect(
+      screen.queryByText("Revealed and selected. Press Ctrl/Cmd-C to copy."),
+    ).not.toBeInTheDocument()
+  })
+
   it("rejects concealing a field that carries an action, at the type level", () => {
     render(
       // @ts-expect-error nothing hands out a credential beside a

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { CopyableValue, CopyField } from "@/shared/components/actions/CopyField"
+import {
+  CONCEALED_SECRET,
+  CopyableValue,
+  CopyField,
+} from "@/shared/components/actions/CopyField"
 
 describe("CopyField", () => {
   // Scoped like CopyButton's above: the failure case spies on
@@ -190,6 +194,178 @@ describe("CopyField", () => {
       />,
     )
     expect(screen.getByLabelText("curl")).toBeInTheDocument()
+  })
+})
+
+describe("CopyField, concealed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("shows the stand-in until the value is asked for, and hides it again", async () => {
+    const user = userEvent.setup()
+    render(
+      <CopyField
+        label="Secret key"
+        value="gw-real-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+
+    const field = screen.getByLabelText("Secret key")
+    expect(field).toHaveValue(CONCEALED_SECRET)
+    // The plaintext is not in the document at all, so it cannot be read off
+    // the screen, scraped out of a screenshot, or found in a DOM dump.
+    expect(document.body.textContent).not.toContain("gw-real-secret")
+
+    await user.click(screen.getByRole("button", { name: "Show Secret key" }))
+    expect(field).toHaveValue("gw-real-secret")
+
+    await user.click(screen.getByRole("button", { name: "Hide Secret key" }))
+    expect(field).toHaveValue(CONCEALED_SECRET)
+  })
+
+  it("copies the real value while it is concealed", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    })
+    render(
+      <CopyField
+        label="Secret key"
+        value="gw-real-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Copy" }))
+
+    // Handed over without being seen, which is the whole point: the clipboard
+    // gets the key and the field still shows the stand-in.
+    expect(writeText).toHaveBeenCalledWith("gw-real-secret")
+    expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+    expect(await screen.findByText("Copied to clipboard.")).toBeInTheDocument()
+  })
+
+  it("reveals and selects when no clipboard path will take it", async () => {
+    const user = userEvent.setup()
+    // Both paths refused, as on a plain-HTTP origin whose browser also has no
+    // `execCommand`: the async API is made to throw and jsdom defines no
+    // legacy fallback, so nothing wrote to the clipboard.
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("not a secure context"),
+    )
+    render(
+      <CopyField
+        label="Secret key"
+        value="gw-real-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+    const field = screen.getByLabelText("Secret key") as HTMLInputElement
+
+    await user.click(screen.getByRole("button", { name: "Copy" }))
+
+    // Ctrl/Cmd-C is the only way left, and it can only reach the plaintext, so
+    // the field reveals it and selects that rather than the stand-in.
+    await waitFor(() => {
+      expect(field).toHaveValue("gw-real-secret")
+      expect(document.activeElement).toBe(field)
+      expect(field.selectionStart).toBe(0)
+      expect(field.selectionEnd).toBe("gw-real-secret".length)
+    })
+    expect(
+      screen.getByText("Revealed and selected. Press Ctrl/Cmd-C to copy."),
+    ).toBeInTheDocument()
+    // Never a claim it copied, which is the rule the whole component follows.
+    expect(screen.queryByText("Copied to clipboard.")).not.toBeInTheDocument()
+  })
+
+  it("leaves focus unselected while concealed, so no Ctrl/Cmd-C copies bullets", async () => {
+    const user = userEvent.setup()
+    render(
+      <CopyField
+        label="Secret key"
+        value="gw-real-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+    const field = screen.getByLabelText("Secret key") as HTMLInputElement
+
+    await user.click(field)
+    expect(field.selectionStart).toBe(field.selectionEnd)
+
+    // Revealed, the field selects on focus the way every other one does.
+    await user.click(screen.getByRole("button", { name: "Show Secret key" }))
+    await user.click(field)
+    expect(field.selectionStart).toBe(0)
+    expect(field.selectionEnd).toBe("gw-real-secret".length)
+  })
+
+  it("conceals a snippet around the stand-in, with the toggle out of the field", async () => {
+    const user = userEvent.setup()
+    const snippet = `curl https://otari.test \\\n  -H "Otari-Key: gw-real-secret"`
+    render(
+      <CopyField
+        label="curl"
+        value={snippet}
+        concealed={snippet.replace("gw-real-secret", CONCEALED_SECRET)}
+        multiline
+      />,
+    )
+
+    const field = screen.getByLabelText("curl")
+    // The request is readable while the key inside it is not: the address is
+    // what the operator has to check, and the key is not.
+    expect(field).toHaveTextContent("https://otari.test")
+    expect((field as HTMLTextAreaElement).value).not.toContain("gw-real-secret")
+
+    await user.click(screen.getByRole("button", { name: "Show curl" }))
+    expect(field).toHaveValue(snippet)
+  })
+
+  it("conceals a second value, rather than inheriting the first one's reveal", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <CopyField
+        label="Secret key"
+        value="gw-first-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Show Secret key" }))
+    expect(screen.getByLabelText("Secret key")).toHaveValue("gw-first-secret")
+
+    // A rotation with the previous key still on screen: the replacement is a
+    // credential nobody has asked to see yet.
+    rerender(
+      <CopyField
+        label="Secret key"
+        value="gw-second-secret"
+        concealed={CONCEALED_SECRET}
+      />,
+    )
+
+    expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+    expect(document.body.textContent).not.toContain("gw-second-secret")
+  })
+
+  it("rejects concealing a field that carries an action, at the type level", () => {
+    render(
+      // @ts-expect-error nothing hands out a credential beside a
+      // domain-verification action, and the in-field arrangement has no room
+      // for a second control.
+      <CopyField
+        label="TXT record"
+        value="otari-verify=abc"
+        concealed={CONCEALED_SECRET}
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+    expect(screen.getByLabelText("TXT record")).toBeInTheDocument()
   })
 })
 

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@heroui/react"
 import type { ReactElement, ReactNode } from "react"
 import { useEffect, useId, useRef, useState } from "react"
+import { FiEye, FiEyeOff } from "react-icons/fi"
 import { CopyButton } from "@/shared/components/actions/CopyButton"
+import { copyToClipboard } from "@/shared/helpers/clipboard"
 
 // An identifier the operator needs verbatim (a model id, an alias target, a
 // request id), rendered so it can be taken either way: highlighted with the mouse
@@ -54,6 +56,15 @@ export function CopyableValue({
   )
 }
 
+/**
+ * What a concealed field shows in place of a credential.
+ *
+ * One fixed run rather than a bullet per character: the length of a key is
+ * itself something not to put on screen, and the same stand-in has to read as
+ * hidden inside a snippet built around it.
+ */
+export const CONCEALED_SECRET = "••••••••••••••••"
+
 // A readonly, always-selectable field with a copy button: how a value an
 // operator has to paste elsewhere is handed over. Shared by the Keys page's
 // one-time reveal and the setup guide, which hand out the same key and the same
@@ -68,6 +79,9 @@ export function CopyableValue({
 // values are handed over in pairs and threes (a key and two snippets), so
 // "which field is this" has to be answerable by a screen reader and by a test
 // that queries the way an operator reads.
+//
+// A value that is a credential is `concealed`: it is handed over without being
+// put on screen, and the operator reveals it only if they need to read it.
 type CopyFieldProps = {
   label: string
   value: string
@@ -75,6 +89,17 @@ type CopyFieldProps = {
 } & (
   | {
       multiline?: boolean
+      /**
+       * What the field shows until the operator asks for the value, for a value
+       * that carries a credential: the plaintext reaches the DOM only once it
+       * has been asked for, while Copy copies the real value either way, so a
+       * key can be handed over without being read off the screen (otari-ai#2111).
+       *
+       * A whole-value field passes `CONCEALED_SECRET`. A snippet passes the same
+       * snippet built around that stand-in, so what is hidden is the key rather
+       * than the request that explains it.
+       */
+      concealed?: string
       /**
        * Excluded here rather than guarded at runtime, so a call site that passes
        * both fails to compile. The multiline field is a `<textarea>`, where the
@@ -85,6 +110,8 @@ type CopyFieldProps = {
     }
   | {
       multiline?: false
+      /** Nothing hands out a credential beside a domain-verification action. */
+      concealed?: never
       /**
        * A control to sit beside the field, which moves the copy affordance
        * inside the field and drops the button from the label row. Absent, the
@@ -104,6 +131,7 @@ export function CopyField({
   multiline = false,
   fieldRef,
   action,
+  concealed,
 }: CopyFieldProps) {
   const internalRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(
     null,
@@ -112,25 +140,76 @@ export function CopyField({
   const fieldId = useId()
   const [copied, setCopied] = useState(false)
   const [selectHint, setSelectHint] = useState(false)
+  const [revealed, setRevealed] = useState(false)
+  // A second credential rendered into the same field arrives concealed rather
+  // than inheriting the reveal the operator asked for on the last one: a
+  // rotation with the previous key still on screen would otherwise publish the
+  // replacement without being asked. Reset in render rather than in an effect,
+  // which is React's own answer to a prop change that invalidates state, so the
+  // new value is never painted revealed.
+  const [concealedFor, setConcealedFor] = useState(value)
+  if (value !== concealedFor) {
+    setConcealedFor(value)
+    setRevealed(false)
+  }
   // Same shape as CopyButton's below: the acknowledgement clears itself on a
   // timer, so the timer has to die with the component (and be replaced rather
   // than stacked when a second copy lands inside the window).
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   )
+  // Set when a failed copy has to reveal the value before it can select it:
+  // `select()` in that same tick would span the stand-in, and the value React
+  // writes on the revealing render discards the selection anyway.
+  const selectOnReveal = useRef(false)
 
   useEffect(() => () => clearTimeout(resetTimer.current), [])
 
+  useEffect(() => {
+    if (!revealed || !selectOnReveal.current) return
+    selectOnReveal.current = false
+    ref.current?.focus()
+    ref.current?.select()
+  }, [revealed, ref])
+
+  const isConcealed = concealed !== undefined && !revealed
+  const shown = isConcealed ? concealed : value
+
+  const acknowledgeCopy = () => {
+    setCopied(true)
+    setSelectHint(false)
+    clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setCopied(false), 2_000)
+  }
+
   const copy = async () => {
+    // A concealed field cannot answer a refused copy with "it is selected,
+    // press Ctrl/Cmd-C": what is selected is the stand-in, so the hint would be
+    // an invitation to copy bullets. It takes the path with the `execCommand`
+    // fallback instead, which copies from an offscreen textarea and so needs
+    // nothing of the value on screen. Only when that refuses too does it reveal
+    // and select, which is the first moment Ctrl/Cmd-C could reach the key.
+    if (concealed !== undefined) {
+      if (await copyToClipboard(value)) {
+        acknowledgeCopy()
+        return
+      }
+      if (revealed) {
+        ref.current?.focus()
+        ref.current?.select()
+      } else {
+        selectOnReveal.current = true
+        setRevealed(true)
+      }
+      setSelectHint(true)
+      return
+    }
     ref.current?.focus()
     ref.current?.select()
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(value)
-        setCopied(true)
-        setSelectHint(false)
-        clearTimeout(resetTimer.current)
-        resetTimer.current = setTimeout(() => setCopied(false), 2_000)
+        acknowledgeCopy()
         return
       }
     } catch {
@@ -185,35 +264,99 @@ export function CopyField({
     )
   }
 
+  const selectUnlessConcealed = (
+    event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    // Selecting a stand-in would invite a Ctrl/Cmd-C that copies bullets.
+    if (isConcealed) return
+    event.currentTarget.select()
+  }
+
+  // A credential, so nothing here invites a password manager to remember the
+  // field or a spellchecker to underline it.
+  const credentialProps =
+    concealed === undefined
+      ? {}
+      : {
+          autoComplete: "off",
+          autoCorrect: "off",
+          autoCapitalize: "off",
+          spellCheck: false,
+          "data-1p-ignore": true,
+          "data-lpignore": "true",
+        }
+
+  const revealToggle = (
+    <Button
+      size="sm"
+      variant="ghost"
+      isIconOnly
+      aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
+      onPress={() => setRevealed(!revealed)}
+    >
+      {revealed ? (
+        <FiEyeOff aria-hidden="true" className="h-3.5 w-3.5" />
+      ) : (
+        <FiEye aria-hidden="true" className="h-3.5 w-3.5" />
+      )}
+    </Button>
+  )
+
+  const field = multiline ? (
+    <textarea
+      id={fieldId}
+      ref={ref as React.RefObject<HTMLTextAreaElement>}
+      readOnly
+      rows={shown.split("\n").length}
+      value={shown}
+      onFocus={selectUnlessConcealed}
+      className={`${shared} resize-none whitespace-pre`}
+      {...credentialProps}
+    />
+  ) : (
+    <input
+      id={fieldId}
+      ref={ref as React.RefObject<HTMLInputElement>}
+      readOnly
+      value={shown}
+      onFocus={selectUnlessConcealed}
+      // Concealed, the right padding clears the toggle rather than the value
+      // running under it, and the field grows below `md` so the 44px touch
+      // floor fits between its borders.
+      className={
+        concealed === undefined
+          ? shared
+          : `${shared} min-h-[2.875rem] pr-14 md:min-h-0 md:pr-11`
+      }
+      {...credentialProps}
+    />
+  )
+
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
         <label htmlFor={fieldId} className="text-caption">
           {label}
         </label>
-        <Button size="sm" variant="ghost" onPress={copy}>
-          {copied ? "Copied" : "Copy"}
-        </Button>
+        <div className="flex items-center gap-1">
+          {/* A snippet's toggle sits in the label row rather than in the field,
+              for the reason `action` is barred from the multiline variant at
+              all: right padding on a textarea indents every line of it. */}
+          {concealed !== undefined && multiline ? revealToggle : null}
+          <Button size="sm" variant="ghost" onPress={copy}>
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
       </div>
-      {multiline ? (
-        <textarea
-          id={fieldId}
-          ref={ref as React.RefObject<HTMLTextAreaElement>}
-          readOnly
-          rows={value.split("\n").length}
-          value={value}
-          onFocus={(e) => e.currentTarget.select()}
-          className={`${shared} resize-none whitespace-pre`}
-        />
+      {concealed !== undefined && !multiline ? (
+        <div className="relative">
+          {field}
+          <span className="absolute top-1/2 right-1 -translate-y-1/2">
+            {revealToggle}
+          </span>
+        </div>
       ) : (
-        <input
-          id={fieldId}
-          ref={ref as React.RefObject<HTMLInputElement>}
-          readOnly
-          value={value}
-          onFocus={(e) => e.currentTarget.select()}
-          className={shared}
-        />
+        field
       )}
       {/* Announce only the "Copied" event, never the secret itself. */}
       <span aria-live="polite" className="text-xs text-success">
@@ -221,7 +364,9 @@ export function CopyField({
       </span>
       {selectHint ? (
         <span className="text-caption">
-          Selected. Press Ctrl/Cmd-C to copy.
+          {concealed === undefined
+            ? "Selected. Press Ctrl/Cmd-C to copy."
+            : "Revealed and selected. Press Ctrl/Cmd-C to copy."}
         </span>
       ) : null}
     </div>

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -139,45 +139,52 @@ export function CopyField({
   const ref = fieldRef ?? internalRef
   const fieldId = useId()
   const [copied, setCopied] = useState(false)
-  const [selectHint, setSelectHint] = useState(false)
-  const [revealed, setRevealed] = useState(false)
-  // A second credential rendered into the same field arrives concealed rather
-  // than inheriting the reveal the operator asked for on the last one: a
-  // rotation with the previous key still on screen would otherwise publish the
-  // replacement without being asked. Reset in render rather than in an effect,
-  // which is React's own answer to a prop change that invalidates state, so the
-  // new value is never painted revealed.
-  const [concealedFor, setConcealedFor] = useState(value)
-  if (value !== concealedFor) {
-    setConcealedFor(value)
-    setRevealed(false)
-  }
+  // Which value each of these is about, rather than a bare flag, because both
+  // outlive the value they were asked for. A second credential rendered into
+  // this field is concealed with nothing having to reset it, and a copy that
+  // fails after the swap cannot reveal or advertise a credential it was not
+  // copying: a rotation with the previous key still on screen would otherwise
+  // publish the replacement without anyone asking to see it.
+  const [revealedValue, setRevealedValue] = useState<string | undefined>(
+    undefined,
+  )
+  const [selectHintFor, setSelectHintFor] = useState<string | undefined>(
+    undefined,
+  )
+  const revealed = revealedValue === value
+  const selectHint = selectHintFor === value
   // Same shape as CopyButton's below: the acknowledgement clears itself on a
   // timer, so the timer has to die with the component (and be replaced rather
   // than stacked when a second copy lands inside the window).
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   )
-  // Set when a failed copy has to reveal the value before it can select it:
-  // `select()` in that same tick would span the stand-in, and the value React
-  // writes on the revealing render discards the selection anyway.
-  const selectOnReveal = useRef(false)
+  // The value a failed copy asked to have selected, once revealing it has put
+  // it on the field: `select()` in the failure's own tick would span the
+  // stand-in, and the value React writes on the revealing render discards a
+  // selection made before it anyway.
+  const selectOnReveal = useRef<string | undefined>(undefined)
 
   useEffect(() => () => clearTimeout(resetTimer.current), [])
 
   useEffect(() => {
-    if (!revealed || !selectOnReveal.current) return
-    selectOnReveal.current = false
+    const wanted = selectOnReveal.current
+    if (wanted === undefined) return
+    selectOnReveal.current = undefined
+    // Only once the reveal has landed on the value the copy was for. Another
+    // credential arriving in the meantime is concealed, and selecting its
+    // stand-in is exactly what this is here to avoid.
+    if (revealedValue !== wanted || value !== wanted) return
     ref.current?.focus()
     ref.current?.select()
-  }, [revealed, ref])
+  }, [revealedValue, value, ref])
 
   const isConcealed = concealed !== undefined && !revealed
   const shown = isConcealed ? concealed : value
 
   const acknowledgeCopy = () => {
     setCopied(true)
-    setSelectHint(false)
+    setSelectHintFor(undefined)
     clearTimeout(resetTimer.current)
     resetTimer.current = setTimeout(() => setCopied(false), 2_000)
   }
@@ -190,18 +197,22 @@ export function CopyField({
     // nothing of the value on screen. Only when that refuses too does it reveal
     // and select, which is the first moment Ctrl/Cmd-C could reach the key.
     if (concealed !== undefined) {
-      if (await copyToClipboard(value)) {
+      // The credential this attempt is for. Another can arrive while the copy
+      // is in flight, and everything below is keyed on this one so a failure
+      // cannot land on its successor.
+      const copying = value
+      if (await copyToClipboard(copying)) {
         acknowledgeCopy()
         return
       }
-      if (revealed) {
-        ref.current?.focus()
-        ref.current?.select()
+      if (ref.current?.value === copying) {
+        ref.current.focus()
+        ref.current.select()
       } else {
-        selectOnReveal.current = true
-        setRevealed(true)
+        selectOnReveal.current = copying
+        setRevealedValue(copying)
       }
-      setSelectHint(true)
+      setSelectHintFor(copying)
       return
     }
     ref.current?.focus()
@@ -217,7 +228,7 @@ export function CopyField({
     }
     // No Clipboard API (or it threw): the text is selected, so the operator can
     // press Ctrl/Cmd-C. Never claim it was copied.
-    setSelectHint(true)
+    setSelectHintFor(value)
   }
 
   const shared =
@@ -292,7 +303,7 @@ export function CopyField({
       variant="ghost"
       isIconOnly
       aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
-      onPress={() => setRevealed(!revealed)}
+      onPress={() => setRevealedValue(revealed ? undefined : value)}
     >
       {revealed ? (
         <FiEyeOff aria-hidden="true" className="h-3.5 w-3.5" />

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -334,11 +334,13 @@ export function CopyField({
 
   return (
     <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between">
+      {/* `gap-2` so a long label and the controls beside it cannot meet: a
+          concealed snippet puts two of them in this row. */}
+      <div className="flex items-center justify-between gap-2">
         <label htmlFor={fieldId} className="text-caption">
           {label}
         </label>
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1">
           {/* A snippet's toggle sits in the label row rather than in the field,
               for the reason `action` is barred from the multiline variant at
               all: right padding on a textarea indents every line of it. */}


### PR DESCRIPTION
## Description

Today, creating an API key prints the whole key on screen, and so do the two
example requests below it. Anyone who can see the screen reads the credential,
not just the person who asked for it: a colleague walking past, a screen share,
a screenshot pasted into a ticket.

After this change the key arrives hidden behind dots. **Copy still copies the
real key**, so it can be pasted into a client without ever being displayed, and
an eye button on the right of the field shows it for anyone who does need to
read it. The example requests hide the key the same way while still showing the
address they call, so the request stays reviewable and the key does not. Every
place Otari hands out a credential does this now: the API keys page, the setup
guide, and the master key rotation in Settings.

Nothing about how keys are issued or stored changes. This is only about what is
on the screen.

## How to test it locally

```sh
make dashboard && make dev     # gateway with the dashboard at http://localhost:8000
```

1. **API keys → Create key.** The new key reads as `••••••••••••••••`. Press
   **Copy** and paste it somewhere: you get the real `gw-…` key. Press the eye
   button on the right of the field to read it, and again to hide it.
2. The **curl** and **Python** snippets under it hide the key too, each with its
   own toggle, while the gateway address in them stays readable.
3. **Settings → Credential security → Regenerate.** The replacement master key
   behaves the same way. (Offered only when the master key was generated at
   first run; with `OTARI_MASTER_KEY` set, rotation is refused as before.)

Automated:

```sh
pnpm --dir web test src/shared/components/actions/CopyField.test.tsx
pnpm --dir web run e2e          # the onboarding project covers the setup-guide key
```

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2111

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Dashboard-only change. `pnpm --dir web run lint`, `run typecheck` and `test`
(4152 tests) are green, the `onboarding` e2e project passes locally, and
`make lint` passes untouched.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
