### PR TITLE
test(dashboard): bind a prop's coverage to its own component's stories

### DIFF
--- a/web/src/design-system/actions/copy.stories.tsx
+++ b/web/src/design-system/actions/copy.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useRef } from "react"
 
+import { Button as ActionButton } from "./Button"
 import { CopyButton } from "./CopyButton"
 import { CONCEALED_SECRET, CopyableValue, CopyField } from "./CopyField"
 
@@ -197,4 +198,29 @@ export const WithFieldRef: Story = {
       </div>
     )
   },
+}
+
+/**
+ * `action` puts a control beside the field, which moves the copy affordance
+ * inside the field and drops the button from the label row. It is the
+ * arrangement a value comes in when the operator has something to do with it
+ * once pasted: paste the record, then press Verify.
+ *
+ * Typed `ReactElement` rather than `ReactNode`, because the latter admits
+ * `false`: `action={enabled && <Button />}` compiled and then silently fell
+ * back to the default arrangement, which is the one this exists to replace.
+ * It is also excluded from `multiline` at the type level, since the right
+ * padding an in-field control needs indents every line of a textarea instead
+ * of making room on the first.
+ */
+export const FieldWithAction: Story = {
+  render: () => (
+    <div className="w-[48rem]">
+      <CopyField
+        label="Copy TXT record for example.com"
+        value="otari-verify=9f3c1a7b4e2d8065af13c9b27d4e5f60"
+        action={<ActionButton variant="primary">Verify</ActionButton>}
+      />
+    </div>
+  ),
 }

--- a/web/src/design-system/forms/Checkbox.stories.tsx
+++ b/web/src/design-system/forms/Checkbox.stories.tsx
@@ -107,3 +107,39 @@ export const Visuals: Story = {
     </div>
   ),
 }
+
+/**
+ * `ariaLabel` when the visible label alone does not say which control it is.
+ *
+ * These three read "Allowed" on screen, which is all a column heading needs;
+ * spoken on its own it names nothing. The accessible name keeps the visible
+ * text inside it, so speech input still reaches the control by what is written
+ * on it.
+ */
+export const NamedForScreenReaders: Story = {
+  render: () => {
+    const [allowed, setAllowed] = useState<string[]>(["staging"])
+    return (
+      <div className="flex flex-col gap-3">
+        {["production", "staging", "sandbox"].map((workspace) => (
+          <span key={workspace} className="flex items-center gap-3">
+            <span className="w-24 text-caption">{workspace}</span>
+            <Checkbox
+              isSelected={allowed.includes(workspace)}
+              onChange={(on) =>
+                setAllowed((current) =>
+                  on
+                    ? [...current, workspace]
+                    : current.filter((name) => name !== workspace),
+                )
+              }
+              ariaLabel={`Allowed in ${workspace}`}
+            >
+              Allowed
+            </Checkbox>
+          </span>
+        ))}
+      </div>
+    )
+  },
+}

--- a/web/src/design-system/forms/Field.stories.tsx
+++ b/web/src/design-system/forms/Field.stories.tsx
@@ -98,3 +98,17 @@ export const InForm: Story = {
 export const AutoFocused: Story = {
   args: { autoFocus: true, description: "The caret starts here." },
 }
+
+/**
+ * `isDisabled` for a field the operator may read but not set: a value the
+ * deployment fixes, or one that belongs to a plan they are not on. It stays in
+ * the tab order's reading path but takes no input, which is why the value is
+ * left legible rather than dimmed to the point of being unreadable.
+ */
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+    value: "gateway-managed",
+    description: "Set by the deployment, not per workspace.",
+  },
+}

--- a/web/src/design-system/forms/FieldMessages.stories.tsx
+++ b/web/src/design-system/forms/FieldMessages.stories.tsx
@@ -94,3 +94,32 @@ export const ControlFieldRig: Story = {
     </div>
   ),
 }
