### PR TITLE
fix(dashboard): render the published catalog at the path it is served from

### DIFF
--- a/.github/workflows/otari-design-system.yml
+++ b/.github/workflows/otari-design-system.yml
@@ -8,15 +8,20 @@ name: Otari Design System
 # `catalog` is the pull request gate: it builds the catalog, which is where a
 # story that stops compiling fails, and it takes about a minute.
 #
-# `render` walks all 327 stories in both themes in headless Chromium, and it is
+# `render` walks every story in both themes in headless Chromium, and it is
 # deliberately NOT a pull request gate. It takes seconds locally and more than
 # twenty minutes on a hosted runner, and the cause has not been pinned down (the
 # per-navigation cost is roughly 45 times the local one; a cold browser cache and
 # the default `raf` polling were both ruled out or fixed and neither accounts for
 # it). Six times the slowest existing job, on every `web/` change, is not a trade
-# worth making for a check that has never yet failed on anything the build did
-# not already catch. So it runs on main and on demand, which is exactly how
+# worth making. So it runs on main and on demand, which is exactly how
 # `otari-dashboard.yml` treats the screenshot suite and for the same reason.
+#
+# It does catch what the build cannot, and an earlier version of this comment
+# claimed otherwise. Two faults reached the published site before it was asked
+# the right question: seven stories with a full-bleed band cut off the left of
+# the frame, and an icon requested from the origin root rather than the base
+# path. Both compiled cleanly.
 #
 # The gap this leaves is real and worth stating: a story that compiles but throws
 # at render reaches main, and `render` is what reports it there. Reduce that by

--- a/.github/workflows/otari-design-system.yml
+++ b/.github/workflows/otari-design-system.yml
@@ -139,7 +139,15 @@ jobs:
     - name: Install Chromium
       run: pnpm run e2e:install
 
+    # Built under the same base path `publish` uses, because that is the build
+    # this job exists to prove. Left at the root it renders a bundle nobody
+    # serves, and a URL written from the origin root instead of the base
+    # resolves in the sweep and 404s on the site. `<img src="/favicon.svg">`
+    # did exactly that on two pages: correct on a dashboard served at `/`,
+    # missing on a project site served under `/otari/`.
     - name: Build the catalog
+      env:
+        STORYBOOK_BASE_PATH: /${{ github.event.repository.name }}/
       run: pnpm run storybook:build
 
     # It serves the static build rather than the dev server, because the static
@@ -151,15 +159,23 @@ jobs:
     # `/iframe.html` are both real files on disk, and a rewrite-everything server
     # would actually be worse, turning a missing asset into a 200 that renders.
     #
+    # It is served one directory up, under the repository name, so the base path
+    # the bundle was built with is the path it is actually reached at. Serving
+    # the build at the root would put every asset one segment away from where
+    # the bundle asks for it, and nothing would load at all.
+    #
     # The exit status is the grep's, not the pipeline's: `smoke.mjs` reports its
     # failures on stdout and exits 0 either way, so without the grep this step
     # passes over a catalog where every story threw.
     - name: Render every story in both themes
       run: |
-        python3 -m http.server 6006 --directory storybook-static &
+        mkdir -p site
+        mv storybook-static "site/${{ github.event.repository.name }}"
+        python3 -m http.server 6006 --directory site &
         curl -s --retry 60 --retry-delay 2 --retry-connrefused \
-          -o /dev/null http://localhost:6006/index.json
-        pnpm exec node .storybook/smoke.mjs | tee smoke.log
+          -o /dev/null "http://localhost:6006/${{ github.event.repository.name }}/index.json"
+        SMOKE_ORIGIN="http://localhost:6006/${{ github.event.repository.name }}" \
+          pnpm exec node .storybook/smoke.mjs | tee smoke.log
         grep -q "ALL RENDERED CLEAN" smoke.log
 
   publish:

--- a/web/.storybook/README.md
+++ b/web/.storybook/README.md
@@ -25,17 +25,34 @@ serves a project site under `/<repo>/`, and the merged `vite.config.ts` carries
 the app's own `base: "/"`. `main.ts` reads that variable and leaves the base
 alone when it is unset, so a local build and the dev server need nothing.
 
+A build made for one base and served at another is a build nobody serves, and
+the `render` job used to be exactly that: it built for the root while `publish`
+shipped a `/<repo>/` build, so a URL written from the origin root passed the
+sweep and 404'd on the site. Both jobs now build under the same base, and
+`render` serves it one directory up so it is reached at that path.
+
 ## Smoke test
 
     pnpm --dir web exec node .storybook/smoke.mjs   # with a catalog served on :6006
 
 Renders every story in headless Chromium, in both themes, and reports any that
