### PR TITLE
docs(pr-template): ask for plain English and local test steps

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,13 @@
 ## Description
-<!-- What does this PR do and why? -->
+<!-- In plain English, for a reader with no context on this area: what changes
+     for someone using Otari, and why. A few sentences. Skip the file paths and
+     the class names; the diff and the commits carry those. -->
+
+
+## How to test it locally
+<!-- The steps a reviewer follows to see the change work: what to run, where to
+     look, what they should see. Name the automated checks that cover it too, so
+     a reviewer knows what is already proven and what is left to eyeball. -->
 
 
 ## PR Type

--- a/.github/skills/pr-cycle/SKILL.md
+++ b/.github/skills/pr-cycle/SKILL.md
@@ -43,8 +43,12 @@ artifacts.
    because the repo squash-merges and git-cliff parses that title into the changelog. Keep the
    template's `## PR Type`, `## Checklist` and `## AI Usage` sections: `pr-template-check.yml`
    fails and labels the PR `missing-template` if any of the three is absent. Fill in AI Usage
-   honestly, including the AI-agent checkbox. No labels are required here. No em dashes in the
-   description (repo prose rule). Default to opening **ready for review**; open a **draft** only
+   honestly, including the AI-agent checkbox. Two further sections are expected on every PR
+   and are gated by nobody, which makes them the ones an agent drops: `## Description` in
+   plain English for a reader with no context on the area (what changes for someone using
+   Otari, and why, no file paths), and `## How to test it locally` with the steps a reviewer
+   runs plus the automated checks that already cover it. No labels are required here. No em
+   dashes in the description (repo prose rule). Default to opening **ready for review**; open a **draft** only
    if the user asked to see it first (confirm which if unsure).
 8. **Self-review.** Invoke the [`review`](../review/SKILL.md) skill on your own PR before anyone
    else reads it. Apply what is valid and push; skip nits that fight the repo's conventions, and


### PR DESCRIPTION
## Description

A PR here can currently be understood only by someone who already knows the area
it touches. The form asks "what does this PR do and why?", which in practice
gets answered in implementation terms, and it never asks how to actually try the
change, so a reviewer works that out themselves.

The template now asks for two things: what the PR does in plain English (what
changes for someone using Otari, and why), and how to test it locally (what to
run, where to look, what to expect, and which automated checks already cover
it).

Prompts only, no new gate. `pr-template-check.yml` keeps checking exactly the
three sections it checked before, so no open PR gets flagged for the two new
headings.

## How to test it locally

Open a PR against a branch of your own and look at the pre-filled body: the two
new headings are there, above **PR Type**, with the guidance in HTML comments.
Or read the file:

```sh
cat .github/pull_request_template.md
```

The template check is unchanged, which is what keeps this safe. `check-template`
passing on this very PR is the proof, since this PR's own body carries the new
sections and the old three.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2115

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Template and skill text only, no code. `pr-cycle`'s step 7 now names both
sections, since nothing gates them and they are the ones an agent drops.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
