### PR TITLE
test(dashboard): gate that every design-system prop is shown by a story

### DIFF
--- a/web/src/design-system/README.md
+++ b/web/src/design-system/README.md
@@ -48,6 +48,13 @@ deliberately not built.
    only last a rule into HeroUI's DOM, with a comment saying why nothing above
    reached it.
 5. A `.stories.tsx` beside it covering each variant, each state, and both themes
-   where the tokens differ. The published catalog renders every one on each PR,
-   so a story is the component's test that it still paints.
+   where the tokens differ. **Every prop has to be passed by some story**, which
+   `src/styles/foundation.test.ts` checks: an optional prop is the one thing that
+   can fall outside the catalog without anything noticing, because the typecheck
+   is happy and the story simply never mentions it. A prop whose effect cannot be
+   put on screen goes in that gate's `CANNOT_BE_SHOWN` with the reason, rather
+   than being passed somewhere to satisfy the check.
+
+   Coverage counts across the whole catalog, not per file: `Field`'s `isInvalid`
+   is exercised by `FieldMessages.stories.tsx`, which is the right place for it.
 6. A `.test.tsx` beside it for behavior you changed.

--- a/web/src/design-system/actions/RowAction.stories.tsx
+++ b/web/src/design-system/actions/RowAction.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
 
 import { RowAction, RowActionRow } from "./RowAction"
 
@@ -88,4 +89,35 @@ export const InContext: Story = {
       ))}
     </div>
   ),
+}
+
+/**
+ * The danger ink, and the rule about when it may appear.
+ *
+ * `src/styles/dotRamp.test.ts` rejects a call site that paints it
+ * unconditionally: a table whose every row carries a red "Delete" reads as a
+ * table of problems, so the hue is spent on the armed step of a confirm rather
+ * than at rest. The prop below is bound to an armed flag, which is the only
+ * shape that gate allows and also the only one worth showing.
+ *
+ * `ConfirmRowAction` is what a row should actually reach for. This story exists
+ * because the prop is public, so the catalog owes a picture of what it does.
+ */
+export const ArmedPaintsDanger: Story = {
+  render: () => {
+    const [armed, setArmed] = useState(false)
+    return (
+      <div className="flex flex-col gap-3">
+        <RowActionRow>
+          <RowAction onPress={() => {}}>Edit</RowAction>
+          <RowAction isDanger={armed} onPress={() => setArmed(!armed)}>
+            {armed ? "Confirm remove" : "Remove"}
+          </RowAction>
+        </RowActionRow>
+        <p className="text-caption">
+          Press Remove: the ink is neutral at rest and danger once armed.
+        </p>
+      </div>
+    )
+  },
 }

--- a/web/src/design-system/actions/copy.stories.tsx
+++ b/web/src/design-system/actions/copy.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useRef } from "react"
 
 import { CopyButton } from "./CopyButton"