-error, render nothing, or log an uncaught exception. Playwright is already a dev
-dependency here, so this needs nothing extra. Around ten seconds for the whole
-catalog against a static build.
+error, render nothing, log an uncaught exception, or put a full-bleed band off
+the left of the frame. Playwright is already a dev dependency here, so this needs
+nothing extra. Around ten seconds for the whole catalog against a static build.
 
-Two knobs, both with working defaults: `SMOKE_ORIGIN` points it at another port,
-and `SMOKE_CONCURRENCY` sets how many pages drain the work list (6). The pool is
+That last one is geometry rather than an error, which is why it is measured.
+`.otari-bleed` reaches the width of its container query, so a band inside a
+fixed-width wrapper overflows half the difference on each side and the left half
+lands where nothing can scroll it back. Seven stories shipped that way. The test
+is a negative left edge and not "left of the canvas", because a band bleeding out
+to the canvas edge is what it does on a page.
+
+Two knobs, both with working defaults. `SMOKE_ORIGIN` is a whole origin and path,
+not just a port, which is what lets the sweep walk a build served under its base
+path (as CI now does, `http://localhost:6006/otari`) or the live site itself.
+Pointing it at https://mozilla-ai.github.io/otari is how a `/favicon.svg` asked
+for from the origin root was found. `SMOKE_CONCURRENCY` sets how many pages drain
+the work list (6). The pool is
 what makes it quick, and the reason it exists is worth keeping: as two sequential
 loops over one page each, the same run took over 45 minutes on a CI runner and
 printed nothing until it finished, so a slow run and a hung one looked identical.

--- a/web/.storybook/smoke.mjs
+++ b/web/.storybook/smoke.mjs
@@ -131,6 +131,16 @@ async function drain() {
           (document.querySelector("#storybook-root")?.textContent ?? "").trim().length +
           (document.querySelector('[role="alertdialog"], [role="dialog"]')?.textContent ?? "").trim().length,
         svgs: document.querySelectorAll("#storybook-root svg").length,
+        // A full-bleed region reaches the width of its container query, so a
+        // story that clamps one inside a fixed-width wrapper pushes the band's
+        // left edge off the viewport, where it cannot be scrolled back into
+        // view. Seven stories shipped that way, cut about 114px in from the
+        // left. Negative and not "left of the canvas": a band bleeding out to
+        // the canvas edge is what it does on a page, and only what leaves the
+        // viewport is unreachable.
+        clipped: [...document.querySelectorAll(".otari-bleed")]
+          .map((el) => Math.round(el.getBoundingClientRect().left))
+          .filter((left) => left < 0),
       }))
       if (shown.errored) failures.push({ theme, id, why: "error display", errorText: shown.errorText })
       else if (shown.children === 0) failures.push({ theme, id, why: "empty root" })
@@ -139,6 +149,7 @@ async function drain() {
       else if (shown.text === 0 && shown.svgs === 0 && !(await page.evaluate(RENDERED)))
         failures.push({ theme, id, why: "no text, no svg, and nothing painted" })
       else if (errors.length) failures.push({ theme, id, why: "console errors", errors: [...new Set(errors)].slice(0, 3) })
+      else if (shown.clipped.length) failures.push({ theme, id, why: "a full-bleed region is cut off the left of the viewport", left: shown.clipped })
     } catch (e) {
       failures.push({ theme, id, why: "timeout", detail: String(e.message).split("\n")[0], errors: [...new Set(errors)].slice(0, 2) })
     }

