### PR TITLE
fix(dashboard): stop every catalog story querying the real gateway

### DIFF
--- a/web/.storybook/apiMock.tsx
+++ b/web/.storybook/apiMock.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import type { Decorator } from "@storybook/react-vite"
 
+import { type ApiMocks, pathOf, route } from "./apiRouting"
+
 /**
  * A stub gateway for the stories whose component fetches its own data.
  *
@@ -26,7 +28,7 @@ import type { Decorator } from "@storybook/react-vite"
  *   parameters: {
  *     api: {
  *       "/v1/settings/mail": { configured: true, from_address: "otari@example.com" },
- *       "/v1/organization/context": organizationContext(),
+ *       "/v1/organizations/me": organizationContext(),
  *     },
  *   }
  *
@@ -47,17 +49,6 @@ import type { Decorator } from "@storybook/react-vite"
  * helper it needs no import -- which matters, because a story lives under `src/`
  * and importing out of this directory would pull it into the app's tsconfig.
  */
-export interface MockFailure {
-  $status: number
-  $body?: unknown
-}
-
-export type ApiMocks = Record<string, unknown>
-
-function isMockFailure(value: unknown): value is MockFailure {
-  return typeof value === "object" && value !== null && "$status" in value
-}
-
 /**
  * The mock tables of every story currently on screen.
  *
@@ -73,19 +64,6 @@ const mounted = new Set<ApiMocks>()
 // later would read the stub.
 const realFetch: typeof fetch = globalThis.fetch.bind(globalThis)
 
-/** Match the whole path first, then its pathname. */
-function lookup(mocks: ApiMocks, path: string): unknown {
-  if (path in mocks) return mocks[path]
-  const pathname = path.split("?")[0]
-  return pathname in mocks ? mocks[pathname] : undefined
-}
-
-function pathOf(input: RequestInfo | URL): string {
-  if (typeof input === "string") return input
-  if (input instanceof URL) return input.pathname + input.search
-  return input.url
-}
-
 function jsonResponse(status: number, body: unknown): Response {
   if (status === 204) return new Response(null, { status })
   return new Response(JSON.stringify(body ?? null), {
@@ -97,28 +75,13 @@ function jsonResponse(status: number, body: unknown): Response {
 // Installed once at module scope, not per story. Patching inside the decorator
 // would reassign on every render, and the second pass would capture the stub as
 // the "real" fetch and never be able to restore it.
+//
+// The decision itself is in `apiRouting.ts`, which has no side effects and is
+// unit-tested; this is only the part that has to touch `globalThis`.
 globalThis.fetch = async (input, init) => {
-  const path = pathOf(input)
-  for (const mocks of mounted) {
-    const match = lookup(mocks, path)
-    if (match === undefined) continue
-    const [status, body] = isMockFailure(match)
-      ? [match.$status, match.$body]
-      : [200, match]
-    return jsonResponse(status, body)
-  }
-
-  // Nothing declared this path. Stories with no `api` parameter register an empty
-  // table, so they land here too and reach the real network -- which is what a
-  // story of a prop-driven component wants, and what lets Storybook's own
-  // requests through.
-  if (mounted.size === 0) return realFetch(input, init)
-
-  // 501, not 404: a 404 is a real gateway answer that some components handle
-  // gracefully, which would hide the fact that a story forgot a path.
-  return jsonResponse(501, {
-    detail: `No story mock for ${path}. Add it to parameters.api.`,
-  })
+  const routed = route(pathOf(input), mounted)
+  if (routed.kind === "network") return realFetch(input, init)
+  return jsonResponse(routed.status, routed.body)
 }
 
 export const withApiMocks: Decorator = (Story, context) => {

--- a/web/.storybook/apiRouting.test.ts
+++ b/web/.storybook/apiRouting.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+
+import { type ApiMocks, pathOf, route } from "./apiRouting"
+
+describe("pathOf", () => {
+  it("normalizes every shape fetch accepts to a path and query", () => {
+    // The three cases used to be returned as they came, which is why the
+    // gateway test below could be fooled: the same path is a relative string
+    // from `apiFetch` and an absolute URL on a `Request`.
+    expect(pathOf("/v1/organizations/me")).toBe("/v1/organizations/me")
+    expect(pathOf("/v1/usage?window=7d")).toBe("/v1/usage?window=7d")
+    expect(pathOf(new URL("https://example.com/v1/usage?window=7d"))).toBe(
+      "/v1/usage?window=7d",
+    )
+    expect(pathOf(new Request("https://example.com/v1/organizations/me"))).toBe(
+      "/v1/organizations/me",
+    )
+  })
+})
+
+describe("route", () => {
+  it("sends Storybook's own requests to the network", () => {
+    // The catalog does not load otherwise: the story index, the bundle chunks
+    // and the fonts are all fetched, and none of them is the gateway's.
+    for (const path of ["/index.json", "/otari/assets/index-abc.js", "/sb-manager/runtime.js"]) {
+      expect(route(path, []), path).toEqual({ kind: "network" })
+    }
+  })
+
+  it("answers a gateway path the story declared", () => {
+    const table: ApiMocks = { "/v1/settings/mail": { configured: true } }
+    expect(route("/v1/settings/mail", [table])).toEqual({
+      kind: "response",
+      status: 200,
+      body: { configured: true },
+    })
+  })
+
+  it("reads the $status envelope as a failure rather than a body", () => {
+    const table: ApiMocks = {
+      "/v1/settings/mail": { $status: 503, $body: { detail: "No transport." } },
+    }
+    expect(route("/v1/settings/mail", [table])).toEqual({
+      kind: "response",
+      status: 503,
+      body: { detail: "No transport." },
+    })
+  })
+
+  it("matches a declared pathname when the request carries a query", () => {
+    const table: ApiMocks = { "/v1/usage": { total: 1 } }
+    expect(route("/v1/usage?window=7d", [table])).toEqual({
+      kind: "response",
+      status: 200,
+      body: { total: 1 },
+    })
+  })
+
+  it("answers what the decorators mount, with no table at all", () => {
+    // The regression this exists for. Every story is wrapped in
+    // `SelectedWorkspaceProvider`, which queries the organization, so a story
+    // that declared nothing still asks. It used to reach the network and 404.
+    const routed = route("/v1/organizations/me", [])
+    expect(routed.kind).toBe("response")
+    if (routed.kind !== "response") return
+    expect(routed.status).toBe(200)
+    expect(routed.body).toMatchObject({ organization_member_id: expect.any(String) })
+  })
+
+  it("lets a story override the baseline", () => {
+    const table: ApiMocks = {
+      "/v1/organizations/me": { $status: 403, $body: { detail: "Not a member." } },
+    }
+    expect(route("/v1/organizations/me", [table])).toEqual({
+      kind: "response",
+      status: 403,
+      body: { detail: "Not a member." },
+    })
+  })
+
+  it("answers an undeclared gateway path with 501, never the network", () => {
+    // 501 rather than 404, because a 404 is a real gateway answer that some
+    // components handle gracefully, which would hide the missing path. And
+    // never `network`: that is what put a failing request on every story.
+    const routed = route("/v1/does/not/exist", [{ "/v1/other": {} }])
+    expect(routed.kind).toBe("response")
+    if (routed.kind !== "response") return
+    expect(routed.status).toBe(501)
+    expect(routed.body).toMatchObject({ detail: expect.stringContaining("/v1/does/not/exist") })
+  })
+
+  it("takes the first table carrying the path when several are mounted", () => {
+    // An autodocs page mounts several stories at once.
+    const first: ApiMocks = { "/v1/usage": { total: 1 } }
+    const second: ApiMocks = { "/v1/usage": { total: 2 } }
+    expect(route("/v1/usage", [first, second])).toEqual({
+      kind: "response",
+      status: 200,
+      body: { total: 1 },
+    })
+  })
+})

--- a/web/.storybook/apiRouting.ts
+++ b/web/.storybook/apiRouting.ts
@@ -1,0 +1,111 @@
+import { organizationContext } from "@/tests/fixtures"
+
+/**
+ * Where a request made inside the catalog should go, decided without touching
+ * the network.
+ *
+ * Split out of `apiMock.tsx` so it can be tested: that file replaces
+ * `globalThis.fetch` at module scope, so importing it from a test would patch
+ * the test process's own fetch as a side effect of asking a question about a
+ * path. Nothing here has a side effect.
+ */
+
+/** The gateway's prefix. Everything else belongs to Storybook itself. */
+const GATEWAY_PREFIX = "/v1/"
+
+export interface MockFailure {
+  $status: number
+  $body?: unknown
+}
+
+export type ApiMocks = Record<string, unknown>
+
+export type Routed =
+  | { kind: "network" }
+  | { kind: "response"; status: number; body: unknown }
+
+function isMockFailure(value: unknown): value is MockFailure {
+  return typeof value === "object" && value !== null && "$status" in value
+}
+
+/**
+ * The gateway a story gets without asking, for what the decorators mount around
+ * it rather than what it declared.
+ *
+ * `withAppContext` wraps every story in `SelectedWorkspaceProvider`, which seeds
+ * itself from `useOrganizationContext()`. So a story about a `Divider` queries
+ * the organization, and before this existed that request found no table, fell
+ * through to the network, and 404d against whatever origin served the catalog.
+ * Every story in the published catalog did it, and the smoke run reported them
+ * clean because it dropped the whole "Failed to load resource" family.
+ *
+ * A story that cares overrides any of this through `parameters.api`, which is
+ * checked first. Keep this to what a decorator causes: a path only one component
+ * needs belongs in that component's story, where a reader can see it.
+ */
+export const BASELINE: ApiMocks = {
+  "/v1/organizations/me": organizationContext(),
+}
+
+/**
+ * The request's path and query, whatever shape the caller passed.
+ *
+ * `apiFetch` passes a relative string, which is why this used to return the
+ * three cases as they came. It normalizes now because `route` keys on the
+ * leading `/v1/`, and a `Request` carries an absolute URL: left alone, the same
+ * path would be mocked as a string and reach the network as a `Request`.
+ */
+export function pathOf(input: RequestInfo | URL): string {
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url
+  try {
+    const url = new URL(raw, globalThis.location?.origin ?? "http://localhost")
+    return url.pathname + url.search
+  } catch {
+    return raw
+  }
+}
+
+/** Match the whole path first, then its pathname. */
+function lookup(mocks: ApiMocks, path: string): unknown {
+  if (path in mocks) return mocks[path]
+  const pathname = path.split("?")[0]
+  return pathname in mocks ? mocks[pathname] : undefined
+}
+
+function responseFor(match: unknown): Routed {
+  return isMockFailure(match)
+    ? { kind: "response", status: match.$status, body: match.$body }
+    : { kind: "response", status: 200, body: match }
+}
+
+/**
+ * `tables` is the mock table of every story currently on screen, most recent
+ * first is not assumed: an autodocs page mounts several at once and the first
+ * one carrying the path wins, which is the same order the live set iterates.
+ */
+export function route(path: string, tables: Iterable<ApiMocks>): Routed {
+  // Not the gateway, so it is Storybook's own: the story index, a bundle chunk,
+  // a font. These have to reach the network or the catalog does not load.
+  if (!path.startsWith(GATEWAY_PREFIX)) return { kind: "network" }
+
+  for (const mocks of tables) {
+    const match = lookup(mocks, path)
+    if (match !== undefined) return responseFor(match)
+  }
+
+  const baseline = lookup(BASELINE, path)
+  if (baseline !== undefined) return responseFor(baseline)
+
+  // 501, not 404: a 404 is a real gateway answer that some components handle
+  // gracefully, which would hide the fact that a story forgot a path.
+  return {
+    kind: "response",
+    status: 501,
+    body: { detail: `No story mock for ${path}. Add it to parameters.api.` },
+  }
+}

--- a/web/.storybook/smoke.mjs
+++ b/web/.storybook/smoke.mjs
@@ -88,7 +88,14 @@ async function drain() {
     const onConsole = (m) => {
       if (m.type() !== "error") return
       const text = m.text().split("\n")[0]
-      if (/Failed to load resource/.test(text)) return
+      // Aborted requests only, not every failed one. This used to drop the
+      // whole "Failed to load resource" family, which is why it reported the
+      // catalog clean while every story 404d on `/v1/organizations/me`: the
+      // decorators mount a provider that queries the organization, and nothing
+      // answered it. Now that `apiMock` owns every `/v1/` path, a load failure
+      // is a real finding. The abort is still this probe's own fault, since it
+      // reuses one page across hundreds of rapid navigations.
+      if (/net::ERR_ABORTED/.test(text)) return
       if (text.trim() === "%o") return
       errors.push(text)
     }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -168,6 +168,17 @@ export default defineConfig({
     css: true,
     // Vitest owns the component tests under src/; the Playwright specs in e2e/
     // run in a real browser and must not be collected here.
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    //
+    // `.storybook/` is in the list for one file. That directory is outside every
+    // tsconfig and outside biome's includes, so nothing checked it at all, and
+    // the catalog's fetch stub turned out to be sending every story's
+    // organization query to the real network. Its routing now lives in a module
+    // with no side effects (`apiRouting.ts`) and is tested here, which is what
+    // makes that a pull request gate rather than something the main-only smoke
+    // run finds later.
+    include: [
+      "src/**/*.{test,spec}.{ts,tsx}",
+      ".storybook/**/*.{test,spec}.{ts,tsx}",
+    ],
   },
 })


### PR DESCRIPTION
## Description

Every story in the published catalog fired a live request for
`/v1/organizations/me` and got a 404. Nothing rendered wrong, but a reference
site that fails a request on every page view is confusing to anyone who opens
DevTools while using it.

`apiMock` answered an unmatched path two ways: a story that declared
`parameters.api` got a deliberate 501 naming the missing path, and a story that
declared nothing reached the real network, which is what let Storybook's own
requests through. `withAppContext` then wraps every story in
`SelectedWorkspaceProvider`, which seeds itself from `useOrganizationContext()`,
so a story about a `Divider` queried the organization and fell through.

The split is by path now rather than by whether a table was registered:

- outside `/v1/`, reach the network, which is what the story index, the bundle
  chunks and the fonts need
- under `/v1/`, answer here: the story's own table first, then a baseline for
  the paths a decorator causes, then the 501

`pathOf` normalizes rather than returning the three shapes as they came, because
the prefix test would otherwise be decided by the caller's argument type: the
same path is a relative string from `apiFetch` and an absolute URL on a
`Request`.

### Why it hid, and what stops it hiding again

Two things, both addressed:

- **`smoke.mjs` dropped the whole `Failed to load resource` family**, so it
  reported 349 stories clean over a 404 on every one. It now ignores aborted
  requests only, which is the part that really is the probe's own fault (it
  reuses one page across hundreds of rapid navigations).
- **`.storybook/` is outside every tsconfig and outside biome's includes**, so
  nothing checked that file at all. The decision moved into `apiRouting.ts`,
  which has no side effects and so can be imported by a test, where
  `apiMock.tsx` cannot: it replaces `globalThis.fetch` at module scope.
  `vite.config.ts` collects that one directory, so the nine routing tests are a
  pull request gate rather than something the main-only smoke run finds later.

### Verification

Both halves confirmed by putting the old behavior back, not just by the fix
passing:

- with the old fall-through restored, the smoke run reports console errors on
  story after story; with the fix, 349 stories in both themes render clean
- emptying the baseline fails `answers what the decorators mount, with no table
  at all`; restoring the network fall-through fails `answers an undeclared
  gateway path with 501, never the network`

`pnpm --dir web run lint`, `typecheck`, and 5195 tests across 151 files are
green, and the app build and catalog build both succeed.

### Left alone

Adding `.storybook/` to a tsconfig and to biome's includes is the larger
cleanup `.storybook/main.ts` already records as open work. This PR does not do
it: it would surface findings across the whole directory and belongs in its own
change. What it does instead is make the one file carrying logic testable.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #1021

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Two of those need a qualifier:

- **Tests**: this is a `web/` only change, so the tests are the frontend suites
  rather than `tests/unit` and `tests/integration`. Nine new tests in
  `web/.storybook/apiRouting.test.ts`, and `pnpm --dir web test` is green at
  5195 tests across 151 files.
- **Definition of Done**: `make lint` and `make typecheck` pass. `make test` is
  the Python suite and was not run: Docker is unavailable in this environment,
  so the integration suite cannot start, and no Python file changed here.
- **OpenAPI**: no API contract changed. Both committed generated artifacts
  (`web/src/client/schema.ts`, `web/src/routeTree.gen.ts`) are unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, through Claude Code.

**Any additional AI details you'd like to share:**

The agent found this while verifying the catalog deployment from #970, filed it
as #1021, and wrote this fix. The scoping decision was the repository owner's:
fix the filed issues rather than fold them into the merged PR.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented catalog stories from sending unintended `/v1/` requests to the real network.
- Added baseline API responses and clear 501 responses for undeclared API paths.
- Preserved network access for non-API Storybook requests.
- Narrowed smoke-test filtering so genuine resource failures are reported.
- Moved routing into a testable module and added routing coverage to Vitest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->