-import { CopyableValue, CopyField } from "./CopyField"
+import { CONCEALED_SECRET, CopyableValue, CopyField } from "./CopyField"
 
 /**
  * The three ways a value an operator has to paste elsewhere is handed over.
@@ -129,4 +130,71 @@ export const Button: Story = {
       <CopyButton value="https://gateway.example.com/v1" label="base URL" />
     </span>
   ),
+}
+
+/**
+ * `concealed` hands a credential over without putting it on screen.
+ *
+ * The plaintext reaches the DOM only once the operator asks for it, while Copy
+ * copies the real value either way. So a key can be pasted elsewhere without
+ * ever being read off the screen, which is the point: a screen share or a
+ * screenshot of this page does not leak it.
+ *
+ * `CONCEALED_SECRET` is the stand-in, and it is one fixed run rather than a
+ * bullet per character. The length of a key is itself something not to show.
+ *
+ * A snippet passes the same snippet built around the stand-in, so what is
+ * hidden is the key rather than the request that explains it.
+ */
+export const Concealed: Story = {
+  render: () => (
+    <div className="flex w-[34rem] flex-col gap-4">
+      <CopyField
+        label="API key"
+        value="sk-otari-4f8a2c9e1b7d3a6f5e0c8b2d"
+        concealed={CONCEALED_SECRET}
+      />
+      <CopyField
+        label="Example request"
+        multiline
+        value={`curl https://gateway.example.com/v1/chat/completions \\\n  -H "Authorization: Bearer sk-otari-4f8a2c9e1b7d3a6f5e0c8b2d"`}
+        concealed={`curl https://gateway.example.com/v1/chat/completions \\\n  -H "Authorization: Bearer ${CONCEALED_SECRET}"`}
+      />
+    </div>
+  ),
+}
+
+/**
+ * `fieldRef` hands the field's element to the caller, so something outside it
+ * can put the caret in the value.
+ *
+ * The Keys page uses it for the one-time reveal: the key appears and the field
+ * is selected, so Ctrl/Cmd-C works without aiming at the button. That matters
+ * because the Clipboard API is undefined on the non-secure origins this
+ * dashboard is routinely served from, which is the same reason the field
+ * selects on click.
+ */
+export const WithFieldRef: Story = {
+  render: () => {
+    const fieldRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+    return (
+      <div className="flex w-[34rem] flex-col gap-3">
+        <CopyField
+          label="API key"
+          value="sk-otari-4f8a2c9e1b7d3a6f5e0c8b2d"
+          fieldRef={fieldRef}
+        />
+        <button
+          type="button"
+          className="min-h-11 self-start border border-control-border px-3 text-body"
+          onClick={() => {
+            fieldRef.current?.focus()
+            fieldRef.current?.select()
+          }}
+        >
+          Select the value from outside the field
+        </button>
+      </div>
+    )
+  },
 }

--- a/web/src/design-system/forms/Field.stories.tsx
+++ b/web/src/design-system/forms/Field.stories.tsx
@@ -85,3 +85,16 @@ export const InForm: Story = {
     )
   },
 }
+
+/**
+ * `autoFocus` puts the caret in the field on mount, for the one field a dialog
+ * or a first-run form exists to collect. Reload the story to see it take: focus
+ * happens once, so switching to this story from another one does not repeat it.
+ *
+ * One per screen. Two fields both claiming the caret means the second wins and
+ * the first looks broken, and a page that steals focus on every render takes it
+ * away from whatever the operator was doing.
+ */
+export const AutoFocused: Story = {
+  args: { autoFocus: true, description: "The caret starts here." },
+}

--- a/web/src/design-system/layout/PageIntro.stories.tsx
+++ b/web/src/design-system/layout/PageIntro.stories.tsx
@@ -79,3 +79,35 @@ export const DocsLinkAndAction: Story = {
     action: <Button variant="primary">Create key</Button>,
   },
 }
+
+/**
+ * `descriptionClassName` overrides the description's measure, and one caller
+ * uses it: the guide, whose own prose is 560px. On the one page whose subject is
+ * the measure, the widest line should not be the scanning-size paragraph
+ * introducing it.
+ *
+ * The default measure is wider, so the two below differ only in where the
+ * sentence wraps.
+ */
+export const NarrowerDescription: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-1">
+        <span className="text-overline">default measure</span>
+        <PageIntro title="User guide">
+          A reference for operating this dashboard, bundled with and
+          version-matched to the running gateway.
+        </PageIntro>
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-overline">
+          descriptionClassName="max-w-[35rem]"
+        </span>
+        <PageIntro title="User guide" descriptionClassName="max-w-[35rem]">
+          A reference for operating this dashboard, bundled with and
+          version-matched to the running gateway.
+        </PageIntro>
+      </div>
+    </div>
+  ),
+}

--- a/web/src/design-system/metrics/charts.stories.tsx
+++ b/web/src/design-system/metrics/charts.stories.tsx
@@ -238,3 +238,43 @@ export const Tooltips: Story = {
     </div>
   ),
 }