--- a/web/src/app/HybridLanding.tsx
+++ b/web/src/app/HybridLanding.tsx
@@ -60,7 +60,11 @@ export function HybridLanding() {
         <Card.Content className="flex flex-col gap-6 p-7">
           <div className="flex flex-col items-center gap-3 text-center">
             {/* Decorative: the heading beside it already names the product. */}
-            <img src="/favicon.svg" alt="" className="h-12 w-12" />
+            <img
+              src={`${import.meta.env.BASE_URL}favicon.svg`}
+              alt=""
+              className="h-12 w-12"
+            />
             <div>
               <h1 className="text-display">Otari gateway</h1>
               <p className="mt-1 text-sm text-muted">

--- a/web/src/features/account/PasswordCard.stories.tsx
+++ b/web/src/features/account/PasswordCard.stories.tsx
@@ -32,21 +32,11 @@ type Story = StoryObj<typeof meta>
  */
 export const Unclaimed: Story = {
   parameters: { deployment: { sign_in_methods: ["master_key"] } },
-  render: () => (
-    <div className="w-[40rem]">
-      <PasswordCard />
-    </div>
-  ),
 }
 
 /** Claimed: the same card is now a change-password form. */
 export const Claimed: Story = {
   parameters: { deployment: { sign_in_methods: ["password"] } },
-  render: () => (
-    <div className="w-[40rem]">
-      <PasswordCard />
-    </div>
-  ),
 }
 
 /**
@@ -56,9 +46,4 @@ export const Claimed: Story = {
  */
 export const BothMethods: Story = {
   parameters: { deployment: { sign_in_methods: ["master_key", "password"] } },
-  render: () => (
-    <div className="w-[40rem]">
-      <PasswordCard />
-    </div>
-  ),
 }

--- a/web/src/features/auth/PublicAuthLayout.tsx
+++ b/web/src/features/auth/PublicAuthLayout.tsx
@@ -32,7 +32,11 @@ export function AuthPageShell({ children }: { children: ReactNode }) {
         {/* The real mark, so the tab icon and the page agree. `alt=""` because
             nothing here is a destination and the heading below names the
             product. */}
-        <img src="/favicon.svg" alt="" className="h-6 w-[26px]" />
+        <img
+          src={`${import.meta.env.BASE_URL}favicon.svg`}
+          alt=""
+          className="h-6 w-[26px]"
+        />
       </header>
       <div className="flex min-h-0 flex-1">
         {/* `min-h-full` on the column is what runs the rule the height of the

--- a/web/src/features/settings/MailDeliveryCard.stories.tsx
+++ b/web/src/features/settings/MailDeliveryCard.stories.tsx
@@ -36,11 +36,6 @@ export const Ready: Story = {
       },
     },
   },
-  render: () => (
-    <div className="w-[40rem]">
-      <MailDeliveryCard />
-    </div>
-  ),
 }
 
 /**
@@ -62,11 +57,6 @@ export const MissingSettings: Story = {
       },
     },
   },
-  render: () => (
-    <div className="w-[40rem]">
-      <MailDeliveryCard />
-    </div>
-  ),
 }
 
 /**
@@ -88,11 +78,6 @@ export const NotConfigured: Story = {
       },
     },
   },
-  render: () => (
-    <div className="w-[40rem]">
-      <MailDeliveryCard />
-    </div>
-  ),
 }
 
 /**
@@ -108,9 +93,4 @@ export const GatewayError: Story = {
       },
     },
   },
-  render: () => (
-    <div className="w-[40rem]">
-      <MailDeliveryCard />
-    </div>
-  ),
 }


### PR DESCRIPTION
## Description

Two things render wrong on the published design-system catalog, and one reason CI
could not see either.

Seven stories were cut off along their left edge, so the first third of every
line was missing. The band that gives a settings region its full-width rules
reaches the width of whatever box it is measured against, and both of these story
files put it inside a 640px wrapper. The band then overflows half the difference
on each side, and the half that goes left lands off the edge of the frame, where
nothing can scroll it back: 79px lost on an 830px canvas, 114px at 900px. The
design system's own region stories never clamp width, which is why none of them
are cut. Dropping the wrapper leaves those stories nothing left to render by
hand, so the render functions go with it.

The product icon 404'd on every page that shows it. Two pages ask for it from the
site root, which is right for a dashboard served at the root and wrong for a
catalog published under a repository path. It is now asked for relative to
whatever base the build was made with, which resolves in both.

Neither was visible to CI, because the job that walks every story built the
catalog for the root and served it there, proving a bundle nobody serves. It now
builds under the path the site actually uses and serves it there. And because a
cut-off band throws no error, the sweep now measures it: a story fails when a
full-width band starts left of the frame. Verified by putting one wrapper back,
which names that story in both themes and nothing else.

## How to test it locally

- `pnpm --dir web run storybook`, then look at Dashboard/Settings/MailDeliveryCard
  and Dashboard/Account/PasswordCard. Before this they start mid-sentence; after,
  they read from the left edge.
- To see the whole gate as CI now runs it:
  ```
  cd web
  STORYBOOK_BASE_PATH=/otari/ pnpm run storybook:build
  mkdir -p site && mv storybook-static site/otari
  python3 -m http.server 6006 --directory site &
  SMOKE_ORIGIN=http://localhost:6006/otari pnpm exec node .storybook/smoke.mjs
  ```
  366 stories in both themes, reporting `ALL RENDERED CLEAN`. Restore one
  `<div className="w-[40rem]">` wrapper and it fails that story in both themes
  instead.
- Pointing `SMOKE_ORIGIN` at https://mozilla-ai.github.io/otari is how the icon
  404 was found; it reports 8 story/theme pairs on the currently published site.
- `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and
  `pnpm --dir web test` (5250 tests) all pass.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Fixes #1028

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

The affected stories were found by measuring, not by reading: a Playwright sweep
over all 366 stories collecting every full-width band whose left edge sits
outside the frame. That is what says seven and not more, and it also separated
the seven real ones from the region stories whose band correctly reaches the
canvas edge.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
