### PR TITLE
fix(dashboard): keep the measuring harness out of the published catalog

### DIFF
--- a/web/.storybook/README.md
+++ b/web/.storybook/README.md
@@ -66,6 +66,14 @@ Three traps it was written around, all worth keeping:
 - `main.ts`: story glob, the `viteFinal` that strips the TanStack Router plugins
   so a Storybook run can never rewrite `src/routeTree.gen.ts`, and the
   `STORYBOOK_BASE_PATH` seam.
+- `harness/`: measuring harnesses, which are **not** catalog entries. Each
+  renders a component in every context some stylesheet rule targets so a script
+  can read the computed geometry before and after a change. They are outside
+  `../src/**` on purpose, because that is the only reliable way to keep them out
+  of the published catalog: **Storybook ignores a `!` pattern in the `stories`
+  array**, so an earlier attempt to exclude one that way published it to the live
+  site. Opt in with `STORYBOOK_HARNESS=1`.
+  `__tableGeometry.mjs` is the reader for the one that exists.
 - `preview.tsx`: imports `globals.css` (the whole design system) and composes
   the decorators. Note the order: innermost first.
 - `theme.tsx`: the light/dark toolbar, writing the same three properties on

--- a/web/.storybook/__tableGeometry.mjs
+++ b/web/.storybook/__tableGeometry.mjs
@@ -6,13 +6,13 @@
 // what the screenshot suite would give if it were a gate (it is
 // workflow-dispatch only, with gitignored baselines).
 //
-//   pnpm --dir web run storybook                      # dev server on :6006
+//   STORYBOOK_HARNESS=1 pnpm --dir web run storybook   # dev server on :6006
 //   pnpm --dir web exec node .storybook/__tableGeometry.mjs > before.json
 //   ...edit src/styles/globals.css...
 //   pnpm --dir web exec node .storybook/__tableGeometry.mjs > after.json
 //   diff <(jq -S . before.json) <(jq -S . after.json)
 //
-// It reads `_TableGeometry.stories.tsx`, which renders `DataTable` inside every
+// It reads `harness/TableGeometry.stories.tsx`, which renders `DataTable` inside every
 // wrapper class the stylesheet targets plus one with no wrapper at all. The
 // contexts and their column ids are derived from globals.css rather than
 // transcribed from the feature files, so it measures what the CSS reaches.

--- a/web/.storybook/harness/TableGeometry.stories.tsx
+++ b/web/.storybook/harness/TableGeometry.stories.tsx
@@ -1,13 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { TableScrollFrame } from "../layout/TableScrollFrame"
-import { DataTable, type DataTableColumn } from "./DataTable"
+import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
+import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 
 /**
  * A measurement harness, not a catalog entry.
  *
- * The `_` prefix is what keeps it out of the published catalog: `main.ts`'s
- * story glob excludes `_*.stories.tsx`. Its reader is
+ * It lives here rather than under `src/` because that is what keeps it out of
+ * the published catalog: `main.ts`'s default glob covers `../src/**` only, and
+ * this directory is added to it just for `STORYBOOK_HARNESS=1`. An earlier
+ * version sat in `src/` and tried to exclude itself with a `!` pattern, which
+ * Storybook ignores, so it published. Its reader is
  * `.storybook/__tableGeometry.mjs`, which renders this one story and reports the
  * computed geometry of every lane; run it before and after a change to table
  * CSS and diff the two, which is the check the screenshot suite would give if it

--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -43,14 +43,24 @@ function withoutTanstackPlugins(plugins: PluginOption[]): PluginOption[] {
 }
 
 const config: StorybookConfig = {
-  // A `_`-prefixed story file is a measuring harness rather than a catalog
-  // entry: it renders a component in every context some stylesheet rule
-  // targets, so a script can read the computed geometry before and after a
-  // change. Excluded here so it does not publish, which also keeps it out of
-  // the smoke run; see `__tableGeometry.mjs` for the one that exists.
+  // The catalog, plus the measuring harness when it is asked for.
+  //
+  // A harness renders a component in every context some stylesheet rule targets
+  // so a script can read the computed geometry before and after a change. It is
+  // not a catalog entry, and it used to try to say so with a `!` pattern in this
+  // array. **Storybook does not support negation here**: the entry was ignored
+  // and `Zz-measure/TableGeometry` published to the live site, in the sidebar,
+  // for anyone reading the design system to trip over.
+  //
+  // So the harness sits outside `../src/**` instead, where the default glob
+  // cannot reach it, and is opted into by an environment variable. That also
+  // keeps it out of the smoke run, which is what a harness wants: it renders one
+  // enormous story whose only reader is a script.
+  //
+  //   STORYBOOK_HARNESS=1 pnpm --dir web run storybook
   stories: [
     "../src/**/*.stories.tsx",