+
+/**
+ * `xTickInterval` and `yTickCount` set the axis density, and both exist because
+ * recharts' defaults are wrong for a strip this shape.
+ *
+ * The x default is `"preserveStartEnd"`, which thins labels by pixel gap, so the
+ * density becomes a function of the window width rather than of the data: the
+ * same chart shows every other day on a wide screen and every fifth on a narrow
+ * one. A number pins it to the data instead. The y default is 5, which is more
+ * gridlines than a short strip earns.
+ *
+ * Compare the rows: same data, three densities.
+ */
+export const AxisDensity: Story = {
+  render: () => (
+    <div className="flex w-[48rem] flex-col gap-6">
+      {(
+        [
+          ["recharts' defaults", undefined, undefined],
+          ["xTickInterval 1, yTickCount 3", 1, 3],
+          ["xTickInterval 6, yTickCount 2", 6, 2],
+        ] as const
+      ).map(([label, xTickInterval, yTickCount]) => (
+        <div key={label} className="flex flex-col gap-1">
+          <span className="text-overline">{label}</span>
+          <TrendChart
+            data={STACK}
+            series={STACK_SERIES}
+            formatValue={count}
+            formatXTick={day}
+            ariaLabel={`Requests per day, ${label}`}
+            showYAxis
+            xTickInterval={xTickInterval}
+            yTickCount={yTickCount}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/web/src/design-system/navigation/FilterMultiComboBox.stories.tsx
+++ b/web/src/design-system/navigation/FilterMultiComboBox.stories.tsx
@@ -154,3 +154,35 @@ export const LargeOptionList: Story = {
     )
   },
 }
+
+/**
+ * `maxVisible` caps how many options the list renders, defaulting to 50.
+ *
+ * The cap is why this control can sit on a page listing thousands of models: it
+ * narrows as you type rather than rendering the catalog. Set low here so the cap
+ * is visible with a list short enough to count. Type to narrow past it.
+ */
+export const CappedList: Story = {
+  render: () => {
+    const [values, setValues] = useState<string[]>([])
+    const options = Array.from({ length: 40 }, (_, index) => ({
+      value: `model-${index}`,
+      label: `provider:model-${String(index).padStart(2, "0")}`,
+    }))
+    return (
+      <div className="flex w-[26rem] flex-col gap-2">
+        <FilterMultiComboBox
+          label="Models"
+          values={values}
+          onChange={setValues}
+          options={options}
+          maxVisible={5}
+        />
+        <p className="text-caption">
+          40 options, maxVisible 5. The list shows five until the query narrows
+          it.
+        </p>
+      </div>
+    )
+  },
+}

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1671,3 +1671,99 @@ describe("buttons come in three variants", () => {
     ).toEqual([])
   })
 })