+
+/**
+ * `reserve={false}` for a field that will never speak: one in a table row or a
+ * toolbar. Holding a line open under each of those would put a band of empty
+ * space through every row.
+ *
+ * The two rows below carry the same message slot. Only the first pays for it.
+ */
+export const WithoutReserve: Story = {
+  render: () => (
+    <div className="flex w-96 flex-col gap-6">
+      {[true, false].map((reserve) => (
+        <div key={String(reserve)} className="flex flex-col gap-1">
+          <span className="text-overline">
+            reserve {reserve ? "on" : "off"}
+          </span>
+          <div className="divide-y divide-border border border-border">
+            {["staging", "sandbox"].map((row) => (
+              <div key={row} className="px-3 py-2">
+                <span className="text-body">{row}</span>
+                <FieldMessages reserve={reserve}>{null}</FieldMessages>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/web/src/design-system/forms/RadioGroup.stories.tsx
+++ b/web/src/design-system/forms/RadioGroup.stories.tsx
@@ -115,3 +115,11 @@ export const Invalid: Story = {
     className: "w-96",
   },
 }
+
+/**
+ * `isRequired` marks the group through HeroUI's own `[data-required]` rule, so
+ * the mark lands on the group's label rather than on any one option.
+ */
+export const Required: Story = {
+  args: { value: "", isRequired: true, className: "w-96" },
+}

--- a/web/src/design-system/forms/SecretField.stories.tsx
+++ b/web/src/design-system/forms/SecretField.stories.tsx
@@ -53,3 +53,29 @@ export const WithValue: Story = {
     )
   },
 }
+
+/**
+ * `isInvalid` is what makes `errorMessage` render, on this field as on every
+ * other one here: the message is not shown by its presence alone, so a form
+ * holding a stale message cannot flash it while the value is being fixed.
+ *
+ * The message replaces the description rather than adding a row, and
+ * `reserveMessage` holds that line open so the form does not move when it
+ * appears.
+ */
+export const Invalid: Story = {
+  render: () => {
+    const [value, setValue] = useState("hunter2")
+    return (
+      <SecretField
+        label="OpenAI API key"
+        value={value}
+        onChange={setValue}
+        description="Stored encrypted. It is never shown again after saving."
+        isInvalid={!value.startsWith("sk-")}
+        errorMessage="An OpenAI key starts with sk-."
+        reserveMessage
+      />
+    )
+  },
+}

--- a/web/src/design-system/forms/Select.stories.tsx
+++ b/web/src/design-system/forms/Select.stories.tsx
@@ -84,3 +84,20 @@ export const UnknownValue: Story = {
 }
 
 export const Disabled: Story = { args: { isDisabled: true, className: "w-72" } }
+
+/**
+ * `isRequired` marks the field through HeroUI's own `[data-required]` rule, so
+ * nothing here spells the asterisk out; writing one renders two.
+ *
+ * `placeholder` is what the trigger says while nothing is selected, and it is
+ * an example rather than a restatement of the label. The default reads "Select
+ * an option", which is what an unset field with nothing better to say shows.
+ */
+export const Required: Story = {
+  args: {
+    value: "",
+    isRequired: true,
+    placeholder: "Pick how failures are routed",
+    className: "w-72",
+  },
+}

--- a/web/src/design-system/forms/TextArea.stories.tsx
+++ b/web/src/design-system/forms/TextArea.stories.tsx
@@ -76,3 +76,16 @@ export const Disabled: Story = {
     className: "w-96",
   },
 }
+
+/**
+ * `isRequired` marks the field through HeroUI's own `[data-required]` rule.
+ * No manual asterisk: writing one renders two.
+ */
+export const Required: Story = {
+  args: {
+    value: "",
+    isRequired: true,
+    placeholder: "One host per line",
+    className: "w-96",
+  },
+}

--- a/web/src/design-system/metrics/KpiStrip.stories.tsx
+++ b/web/src/design-system/metrics/KpiStrip.stories.tsx
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   render: () => (
-    <KpiStrip empty={false}>
+    <KpiStrip empty={false} columns={4}>
       <KpiCell label="Spend" value="$412.08" subline="This month" />
       <KpiCell label="Requests" value="1,284,901" subline="This month" />
       <KpiCell label="Tokens" value="94.2M" subline="This month" />
@@ -46,7 +46,7 @@ export const Default: Story = {
  */
 export const WithDeltaAndGraphic: Story = {
   render: () => (
-    <KpiStrip empty={false}>
+    <KpiStrip empty={false} columns={4}>
       <KpiCell
         label="Spend"
         value="$412.08"
@@ -81,7 +81,7 @@ export const WithDeltaAndGraphic: Story = {
  */
 export const WithSeverity: Story = {
   render: () => (
-    <KpiStrip empty={false}>
+    <KpiStrip empty={false} columns={4}>
       <KpiCell
         label="Budget"
         value="$1,041.20"
@@ -112,11 +112,29 @@ export const WithSeverity: Story = {
  */
 export const Empty: Story = {
   render: () => (
-    <KpiStrip empty>
+    <KpiStrip empty columns={4}>
       <KpiCell label="Spend" value="—" subline="No requests yet" />
       <KpiCell label="Requests" value="—" subline="No requests yet" />
       <KpiCell label="Tokens" value="—" subline="No requests yet" />
       <KpiCell label="Errors" value="—" subline="No requests yet" />
+    </KpiStrip>
+  ),
+}
+
+/**
+ * `columns` is the number of cells the caller passes, not a layout preference.
+ * The four stories above pass `columns={4}` for that reason: left at the
+ * default 5, a strip of four cells lays a fifth track and ends the row on a
+ * blank column. Five is the default because that is what Usage opens with.
+ */
+export const FiveColumns: Story = {
+  render: () => (
+    <KpiStrip empty={false} columns={5}>
+      <KpiCell label="Spend" value="$412.08" subline="This month" />
+      <KpiCell label="Requests" value="1,284,901" subline="This month" />
+      <KpiCell label="Tokens" value="94.2M" subline="This month" />
+      <KpiCell label="Errors" value="0.4%" subline="This month" />
+      <KpiCell label="Latency (p95)" value="812ms" subline="This month" />
     </KpiStrip>
   ),
 }

--- a/web/src/design-system/metrics/charts.stories.tsx
+++ b/web/src/design-system/metrics/charts.stories.tsx
@@ -278,3 +278,44 @@ export const AxisDensity: Story = {
     </div>
   ),
 }
+
+/**
+ * `height` on both, and it is the one dimension a chart takes as a number
+ * rather than from its parent. `ResponsiveContainer` measures the width and is
+ * told the height, so a chart in an unsized box collapses horizontally but
+ * never vertically.
+ *
+ * `TrendChart` defaults to 200, which is where the axis labels and the plot
+ * both have room. Below roughly 120 the y ticks start colliding, so a shorter
+ * strip wants `showYAxis={false}` with it. `Sparkline` defaults to 32: at that
+ * height there is nothing to label, which is why it takes bare numbers.
+ */
+export const Heights: Story = {
+  render: () => (
+    <div className="flex w-[40rem] flex-col gap-6">
+      {[120, 200, 320].map((height) => (
+        <div key={height} className="flex flex-col gap-1">
+          <span className="text-overline">TrendChart height {height}</span>
+          <TrendChart
+            data={SINGLE}
+            series={SINGLE_SERIES}
+            formatValue={count}
+            formatXTick={day}
+            ariaLabel={`Requests, ${height}px high`}
+            height={height}
+          />
+        </div>
+      ))}
+      {[16, 32, 64].map((height) => (
+        <div key={height} className="flex flex-col gap-1">
+          <span className="text-overline">Sparkline height {height}</span>
+          <Sparkline
+            values={[12, 18, 15, 24, 22, 31, 28, 36, 34, 41]}
+            ariaLabel={`Spend trend, ${height}px high`}
+            height={height}
+          />
+        </div>
+      ))}
+    </div>
+  ),
+}

--- a/web/src/design-system/navigation/FilterSelect.stories.tsx
+++ b/web/src/design-system/navigation/FilterSelect.stories.tsx
@@ -105,3 +105,32 @@ export const InFilterBar: Story = {
     )
   },
 }
+
+/**
+ * `id` when something outside the control has to point at it: a `<label
+ * htmlFor>` the filter bar owns rather than the control's own label, or a
+ * `aria-describedby` on a hint beside it.
+ *
+ * Passing `id` does not name the control on its own. The label below is
+ * associated through `htmlFor`, which is what makes the two one control to a
+ * screen reader; `ariaLabel` is the alternative when there is no visible text
+ * to associate.
+ */
+export const WithExternalLabel: Story = {
+  render: () => {
+    const [value, setValue] = useState("error")
+    return (
+      <div className="flex items-center gap-2">
+        <label htmlFor="activity-status" className="text-caption">
+          Status
+        </label>
+        <FilterSelect
+          id="activity-status"
+          value={value}
+          onChange={setValue}
+          options={STATUSES}
+        />
+      </div>
+    )
+  },
+}

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1741,10 +1741,41 @@ describe("the catalog shows every prop", () => {
     return names
   }
 
-  const stories = walk(DS)
+  // Comments stripped: a story's prose naming a prop would otherwise satisfy
+  // the shorthand pattern below.
+  const storyFiles = walk(DS)
     .filter((name) => name.endsWith(".stories.tsx"))
-    .map((name) => readFileSync(join(DS, name), "utf8"))
-    .join("\n")
+    .map((name) => withoutComments(readFileSync(join(DS, name), "utf8")))
+
+  const stories = storyFiles.join("\n")
+
+  /**
+   * The stories that could be showing this module's components: the ones that
+   * name any of its exports.
+   *
+   * A global search over the whole catalog was the first spelling and it was too
+   * loose by twelve props: `<Button isDisabled>` satisfied `isDisabled` for
+   * every other component that happens to declare it, so a prop with a common
+   * name passed without anyone having shown it. Narrowing to the files that
+   * mention the component keeps the cross-file coverage that matters, since
+   * `FieldMessages.stories.tsx` imports and renders `Field`, which is where
+   * `Field`'s message props are properly shown.
+   */
+  function corpusFor(source: string): string {
+    const exported = [
+      ...source.matchAll(/export (?:function|class) ([A-Z]\w*)/g),
+    ].map((match) => match[1])
+    // Every module in the layer declares at least one, `ErrorBoundary`'s being
+    // the only `class` among them. Falling back to the whole catalog would put
+    // one module back on the loose search this narrowing exists to replace, so
+    // a module the pattern cannot read reports no corpus and fails loudly.
+    expect(exported.length).toBeGreaterThan(0)
+    return storyFiles
+      .filter((text) =>
+        exported.some((name) => new RegExp(`\\b${name}\\b`).test(text)),
+      )
+      .join("\n")
+  }
 
   const components = walk(DS).filter(
     (name) =>
@@ -1782,6 +1813,7 @@ describe("the catalog shows every prop", () => {
   it.each(components)("shows every prop of %s", (name) => {
     const source = readFileSync(join(DS, name), "utf8")
     const module = name.replace(/\.tsx$/, "")
+    const corpus = corpusFor(source)
     const missing = [...propsOf(source)]
       .filter((prop) => CANNOT_BE_SHOWN[`${module}.${prop}`] === undefined)
       .filter((prop) => {
@@ -1789,7 +1821,7 @@ describe("the catalog shows every prop", () => {
         // shorthand, which is how the stories pass `bounded` and `nested`.
         const assigned = new RegExp(`\\b${prop}\\s*[=:]`)
         const shorthand = new RegExp(`\\b${prop}\\s*(?:/?>|\\n)`)
-        return !assigned.test(stories) && !shorthand.test(stories)
+        return !assigned.test(corpus) && !shorthand.test(corpus)
       })
       .sort()
 


### PR DESCRIPTION
## Description

The design-system catalog has a test that fails when a component has a prop no
Storybook story ever passes, so the published catalog cannot quietly stop
documenting an option. It was searching the whole catalog for each prop name,
which made it much weaker than it read: one story writing `<Button isDisabled>`
counted as coverage for every other component that happens to declare
`isDisabled`. Twelve props were passing that way with no story showing them
anywhere.

The search is now bound to the story files that name the component's own
exports, and story files are stripped of comments first (a story's prose
mentioning a prop satisfied the same pattern). That surfaced thirteen real gaps,
and this adds a story for each, so the catalog now shows the concealed-copy
field's in-field action arrangement, a checkbox named for screen readers, a
disabled field, the message line's no-reserve form, the required state of three
form controls, a select's placeholder, an invalid secret field, both chart
heights, and a filter select driven by an external label.

One of those gaps was a bug rather than a hole. All four KPI strip stories
render four cells but left the column count at its default of five, so each was
laying a fifth track and ending the row on a blank column; they now pass four,
and a fifth story shows the five-column form the Usage page opens with.

Follow-up to a CodeRabbit finding on #1023, which introduced the gate.

## How to test it locally

- `pnpm --dir web vitest run src/styles/foundation.test.ts` covers this
  directly: the "the catalog shows every prop" block is the gate.
- To see it still bite, delete one of the new stories and re-run; it should name
  the prop that story was covering.
- `pnpm --dir web run storybook` and look under Design system for the new
  stories (Actions/Copy, Forms/Checkbox, Forms/Field, Forms/FieldMessages,
  Forms/RadioGroup, Forms/SecretField, Forms/Select, Forms/TextArea,
  Metrics/Charts, Metrics/KpiStrip, Navigation/FilterSelect).
- `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and
  `pnpm --dir web test` all pass, as does the catalog render gate
  (`pnpm --dir web run storybook:build`, then `.storybook/smoke.mjs`): 367
  stories in both themes, all clean.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #1020 / #1023.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

The twelve loose props were measured before the gate was changed, by diffing
the reported gaps with the search narrowed against the search as it was.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