-    "!../src/**/_*.stories.tsx",
+    ...(process.env.STORYBOOK_HARNESS ? ["./harness/*.stories.tsx"] : []),
   ],
   addons: ["@storybook/addon-docs"],
   framework: { name: "@storybook/react-vite", options: {} },


### PR DESCRIPTION
## Description

`Zz-measure/TableGeometry` is visible in the published catalog's sidebar, on the
live site, for anyone reading the design system to trip over.

It is a measuring harness: one enormous story that renders `DataTable` inside
every context the stylesheet targets, so `.storybook/__tableGeometry.mjs` can
read the computed geometry before and after a change to table CSS. It has no
business in a catalog.

It tried to say so with a negated pattern in `main.ts`:

```ts
stories: [
  "../src/**/*.stories.tsx",
  "!../src/**/_*.stories.tsx",   // does nothing
],
```

**Storybook does not support negation in the `stories` array.** The entry was
ignored and the file was collected like any other story. Neither the build nor
the smoke run had anything to say about it, because from their point of view it
is a story that renders.

So the harness sits outside `../src/**` now, in `.storybook/harness/`, where the
default glob cannot reach it, and is opted into with an environment variable:

```ts
stories: [
  "../src/**/*.stories.tsx",
  ...(process.env.STORYBOOK_HARNESS ? ["./harness/*.stories.tsx"] : []),
],
```

That is not a second mechanism to remember. It is the absence of one, which is
what makes it reliable.

### Verification

Both directions, not just the fix:

- the default build has **348** entries and none is the harness (it had 349)
- `STORYBOOK_HARNESS=1` gives **349** with the harness present, and
  `__tableGeometry.mjs` still reads it: 15 contexts across 6 viewport and theme
  combinations, with lane widths matching the CSS
- 348 stories render clean in both themes, and the app build, lint, typecheck
  and 5176 tests are green

### One consequence worth knowing

The harness is now outside `src/`, so it is no longer typechecked, linted, or
swept by the token gates in `src/styles/foundation.test.ts`. That is the same
state the rest of `.storybook/` is already in, which `main.ts`'s own docstring
records as open work. For an instrument whose only reader is a script, it is the
right trade against publishing it; a component would not be.

I confirmed this does not interact with #1023, which adds a gate that reads the
story corpus: that gate passes with the harness absent from `src/design-system`.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed. Found from a screenshot of the published catalog after #970 merged.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Three need a qualifier:

- **Tests**: no test added, and the honest reason is that the thing to assert is
  a Storybook config behavior. The check that would catch a regression is
  "the built index contains no harness entry", which needs a catalog build, so it
  belongs to the `catalog` CI job rather than to Vitest. Verified by hand in both
  directions, with the entry counts above. Happy to add it to the workflow as a
  grep over `storybook-static/index.json` if a reviewer wants it gated.
- **Definition of Done**: `make lint` and `make typecheck` pass. `make test` is
  the Python suite and was not run: Docker is unavailable in this environment,
  so the integration suite cannot start, and no Python file changed here.
- **OpenAPI**: no API contract changed. Both committed generated artifacts are
  unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, through Claude Code.

**Any additional AI details you'd like to share:**

The agent wrote the broken negated glob in #970 and this fixes it. The
repository owner spotted the harness in the published sidebar from a screenshot,
which is what prompted looking.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