+
+// Every prop of every design-system component is passed by some story.
+//
+// The catalog's claim is that it shows a component's variants and options, and
+// an optional prop is the one thing that can quietly fall outside it: `tsc` is
+// happy, the smoke run renders every story clean, and the story simply never
+// mentions the prop. #970 hit that three times in one rebase (`bounded`, and
+// `docsHref` on two components), each found by reading rather than by a check.
+//
+// Coverage is measured across the WHOLE catalog rather than per file. `Field`'s
+// `isInvalid` is exercised by `FieldMessages.stories.tsx`, which is the right
+// place for it, and a per-file rule would call that a gap.
+describe("the catalog shows every prop", () => {
+  const DS = join(WEB, "src", "design-system")
+
+  /**
+   * Props whose effect cannot be put on screen, each with the reason.
+   *
+   * Passing one in a story to satisfy a checker teaches a reader nothing, so
+   * these are named here instead. Keep it short: a prop lands here only when a
+   * story genuinely cannot show what it does, not when writing one is awkward.
+   */
+  const CANNOT_BE_SHOWN: Record<string, string> = {
+    "actions/CopyButton.selectOnFailure":
+      "the fallback for a refused clipboard write, which a story cannot provoke without breaking the clipboard",
+  }
+
+  // Not props: the first two are every component's, and a leading underscore is
+  // this tree's mark for a parameter destructured only to keep it off the DOM.
+  const NOT_A_PROP = new Set(["children", "className", "ref"])
+
+  function withoutComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "")
+  }
+
+  /** A component's props, from its destructured parameters and its Props type. */
+  function propsOf(source: string): Set<string> {
+    const bare = withoutComments(source)
+    const names = new Set<string>()
+    for (const match of bare.matchAll(
+      /export (?:function|const) \w+(?:<[^>]*>)?\(\{([^}]*)\}/g,
+    )) {
+      for (const token of match[1].matchAll(/(?:^|,)\s*([a-zA-Z_]\w*)/g)) {
+        names.add(token[1])
+      }
+    }
+    for (const match of bare.matchAll(
+      /(?:interface|type) \w*Props\w*\s*(?:=\s*)?\{([^}]*)\}/g,
+    )) {
+      for (const token of match[1].matchAll(/^\s*([a-zA-Z_]\w*)\??\s*:/gm)) {
+        names.add(token[1])
+      }
+    }
+    for (const name of [...names]) {
+      if (NOT_A_PROP.has(name) || name.startsWith("_")) names.delete(name)
+    }
+    return names
+  }
+
+  const stories = walk(DS)
+    .filter((name) => name.endsWith(".stories.tsx"))
+    .map((name) => readFileSync(join(DS, name), "utf8"))
+    .join("\n")
+
+  const components = walk(DS).filter(
+    (name) =>
+      name.endsWith(".tsx") &&
+      !name.endsWith(".test.tsx") &&
+      !name.endsWith(".stories.tsx"),
+  )
+
+  it("covers the layer and its catalog", () => {
+    expect(components.length).toBeGreaterThan(40)
+    expect(stories.length).toBeGreaterThan(10_000)
+  })
+
+  it.each(components)("shows every prop of %s", (name) => {
+    const source = readFileSync(join(DS, name), "utf8")
+    const module = name.replace(/\.tsx$/, "")
+    const missing = [...propsOf(source)]
+      .filter((prop) => CANNOT_BE_SHOWN[`${module}.${prop}`] === undefined)
+      .filter((prop) => {
+        // `prop=` or `prop:` for a value, and bare `prop` for JSX boolean
+        // shorthand, which is how the stories pass `bounded` and `nested`.
+        const assigned = new RegExp(`\\b${prop}\\s*[=:]`)
+        const shorthand = new RegExp(`\\b${prop}\\s*(?:/?>|\\n)`)
+        return !assigned.test(stories) && !shorthand.test(stories)
+      })
+      .sort()
+
+    expect(
+      missing,
+      `no story passes ${missing.map((p) => `\`${p}\``).join(", ")} on ${module}. Add one, or name it in CANNOT_BE_SHOWN with the reason.`,
+    ).toEqual([])
+  })
+})

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1717,10 +1717,21 @@ describe("the catalog shows every prop", () => {
         names.add(token[1])
       }
     }
-    for (const match of bare.matchAll(
-      /(?:interface|type) \w*Props\w*\s*(?:=\s*)?\{([^}]*)\}/g,
-    )) {
-      for (const token of match[1].matchAll(/^\s*([a-zA-Z_]\w*)\??\s*:/gm)) {
+    // The Props declaration, read as a block rather than as a `{ ... }` right
+    // after the name. `Button`'s is `Omit<HeroButtonProps, …> & { … }`, so a
+    // pattern anchored on the brace missed `size`, which is declared there and
+    // forwarded through `...rest` without ever being destructured. Two props in
+    // the whole layer are only visible this way, and the canary above is what
+    // keeps that true.
+    //
+    // Line-anchored on purpose: a member of a nested object type is written
+    // inline here (`options: { value: string; label: string }[]`), so it cannot
+    // match and this stays free of the false positives a greedier read invites.
+    for (const match of bare.matchAll(/(?:interface|type)\s+\w*Props\w*\b/g)) {
+      const tail = bare.slice(match.index + match[0].length)
+      const stop = /\n(?:export|function|const|type|interface)\b/.exec(tail)
+      const block = stop ? tail.slice(0, stop.index) : tail
+      for (const token of block.matchAll(/^\s{2,}([a-zA-Z_]\w*)\??\s*:/gm)) {
         names.add(token[1])
       }
     }
@@ -1745,6 +1756,27 @@ describe("the catalog shows every prop", () => {
   it("covers the layer and its catalog", () => {
     expect(components.length).toBeGreaterThan(40)
     expect(stories.length).toBeGreaterThan(10_000)
+
+    // A guard on the extractor, not on the layer. The rule below asserts only
+    // that a list of missing props is empty, so a regex that stopped matching a
+    // component shape would report every prop as covered and pass. Five
+    // components legitimately yield nothing (their only props are `children` or
+    // `className`), so a per-component floor is wrong; the total is what says
+    // the extractor still works.
+    const extracted = components.reduce(
+      (total, name) =>
+        total + propsOf(readFileSync(join(DS, name), "utf8")).size,
+      0,
+    )
+    expect(extracted).toBeGreaterThan(200)
+
+    // And a canary with known props, so a shape this file reads today cannot
+    // silently stop being read. `Button` is `Omit<HeroButtonProps, …> & { … }`,
+    // which is the least regex-friendly declaration in the layer.
+    const button = propsOf(
+      readFileSync(join(DS, "actions", "Button.tsx"), "utf8"),
+    )
+    expect([...button].sort()).toEqual(["size", "variant"])
   })
 
   it.each(components)("shows every prop of %s", (name) => {


### PR DESCRIPTION
## Description

The catalog's claim is that it shows a component's variants and options, and an
optional prop is the one thing that could fall outside it without anything
noticing: the typecheck is happy, the smoke run renders every story clean, and
the story simply never mentions the prop. #970 hit that three times in one
rebase (`bounded`, and `docsHref` on two components), each found by reading
rather than by a check.

So the gate is the point of this PR and the eight stories are what it demanded.

### The gate

It reads each component's props from its destructured parameters and its `Props`
type, then asks whether any story in the catalog passes each one. Three
decisions in it are worth stating, because each one was a false positive in an
earlier draft:

- **Coverage counts across the whole catalog, not per file.** `Field`'s
  `isInvalid` is exercised by `FieldMessages.stories.tsx`, which is the right
  place for it, and a per-file rule would call that a gap.
- **JSX boolean shorthand counts.** The stories pass `bounded` and `nested` as
  `<SettingRow nested>`, with no `=`.
- **A prop whose effect cannot be shown is named, not passed.**
  `CopyButton.selectOnFailure` is the fallback for a refused clipboard write,
  which a story cannot provoke without breaking the clipboard, so it is in
  `CANNOT_BE_SHOWN` with that reason. Passing it somewhere to satisfy a checker
  would teach a reader nothing.

It reports 3041 assertions and found exactly the eight props with no false
positives across the rest of the layer.

### The eight stories

Three are worth calling out:

- **`concealed` on `CopyField`** is what #1016 exists for: handing a credential
  over without putting it on screen, so a screen share or a screenshot of the
  page does not leak it. The catalog only showed the revealed state. The story
  covers both the whole-value field and a snippet built around the stand-in.
- **`isDanger` on `RowAction`** is bound to an armed flag, which is the only
  shape `src/styles/dotRamp.test.ts` allows and also the only one worth showing:
  a table whose every row carries a red "Delete" reads as a table of problems,
  so the hue belongs on the armed step. That gate passes on the new story.
- **`xTickInterval` and `yTickCount` on the charts** exist because recharts'
  x default thins labels by pixel gap, so density becomes a function of the
  window width rather than of the data. The story puts three densities side by
  side.

The rest are `fieldRef` on `CopyField`, `autoFocus` on `Field`,
`descriptionClassName` on `PageIntro`, and `maxVisible` on
`FilterMultiComboBox`.

`src/design-system/README.md` states the new rule where it already stated the
story requirement.

### Verification

`pnpm --dir web run lint`, `typecheck`, and 5251 tests across 150 files are
green. The app build succeeds, and all 356 stories render clean in both themes
through the same path CI uses (up from 349).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #1020

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Two need a qualifier:

- **Tests**: this is a `web/` only change, so the tests are the frontend suites
  rather than `tests/unit` and `tests/integration`. The gate itself is the test
  added here, and `pnpm --dir web test` is green at 5251 tests across 150 files.
- **Definition of Done**: `make lint` and `make typecheck` pass. `make test` is
  the Python suite and was not run: Docker is unavailable in this environment,
  so the integration suite cannot start, and no Python file changed here.
- **OpenAPI**: no API contract changed. Both committed generated artifacts are
  unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, through Claude Code.

**Any additional AI details you'd like to share:**

The agent hit this class of miss three times while rebasing #970, filed it as
#1020 arguing for a gate over the individual stories, and wrote both here. The
scoping decision was the repository owner's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added catalog stories for eight previously uncovered component props.
- Added a test gate that checks prop coverage across all design-system stories.
- Documented coverage requirements and supported exceptions.
- Improved catalog visibility for concealed fields, danger actions, focus behavior, chart settings, and option limits.

## Technical notes

- The gate supports JSX boolean shorthand.
- `CANNOT_BE_SHOWN` requires a documented reason.
- Validation passed for lint, typecheck, tests, and build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->