### PR TITLE
fix(dashboard): put the organization rename behind a confirming dialog

### DIFF
--- a/web/e2e/parity.tenancy.spec.ts
+++ b/web/e2e/parity.tenancy.spec.ts
@@ -27,6 +27,25 @@ async function openPage(
   ).toBeVisible()
 }
 
+// The value beside a term in the organization's detail list, the way
+// `tileValue` reads the value beside a tile's label.
+function organizationDetail(page: Page, term: string): Locator {
+  return page
+    .getByText(term, { exact: true })
+    .locator("xpath=following-sibling::dd[1]")
+}
+
+// Renaming is a dialog away, and the dialog shows the name being replaced
+// before it takes the one replacing it.
+async function rename(page: Page, to: string): Promise<void> {
+  await page.getByRole("button", { name: "Change organization name" }).click()
+  const dialog = page.getByRole("alertdialog")
+  await expect(dialog.getByText("Current name")).toBeVisible()
+  await dialog.getByLabel("New name").fill(to)
+  await dialog.getByRole("button", { name: "Change name" }).click()
+  await expect(dialog).toBeHidden()
+}
+
 function memberRow(page: Page, name: string | RegExp): Locator {
   return tableRows(page, "Organization members").filter({
     has: page.getByRole("rowheader", { name }),
@@ -49,19 +68,21 @@ test.describe("standalone tenancy", () => {
 
     // The master key names no user, so the first authenticated request
     // provisions this: one organization, one owner identity, one workspace.
-    const name = page.getByLabel("Organization name")
-    const original = await name.inputValue()
+    const name = organizationDetail(page, "Organization name")
+    const original = ((await name.textContent()) ?? "").trim()
     expect(original).not.toBe("")
 
-    await name.fill("Parity Organization")
-    await page.getByRole("button", { name: "Save name" }).click()
-    await expect(name).toHaveValue("Parity Organization")
+    // The page reads the name rather than offering it in an open box, so
+    // nothing here can be renamed by a stray keystroke on arrival.
+    await expect(page.getByRole("main").getByRole("textbox")).toHaveCount(0)
+
+    await rename(page, "Parity Organization")
+    await expect(name).toHaveText("Parity Organization")
 
     // The slug is set at creation and deliberately does not follow a rename,
     // which is what makes it safe to key anything off.
-    await name.fill(original)
-    await page.getByRole("button", { name: "Save name" }).click()
-    await expect(name).toHaveValue(original)
+    await rename(page, original)
+    await expect(name).toHaveText(original)
   })
 
   test("lists the operator as an undemotable owner", async ({ page }) => {

--- a/web/src/features/organization/OrganizationGeneralPage.test.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.test.tsx
@@ -181,11 +181,11 @@ describe("OrganizationGeneralPage", () => {
     renderPage(<OrganizationGeneralPage />)
 
     expect(
-      await screen.findByRole("button", { name: "Change organization name" }),
-    ).toBeDisabled()
-    expect(
-      screen.getByText(/Only owners and admins can change it/),
+      await screen.findByText(/Only owners and admins can change it/),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Change organization name" }),
+    ).toBeNull()
   })
 
   it("reports a context that could not be read instead of an empty page", async () => {

--- a/web/src/features/organization/OrganizationGeneralPage.test.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -41,6 +41,15 @@ function renderPage(ui: ReactElement) {
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 
+// Opens the rename dialog and hands back its scope, so an assertion about the
+// dialog cannot be satisfied by the page underneath it (both show the name).
+async function openRenameDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(
+    await screen.findByRole("button", { name: "Change organization name" }),
+  )
+  return within(await screen.findByRole("alertdialog"))
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
@@ -50,11 +59,41 @@ describe("OrganizationGeneralPage", () => {
     mockApi()
     renderPage(<OrganizationGeneralPage />)
 
-    expect(
-      await screen.findByDisplayValue("Default Organization"),
-    ).toBeInTheDocument()
+    expect(await screen.findByText("Default Organization")).toBeInTheDocument()
     expect(screen.getByText(/Your role here is owner/)).toBeInTheDocument()
     expect(screen.getByText("default-organization")).toBeInTheDocument()
+  })
+
+  it("keeps the name out of an editable box until the rename is asked for", async () => {
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationGeneralPage />)
+
+    // The accident this page is guarded against: a focusable input holding the
+    // tenant's name, sitting open on arrival.
+    await screen.findByText("Default Organization")
+    expect(screen.queryByRole("textbox")).toBeNull()
+
+    const dialog = await openRenameDialog(user)
+    expect(dialog.getByRole("textbox", { name: /New name/ })).toHaveValue(
+      "Default Organization",
+    )
+  })
+
+  it("shows the name being replaced beside the one being typed", async () => {
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationGeneralPage />)
+
+    const dialog = await openRenameDialog(user)
+    await user.clear(dialog.getByRole("textbox", { name: /New name/ }))
+    await user.type(
+      dialog.getByRole("textbox", { name: /New name/ }),
+      "Platform",
+    )
+
+    expect(dialog.getByText("Current name")).toBeInTheDocument()
+    expect(dialog.getByText("Default Organization")).toBeInTheDocument()
   })
 
   it("renames the organization through the active-organization endpoint", async () => {
@@ -62,29 +101,66 @@ describe("OrganizationGeneralPage", () => {
     const user = userEvent.setup()
     renderPage(<OrganizationGeneralPage />)
 
-    const name = await screen.findByDisplayValue("Default Organization")
+    const dialog = await openRenameDialog(user)
+    const name = dialog.getByRole("textbox", { name: /New name/ })
     await user.clear(name)
     await user.type(name, "Platform")
-    await user.click(screen.getByRole("button", { name: "Save name" }))
+    await user.click(dialog.getByRole("button", { name: "Change name" }))
 
     const patch = requests.find((request) => request.method === "PATCH")
     expect(patch?.url).toContain("/v1/organizations/me")
     expect(patch?.body).toEqual({ name: "Platform" })
   })
 
-  it("will not save a name that has not changed", async () => {
+  it("closes the dialog once the rename lands", async () => {
     mockApi()
+    const user = userEvent.setup()
     renderPage(<OrganizationGeneralPage />)
 
-    await screen.findByDisplayValue("Default Organization")
-    expect(screen.getByRole("button", { name: "Save name" })).toBeDisabled()
+    const dialog = await openRenameDialog(user)
+    const name = dialog.getByRole("textbox", { name: /New name/ })
+    await user.clear(name)
+    await user.type(name, "Platform")
+    await user.click(dialog.getByRole("button", { name: "Change name" }))
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull())
+  })
+
+  it("will not save a name that has not changed", async () => {
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationGeneralPage />)
+
+    const dialog = await openRenameDialog(user)
+    expect(dialog.getByRole("button", { name: "Change name" })).toBeDisabled()
+  })
+
+  it("reports a rejected rename in the dialog rather than closing over it", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if ((init?.method ?? "GET").toUpperCase() === "PATCH") {
+        return jsonResponse({ detail: "Name already taken" }, 409)
+      }
+      return jsonResponse(organizationContext())
+    })
+    renderPage(<OrganizationGeneralPage />)
+
+    const dialog = await openRenameDialog(user)
+    const name = dialog.getByRole("textbox", { name: /New name/ })
+    await user.clear(name)
+    await user.type(name, "Platform")
+    await user.click(dialog.getByRole("button", { name: "Change name" }))
+
+    expect(await dialog.findByRole("alert")).toHaveTextContent(
+      "Name already taken",
+    )
   })
 
   it("leaves creating and switching to the scope switcher, and offers no delete", async () => {
     mockApi()
     renderPage(<OrganizationGeneralPage />)
 
-    await screen.findByDisplayValue("Default Organization")
+    await screen.findByText("Default Organization")
     // Both controls exist, in the switcher above the rail: they are about which
     // organization you are looking at, where this page is about the one you are
     // in. A second copy here would be a second thing to keep in step.
@@ -100,12 +176,13 @@ describe("OrganizationGeneralPage", () => {
     expect(screen.queryByText("Danger zone")).toBeNull()
   })
 
-  it("leaves the name read-only for a caller who cannot manage the organization", async () => {
+  it("offers no rename to a caller who cannot manage the organization", async () => {
     mockApi(organizationContext({ role: "member" }))
     renderPage(<OrganizationGeneralPage />)
 
-    await screen.findByDisplayValue("Default Organization")
-    expect(screen.getByRole("button", { name: "Save name" })).toBeDisabled()
+    expect(
+      await screen.findByRole("button", { name: "Change organization name" }),
+    ).toBeDisabled()
     expect(
       screen.getByText(/Only owners and admins can change it/),
     ).toBeInTheDocument()

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -69,12 +69,18 @@ function OrganizationDetails({
         </dd>
       </dl>
       {/* The action sits under a rule of its own, so the control that changes
-          the organization is divided from what the organization is. */}
-      <div className="flex items-center justify-end border-t border-border pt-4">
-        <Button variant="primary" isDisabled={!canEdit} onPress={onRename}>
-          Change organization name
-        </Button>
-      </div>
+          the organization is divided from what the organization is. Absent
+          rather than disabled for a member, the way Email domains and Provider
+          keys drop their own primary action: the banner above has already said
+          why, and a rule under the values with nothing beneath it is a band
+          that looks unfinished. */}
+      {canEdit ? (
+        <div className="flex items-center justify-end border-t border-border pt-4">
+          <Button variant="primary" onPress={onRename}>
+            Change organization name
+          </Button>
+        </div>
+      ) : null}
     </Section>
   )
 }

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -1,10 +1,9 @@
-import { Button } from "@heroui/react"
 import { useState } from "react"
+import { Button } from "@/design-system/actions/Button"
 import { CopyableValue } from "@/design-system/actions/CopyField"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { PageLoading } from "@/design-system/feedback/PageLoading"
-import { Field } from "@/design-system/forms/Field"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import {
@@ -12,6 +11,7 @@ import {
   useUpdateOrganization,
 } from "@/shared/api/organizations"
 
+import { RenameOrganizationDialog } from "./RenameOrganizationDialog"
 import { canManage } from "./roles"
 
 // The organization this deployment is, and the one thing an operator does to
@@ -25,25 +25,26 @@ import { canManage } from "./roles"
 // (Members), which is how otari.ai splits the same surface.
 
 /**
- * The form band: a rule above it, a rule below it, and a third rule dividing
- * the fields from the row that commits them. No card, because a page with one
- * form on it does not need a box to say where the form is; the rules already
- * do, and the box was the only thing making this page look like a different
- * page from Keys, which has the same shape.
+ * The detail band: a rule above it, a rule below it, and a third rule dividing
+ * what the organization is from the button that changes it. No card, because a
+ * page with one band on it does not need a box to say where the band is; the
+ * rules already do, and the box was the only thing making this page look like a
+ * different page from Keys, which has the same shape.
+ *
+ * The values read rather than edit: a name in an open input is one stray
+ * keystroke from being changed, so the rename is a dialog away.
  */
 function OrganizationDetails({
   name,
   slug,
   canEdit,
+  onRename,
 }: {
   name: string
   slug: string
   canEdit: boolean
+  onRename: () => void
 }) {
-  const update = useUpdateOrganization()
-  const [draft, setDraft] = useState(name)
-  const trimmed = draft.trim()
-  const isUnchanged = trimmed === name
   return (
     <Section
       aria-labelledby="organization-details-title"
@@ -53,31 +54,25 @@ function OrganizationDetails({
       <h2 id="organization-details-title" className="text-title">
         Details
       </h2>
-      <ErrorBanner error={update.error} />
-      <Field
-        label="Organization name"
-        value={draft}
-        onChange={setDraft}
-        isRequired
-        isDisabled={!canEdit}
-        description="What this deployment's tenant is called across the dashboard. The slug below is set when the organization is provisioned and does not follow a rename."
-      />
-      <div className="flex flex-col gap-1">
-        <span className="text-body">Slug</span>
-        <CopyableValue value={slug} label="organization slug">
-          <code className="text-xs text-muted">{slug}</code>
-        </CopyableValue>
-      </div>
-      {/* The actions sit under a rule of their own, so the row that commits the
-          form is divided from the fields rather than floating after them. */}
+      <dl className="grid items-baseline gap-x-6 gap-y-3 sm:grid-cols-[10rem_1fr]">
+        <dt className="text-muted">Organization name</dt>
+        <dd className="text-emphasis">{name}</dd>
+        <dt className="text-muted">Slug</dt>
+        <dd className="flex flex-col gap-1">
+          <CopyableValue value={slug} label="organization slug">
+            <code className="text-xs text-muted">{slug}</code>
+          </CopyableValue>
+          <span className="text-caption text-subtle">
+            Set when the organization is provisioned. It does not follow a
+            rename.
+          </span>
+        </dd>
+      </dl>
+      {/* The action sits under a rule of its own, so the control that changes
+          the organization is divided from what the organization is. */}
       <div className="flex items-center justify-end border-t border-border pt-4">
-        <Button
-          variant="primary"
-          isDisabled={!canEdit || isUnchanged || trimmed === ""}
-          isPending={update.isPending}
-          onPress={() => update.mutate({ name: trimmed })}
-        >
-          Save name
+        <Button variant="primary" isDisabled={!canEdit} onPress={onRename}>
+          Change organization name
         </Button>
       </div>
     </Section>
@@ -86,6 +81,8 @@ function OrganizationDetails({
 
 export function OrganizationGeneralPage() {
   const context = useOrganizationContext()
+  const update = useUpdateOrganization()
+  const [isRenaming, setIsRenaming] = useState(false)
 
   if (context.isLoading) {
     return <PageLoading label="Loading organization…" />
@@ -117,13 +114,27 @@ export function OrganizationGeneralPage() {
         </InfoBanner>
       )}
 
-      {/* Keyed on the organization so a change of tenant reseeds the name
-          draft, which is seeded on mount only. */}
       <OrganizationDetails
-        key={organization.id}
         name={organization.name}
         slug={organization.slug}
         canEdit={canEdit}
+        onRename={() => {
+          // A rejected attempt must not be waiting in the dialog the next time
+          // it opens.
+          update.reset()
+          setIsRenaming(true)
+        }}
+      />
+
+      <RenameOrganizationDialog
+        isOpen={isRenaming}
+        onOpenChange={setIsRenaming}
+        currentName={organization.name}
+        isPending={update.isPending}
+        error={update.error}
+        onSubmit={(name) =>
+          update.mutate({ name }, { onSuccess: () => setIsRenaming(false) })
+        }
       />
     </div>
   )

--- a/web/src/features/organization/RenameOrganizationDialog.test.tsx
+++ b/web/src/features/organization/RenameOrganizationDialog.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  RenameOrganizationDialog,
+  type RenameOrganizationDialogProps,
+} from "@/features/organization/RenameOrganizationDialog"
+
+function renderDialog(overrides: Partial<RenameOrganizationDialogProps> = {}) {
+  const onSubmit = vi.fn()
+  render(
+    <RenameOrganizationDialog
+      isOpen
+      onOpenChange={() => {}}
+      currentName="Default Organization"
+      isPending={false}
+      onSubmit={onSubmit}
+      {...overrides}
+    />,
+  )
+  return { onSubmit }
+}
+
+function dialog() {
+  return within(screen.getByRole("alertdialog"))
+}
+
+function newNameField() {
+  return dialog().getByRole("textbox", { name: /New name/ })
+}
+
+describe("RenameOrganizationDialog", () => {
+  it("shows the name being replaced alongside the field that replaces it", () => {
+    renderDialog()
+
+    expect(dialog().getByText("Current name")).toBeInTheDocument()
+    expect(dialog().getByText("Default Organization")).toBeInTheDocument()
+    expect(newNameField()).toHaveValue("Default Organization")
+  })
+
+  it("submits the trimmed name", async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderDialog()
+
+    await user.clear(newNameField())
+    await user.type(newNameField(), "  Platform  ")
+    await user.click(dialog().getByRole("button", { name: "Change name" }))
+
+    expect(onSubmit).toHaveBeenCalledWith("Platform")
+  })
+
+  it("refuses a name that is unchanged or blank", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const confirm = dialog().getByRole("button", { name: "Change name" })
+    expect(confirm).toBeDisabled()
+
+    await user.clear(newNameField())
+    expect(confirm).toBeDisabled()
+
+    // Whitespace is not a name, and trimming is what the submit sends.
+    await user.type(newNameField(), "   ")
+    expect(confirm).toBeDisabled()
+
+    await user.clear(newNameField())
+    await user.type(newNameField(), "Platform")
+    expect(confirm).toBeEnabled()
+  })
+
+  it("keeps Cancel out of reach while the rename is in flight", () => {
+    renderDialog({ isPending: true })
+
+    expect(dialog().getByRole("button", { name: "Cancel" })).toBeDisabled()
+  })
+
+  it("reports a rejected rename inside the dialog", () => {
+    renderDialog({ error: new Error("Name already taken") })
+
+    expect(dialog().getByRole("alert")).toHaveTextContent("Name already taken")
+  })
+
+  it("starts each open from the name as it stands, not from the abandoned draft", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [isOpen, setIsOpen] = useState(true)
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Reopen
+          </button>
+          <RenameOrganizationDialog
+            isOpen={isOpen}
+            onOpenChange={setIsOpen}
+            currentName="Default Organization"
+            isPending={false}
+            onSubmit={() => {}}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+
+    await user.clear(newNameField())
+    await user.type(newNameField(), "Abandoned")
+    await user.click(dialog().getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Reopen" }))
+
+    expect(newNameField()).toHaveValue("Default Organization")
+  })
+})

--- a/web/src/features/organization/RenameOrganizationDialog.tsx
+++ b/web/src/features/organization/RenameOrganizationDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react"
+
+import { Button } from "@/design-system/actions/Button"
+import { Dialog } from "@/design-system/feedback/Dialog"
+import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { Field } from "@/design-system/forms/Field"
+
+export interface RenameOrganizationDialogProps {
+  isOpen: boolean
+  onOpenChange: (isOpen: boolean) => void
+  /** The name being replaced, kept in front of the caller while they type. */
+  currentName: string
+  isPending: boolean
+  /** A rejected attempt, reported inside the dialog. */
+  error?: unknown
+  /** Receives the trimmed name; the dialog never submits an empty one. */
+  onSubmit: (name: string) => void
+}
+
+/**
+ * The rename, behind a dialog rather than an input sitting open on the page.
+ *
+ * The organization's name is read by every screen that names it, and a box open
+ * on the settings page is one stray keystroke from changing it. The dialog is
+ * the deliberate step; showing the current name beside the new one is the other
+ * half, because a guard that does not say what is being replaced only slows the
+ * mistake down.
+ */
+export function RenameOrganizationDialog({
+  isOpen,
+  onOpenChange,
+  currentName,
+  isPending,
+  error,
+  onSubmit,
+}: RenameOrganizationDialogProps) {
+  const [draft, setDraft] = useState(currentName)
+
+  // The dialog stays mounted across close and reopen, so the draft is reseeded
+  // each time it opens: an abandoned edit, or a switch to another organization
+  // while this was shut, must not be what the next confirm sends.
+  useEffect(() => {
+    if (isOpen) setDraft(currentName)
+  }, [isOpen, currentName])
+
+  const trimmed = draft.trim()
+  const isUnchanged = trimmed === currentName
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      heading="Change organization name"
+      footer={
+        <>
+          <Button isDisabled={isPending} onPress={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            isDisabled={isUnchanged || trimmed === ""}
+            isPending={isPending}
+            onPress={() => onSubmit(trimmed)}
+          >
+            Change name
+          </Button>
+        </>
+      }
+    >
+      <dl className="flex flex-col gap-1">
+        <dt className="text-muted">Current name</dt>
+        <dd className="text-emphasis">{currentName}</dd>
+      </dl>
+      <Field
+        label="New name"
+        value={draft}
+        onChange={setDraft}
+        isRequired
+        autoFocus
+        description="What this deployment's tenant is called across the dashboard. The slug does not follow a rename."
+        reserveMessage
+      />
+      <ErrorBanner error={error} />
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Description

Org settings used to open straight onto an editable box holding the organization's
name, with a Save button beside it. That put a rename one stray keystroke and one
click away, on a value every screen in the dashboard reads.

The page now reads rather than edits. The organization's name and slug are shown as
plain values, and a "Change organization name" button under them opens a dialog that
keeps the current name in front of you, takes the new one, and only commits when you
press Change name. Nothing is renamed without that deliberate step, a rejected rename
is reported inside the dialog rather than losing what you typed, and a member who
cannot manage the organization is offered no rename at all.

Fixes mozilla-ai/otari-ai#2113

## How to test it locally

1. `make dashboard` and start the gateway, then sign in.
2. Go to Organization, then Org settings.
3. The name is text now, not an input: nothing on the page is typeable.
4. Press "Change organization name". The dialog shows "Current name" with the name as
   it stands and a "New name" field seeded from it. Change name stays disabled while
   the name is unchanged or blank.
5. Type a new name, press Change name. The dialog closes and the page shows the new
   name. The slug does not follow the rename.
6. Cancel or press Escape after typing something else, reopen: the field is back to
   the current name.

Already covered automatically: `web/src/features/organization/RenameOrganizationDialog.test.tsx`
(current name shown, trimming, the disabled cases, the in-flight state, the error, the
reseed on reopen) and `web/src/features/organization/OrganizationGeneralPage.test.tsx`
(no textbox on arrival, the PATCH the confirm sends, the dialog closing on success, a
rejected rename staying in the dialog, and the read-only case for a member). The
behavioral e2e flow in `web/e2e/parity.tenancy.spec.ts` renames through the dialog and
back against a real gateway. `pnpm --dir web run lint`, `pnpm --dir web run typecheck`,
`pnpm --dir web test` (5270 tests) and `make lint` are green.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2113

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change. Dashboard-only, so the tests are colocated Vitest specs plus the behavioral e2e flow, not `tests/unit` or `tests/integration`.
- [x] I ran the Definition of Done checks locally. `make lint` is green; the dashboard's own three (`pnpm --dir web run lint`, `run typecheck`, `test`) are what cover this change, and no Python changed, so `make typecheck` and `make test` have nothing here to exercise.
- [x] Documentation was updated where necessary. Nothing in `docs/` describes this control.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API change: this is UI only, and `web/src/client/schema.ts` and `web/src/routeTree.gen.ts` are both unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Implementation, tests and this description were written by the agent, then self-reviewed
against the repo's frontend standards before opening.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Changed organization details to read-only values.
- Added a confirmation dialog for organization renaming.
- Restricted the rename action to members with organization-management permissions.
- Preserved entered names when a rename fails and reset the field when the dialog reopens.
- Added unit and end-to-end coverage for permissions, validation, successful renames, failed renames, and dialog behavior.

This makes renaming more deliberate and reduces accidental changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->