### PR TITLE
feat(dashboard): add FormDialog, the one surface every create form opens in

### DIFF
--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -63,7 +63,7 @@ for a component, not for those.
 | `metrics/SeverityMark` | `SeverityMark`, and the `Severity` type |
 | `metrics/TrendChip` | `TrendChip`, `trendState`, and the `Trend*` types |
 | `metrics/charts` | `TrendChart`, `Sparkline`, `ChartLegend`, and the `SeriesDef` / `StackedPoint` types |
-| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/PageError` · `/ConfirmDialog` · `/Dialog` · `/ErrorBoundary` · `/Skeleton` · `/errorMessage` | one each |
+| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/PageError` · `/ConfirmDialog` · `/FormDialog` · `/Dialog` · `/ErrorBoundary` · `/Skeleton` · `/errorMessage` | one each |
 | `forms/Field` · `/SecretField` · `/TextArea` · `/SearchField` · `/FieldAction` | one component each |
 | `forms/Select` | `Select`, and the `SelectOption` type |
 | `forms/RadioGroup` | `RadioGroup`, and the `RadioOption` type |

--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -62,6 +62,47 @@ band, the secondary one becomes a ghost.
 `Button` takes `isPending` while a mutation is in flight; it disables itself and
 shows its own spinner. Do not pair it with `isDisabled` for the same condition.
 
+## Where a create action lives, and what it says
+
+Two rules, and both are "always the same" rather than "usually". The dashboard
+had the action in a page's top right on one route and halfway down another, and
+pressing it opened a modal on one and appended a section on the next, so an
+operator learned each page separately.
+
+**Placement: the heading row of the collection being created into.** When the
+page is one collection that is `PageIntro`'s `action` slot; when the page holds
+several it is the section's own heading row, right-aligned, the same button. An
+empty state may repeat the call to action, and it opens the same dialog. The
+header button does not hide while the form is open: the form is a dialog now, so
+there is nothing for hiding it to prevent.
+
+**Surface: `FormDialog`, every time.** See [feedback.md](feedback.md).
+
+**Labels: the trigger and the submit are the same string, word for word.** The
+dialog's title names the object instead.
+
+| Trigger | Title | Submit |
+| --- | --- | --- |
+| Create key | New key | Create key |
+| Add MCP server | New MCP server | Add MCP server |
+
+**Create or Add** is not a style choice: *create* is for an object born here (a
+key, a budget, a policy, a workspace), *add* is for attaching something that
+already exists elsewhere (a provider, a provider key, an MCP server, a member,
+an override, a ceiling). *Invite* and *Claim* keep their own verb, because
+neither is either of those.
+
+```tsx
+// Correct
+<PageIntro title="API keys" action={
+  <Button variant="primary" onPress={openCreate}>Create key</Button>
+} />
+
+// Incorrect: a second vocabulary for the same act, and a title that restates
+// the button instead of naming what appears
+<Button variant="primary" onPress={openCreate}>New key +</Button>
+```
+
 ## Sizes
 
 `sm` 32px, `md` 36px (the default), `lg` 40px. Press is `scale(0.98)` at every

--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -59,8 +59,17 @@ band, the secondary one becomes a ghost.
 <Button variant="outline" onPress={exportCsv}>Export CSV</Button>
 ```
 
-`Button` takes `isPending` while a mutation is in flight; it disables itself and
-shows its own spinner. Do not pair it with `isDisabled` for the same condition.
+`Button` takes `isPending` while a mutation is in flight. **It draws no spinner**,
+whatever this file used to say: HeroUI puts `data-pending` on the element and the
+stylesheet answers that with `pointer-events: none` and nothing else, so the
+spinner is the call site's to render. What `isPending` does supply is the press
+block, `aria-disabled`, and react-aria's announcement, and it paints the button
+at the disabled 0.4. Do not pair it with `isDisabled` for the same condition.
+
+Which means `isPending` is the wrong prop wherever the button should read as
+*working* rather than *refused*, since 0.4 is the denied treatment
+([motion-and-access.md](motion-and-access.md)). `FormDialog`'s submit is the
+worked example: it keeps its fill, blocks its own press, and says `aria-busy`.
 
 ## Where a create action lives, and what it says
 

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -29,6 +29,8 @@ Does the action delete a record?
  └── ConfirmDialog          (always, one row or many; see actions.md)
 Is it destructive but deletes nothing (regenerate, archive, reset)?
  └── ConfirmButton          (the two-step confirm; see actions.md)
+Is the operator creating or editing an object?
+ └── FormDialog             (every one of them; see the placement rule in actions.md)
 ```
 
 ## Signatures
@@ -43,6 +45,9 @@ PageLoading: { label = "Loading…" }
 PageError: { error: unknown, children? }
 ConfirmDialog: { isOpen, onOpenChange, heading, body, confirmLabel, onConfirm,
   confirmVariant = "danger", isPending?, error? }
+FormDialog: { isOpen, onOpenChange, title, description?, size = "md",
+  submitLabel, onSubmit, isPending, error?, isDirty?, footerStart?, tabs?,
+  children }
 ErrorBoundary: { children, resetKey? }
 ```
 
@@ -116,6 +121,61 @@ behind the backdrop they are looking at.
 
 `ConfirmButton`'s two-step is what is left, for a destructive action that deletes
 nothing. See [actions.md](actions.md) for both.
+
+## FormDialog
+
+Every create and every edit opens here. Not a panel that appears under the
+table, not a section appended to the page: one surface, so an operator who has
+created a key knows what adding a provider will do.
+
+Built on HeroUI's `Modal` rather than `AlertDialog`, and that is the difference
+between the two dialogs rather than a detail of them. An alert interrupts to ask
+one question; a form is a place to work.
+
+```tsx
+// Correct: the title names the object, the submit repeats the trigger
+<FormDialog
+  isOpen={isCreating}
+  onOpenChange={setCreating}
+  title="New key"
+  description="The secret is shown once, right after you create it."
+  submitLabel="Create key"
+  onSubmit={submit}
+  isPending={create.isPending}
+  error={create.error}
+  isDirty={name !== ""}
+>
+  <Field label="Key name" value={name} onChange={setName} reserveMessage />
+</FormDialog>
+
+// Incorrect: the title restates the button, and nothing says what was made
+<FormDialog title="Create key" submitLabel="Save" …>
+```
+
+**Sizes.** `sm` 440 for one or two fields, `md` 520 by default, `lg` 640 for
+tabs or six fields and up. Below a 640px viewport every size is a full-screen
+sheet. Those widths cannot be spelled as a class: `globals.css` pins
+`.modal__dialog` unlayered, which outranks `@layer utilities` and puts a 448px
+floor under it, so the component sets `--form-dialog-width` inline and the
+geometry is settled beside the rule it has to beat.
+
+**Fields go in with `reserveMessage` on**, so a validation message opens a line
+that was already there instead of moving the footer. The first field takes
+`autoFocus`.
+
+**The footer's height never changes.** `isPending` keeps the primary at its
+resting width, because the spinner replaces the label in place rather than
+sitting beside it; Cancel and the close control are disabled for the same
+duration. HeroUI's own `isPending` draws no spinner, so this one is the
+component's, not the library's.
+
+**`isDirty` arms a guard in the footer, not a second dialog.** Escape and a
+click outside swap the actions for "Unsaved changes · Keep editing · Discard".
+A dialog never opens a dialog.
+
+**The success step is not a prop.** When a mutation has something to hand back
+(a key's secret), the caller swaps the children and the submit label to "Done"
+and the frame stays where it was. `footerStart` is where "Create another" goes.
 
 ## Copy
 

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -145,7 +145,13 @@ one question; a form is a place to work.
   error={create.error}
   isDirty={name !== ""}
 >
-  <Field label="Key name" value={name} onChange={setName} reserveMessage />
+  <Field
+    label="Key name"
+    value={name}
+    onChange={setName}
+    description="Lowercase, hyphens, no spaces."
+    reserveMessage
+  />
 </FormDialog>
 
 // Incorrect: the title restates the button, and nothing says what was made
@@ -159,15 +165,21 @@ sheet. Those widths cannot be spelled as a class: `globals.css` pins
 floor under it, so the component sets `--form-dialog-width` inline and the
 geometry is settled beside the rule it has to beat.
 
-**Fields go in with `reserveMessage` on**, so a validation message opens a line
-that was already there instead of moving the footer. The first field takes
-`autoFocus`.
+**A field reserves its message line only where it has a description**, which is
+[forms.md](forms.md)'s rule and not a dialog rule: the reserved line exists so an
+error can replace a description rather than push the footer down, so a field with
+nothing to say under it holds nothing. The first field takes `autoFocus`.
 
-**The footer's height never changes.** `isPending` keeps the primary at its
-resting width, because the spinner replaces the label in place rather than
-sitting beside it; Cancel and the close control are disabled for the same
-duration. HeroUI's own `isPending` draws no spinner, so this one is the
-component's, not the library's.
+**Fields fill the dialog.** `Field` and `SecretField` cap themselves at 448px,
+which is right on a page and wrong in a 640px dialog; `globals.css` lifts the cap
+for this place, so no call site sets a width.
+
+**The footer's height never changes, and the primary keeps its width.** The
+spinner replaces the label in place rather than sitting beside it. The primary
+is **not** disabled while it runs: disabled is one treatment at 0.4 opacity and
+it has to read as denied, and a submit in flight is working rather than refused,
+so it keeps its fill and blocks its own press. Cancel and the close control *are*
+disabled, because they genuinely are refused until it lands.
 
 **`isDirty` arms a guard in the footer, not a second dialog.** Escape and a
 click outside swap the actions for "Unsaved changes · Keep editing · Discard".

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -168,7 +168,12 @@ geometry is settled beside the rule it has to beat.
 **A field reserves its message line only where it has a description**, which is
 [forms.md](forms.md)'s rule and not a dialog rule: the reserved line exists so an
 error can replace a description rather than push the footer down, so a field with
-nothing to say under it holds nothing. The first field takes `autoFocus`.
+nothing to say under it holds nothing. Spell that as `reserveMessage={false}`
+rather than by leaving the prop off, which currently reserves anyway: forms.md
+says the prop defaults to off and it does not, because `FieldMessages` defaults
+its own `reserve` to true and the four controls forward an undefined prop into
+it. Measured, a bare field in a dialog is 83px against the 60px it should be.
+The first field takes `autoFocus`.
 
 **Fields fill the dialog.** `Field` and `SecretField` cap themselves at 448px,
 which is right on a page and wrong in a 640px dialog; `globals.css` lifts the cap

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -75,18 +75,21 @@ says the same about React Aria popovers under "Checks".
 
 ## Dialog
 
-Modal and centered. `Dialog` is the shell; `ConfirmDialog` is its
-specialization for a destructive action, with the two buttons and the error line
-built in.
+Modal and centered. Three of them, and the question sorts them:
 
-Reach for `ConfirmDialog` when the dialog's whole job is "are you sure", which
-includes every delete of a record, and for `Dialog` when it holds a form.
+- **`FormDialog`** when the operator is creating or editing an object. Every
+  create flow in the product, no exceptions. See [feedback.md](feedback.md).
+- **`ConfirmDialog`** when the dialog's whole job is "are you sure", which
+  includes every delete of a record.
+- **`Dialog`** is the bare `AlertDialog` shell the other pattern was built from.
+  It has no call sites; a form wants `FormDialog`, which is a `Modal`, because
+  an alert interrupts to ask one question and a form is a place to work.
 
-Both are controlled only, because a dialog opens from something elsewhere on the
-page (a row's Edit, a toolbar's Add) rather than from a trigger inside itself.
-Both mount their body only while open, which is not an optimization: the body of
-a form dialog holds controlled inputs, and leaving them mounted carries one
-row's draft into the next row's dialog.
+All three are controlled only, because a dialog opens from something elsewhere
+on the page (a row's Edit, a heading row's Create) rather than from a trigger
+inside itself. All three mount their body only while open, which is not an
+optimization: the body of a form dialog holds controlled inputs, and leaving
+them mounted carries one row's draft into the next row's dialog.
 
 `isDismissable` is on by default. Turning it off takes away Escape and the
 outside click, and the only honest reason is unsaved work that would be lost;

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -11,7 +11,7 @@ Does the operator need to interact with what appears?
       ├── Is it about the control that opened it?
       │    └── Yes -> Popover      (anchored, takes focus, not modal)
       └── Does it want the whole screen's attention?
-           └── Yes -> Dialog       (modal, centered, dismissed deliberately)
+           └── Yes -> Dialog       (modal, dismissed deliberately)
 ```
 
 `Dialog` lives in [feedback.md](feedback.md)'s directory rather than this one,

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -75,7 +75,7 @@ says the same about React Aria popovers under "Checks".
 
 ## Dialog
 
-Modal and centered. Three of them, and the question sorts them:
+Modal. Three of them, and the question sorts them:
 
 - **`FormDialog`** when the operator is creating or editing an object. Every
   create flow in the product, no exceptions. See [feedback.md](feedback.md).

--- a/web/src/design-system/feedback/Dialog.tsx
+++ b/web/src/design-system/feedback/Dialog.tsx
@@ -13,7 +13,10 @@ import type { ReactNode } from "react"
  *
  * `ConfirmDialog` is the specialization of this for a destructive action, with
  * the two buttons and the error line built in. Reach for that one when the
- * dialog's whole job is "are you sure"; reach for this one when it holds a form.
+ * dialog's whole job is "are you sure", and for `FormDialog` when it holds a
+ * form: that one is a `Modal` rather than an `AlertDialog`, because an alert
+ * interrupts to ask one question and a form is a place to work. This shell has
+ * no call sites of its own.
  *
  * Controlled only. A dialog opens because something happened elsewhere on the
  * page (a row's Edit, a toolbar's Add), so an uncontrolled variant would need a

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -53,7 +53,6 @@ function KeyFields() {
           { value: "workspace", label: "This workspace" },
           { value: "organization", label: "Whole organization" },
         ]}
-        reserveMessage
       />
     </>
   )
@@ -251,7 +250,9 @@ function ManyFields() {
               prev.map((item, at) => (at === index ? next : item)),
             )
           }
-          reserveMessage
+          // No description, so no reserved line: the line exists for an error to
+          // replace a description in, and eight of them reserved against nothing
+          // added 8 empty rungs to a body that already scrolls.
         />
       ))}
     </>

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -1,0 +1,300 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import { Button } from "../actions/Button"
+import { CopyField } from "../actions/CopyField"
+import { Checkbox } from "../forms/Checkbox"
+import { Field } from "../forms/Field"
+import { SecretField } from "../forms/SecretField"
+import { Select } from "../forms/Select"
+import { Tab, TabRow } from "../navigation/TabRow"
+import { FormDialog } from "./FormDialog"
+
+const meta = {
+  title: "Design system/Feedback/FormDialog",
+  component: FormDialog,
+  parameters: { layout: "fullscreen" },
+  args: {
+    isOpen: true,
+    onOpenChange: () => {},
+    title: "New key",
+    description: "The secret is shown once, right after you create it.",
+    submitLabel: "Create key",
+    onSubmit: () => {},
+    isPending: false,
+    children: null,
+  },
+} satisfies Meta<typeof FormDialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/** The two fields every create form has at least one of. */
+function KeyFields() {
+  const [name, setName] = useState("")
+  const [scope, setScope] = useState("workspace")
+  return (
+    <>
+      <Field
+        label="Key name"
+        value={name}
+        onChange={setName}
+        placeholder="checkout-service"
+        description="Lowercase, hyphens, no spaces."
+        autoFocus
+        reserveMessage
+      />
+      <Select
+        label="Scope"
+        value={scope}
+        onChange={setScope}
+        options={[
+          { value: "workspace", label: "This workspace" },
+          { value: "organization", label: "Whole organization" },
+        ]}
+        reserveMessage
+      />
+    </>
+  )
+}
+
+/**
+ * `md`, the default, and the size all but three call sites want: a form of two
+ * to five fields with nothing to choose between.
+ */
+export const Medium: Story = {
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
+/** `sm`, for one or two fields. Narrower than HeroUI's own floor; see the CSS. */
+export const Small: Story = {
+  args: {
+    size: "sm",
+    title: "Claim domain",
+    description: undefined,
+    submitLabel: "Claim domain",
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <DomainField />
+    </FormDialog>
+  ),
+}
+
+function DomainField() {
+  const [domain, setDomain] = useState("mozilla.ai")
+  return (
+    <Field
+      label="Domain"
+      value={domain}
+      onChange={setDomain}
+      description="You will verify it with a DNS record next."
+      autoFocus
+      reserveMessage
+    />
+  )
+}
+
+/** `lg`, the size a form earns by having two shapes or six or more fields. */
+export const LargeWithTabs: Story = {
+  args: {
+    size: "lg",
+    title: "Add provider",
+    description:
+      "Credentials are encrypted with the server secret key and never leave this gateway.",
+    submitLabel: "Add provider",
+    footerStart: (
+      <p className="text-caption">A test request runs before saving.</p>
+    ),
+  },
+  render: (args) => <ProviderForm {...args} />,
+}
+
+function ProviderForm(args: React.ComponentProps<typeof FormDialog>) {
+  const [tab, setTab] = useState("known")
+  const [secret, setSecret] = useState("")
+  const [isDefault, setIsDefault] = useState(false)
+  return (
+    <FormDialog
+      {...args}
+      tabs={
+        <TabRow>
+          <Tab isActive={tab === "known"} onPress={() => setTab("known")}>
+            Known provider
+          </Tab>
+          <Tab isActive={tab === "custom"} onPress={() => setTab("custom")}>
+            Custom endpoint
+          </Tab>
+        </TabRow>
+      }
+    >
+      <SecretField
+        label="API key"
+        value={secret}
+        onChange={setSecret}
+        description="Stored encrypted. Autofill is off for this field."
+        reserveMessage
+      />
+      <Checkbox isSelected={isDefault} onChange={setIsDefault}>
+        Make this the default route for Anthropic models
+      </Checkbox>
+    </FormDialog>
+  )
+}
+
+/**
+ * The mutation is in flight. The primary keeps its resting width, because the
+ * spinner replaces the label in place; Cancel and the close control are
+ * disabled for the same duration, so the footer's height never moves.
+ */
+export const Submitting: Story = {
+  args: { isPending: true },
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
+/**
+ * The gateway refused. The dialog stays open holding its own fields, and the
+ * banner mounts at the top of the body, where `ConfirmDialog` already puts it.
+ */
+export const RequestFailed: Story = {
+  args: {
+    error: new Error(
+      "Could not claim mozilla.ai. Another organization already verified it.",
+    ),
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
+/**
+ * `isDirty`, after Escape or a click outside. The guard is in the footer rather
+ * than in a second dialog: a dialog never opens a dialog.
+ */
+export const DirtyGuard: Story = {
+  args: { isDirty: true },
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
+/**
+ * The success step is not a prop. The caller swaps the children and the submit
+ * label once the mutation resolves; the frame stays mounted, so the secret
+ * appears where the form was rather than in a second surface.
+ */
+export const SuccessStep: Story = {
+  args: {
+    title: "Key created",
+    description: "Copy it now. Otari stores a hash and cannot show it again.",
+    submitLabel: "Done",
+    footerStart: <Button>Create another</Button>,
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <CopyField
+        label="checkout-service"
+        value="otari-sk-9f3a1c77b0e244d1e8a972fc0a3bc5d86e10f4b2"
+      />
+      <p className="text-caption">
+        Owner Léa Fontaine-Whitaker · $500.00 per month · never expires
+      </p>
+    </FormDialog>
+  ),
+}
+
+/**
+ * A body taller than the height budget. The header and the footer stay put and
+ * the body scrolls between them, and the header gains its rule only once
+ * content is under it.
+ */
+export const ScrollingBody: Story = {
+  args: {
+    size: "lg",
+    title: "Add MCP server",
+    description: "Otari calls it on the operator's behalf.",
+    submitLabel: "Add server",
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <ManyFields />
+    </FormDialog>
+  ),
+}
+
+function ManyFields() {
+  const [values, setValues] = useState<string[]>(() => Array(8).fill(""))
+  return (
+    <>
+      {values.map((value, index) => (
+        <Field
+          // The list is fixed-length and positional, so the index is the
+          // identity: there is nothing to reorder and nothing to key on.
+          key={index}
+          label={`Header ${index + 1}`}
+          value={value}
+          onChange={(next) =>
+            setValues((prev) =>
+              prev.map((item, at) => (at === index ? next : item)),
+            )
+          }
+          reserveMessage
+        />
+      ))}
+    </>
+  )
+}
+
+/**
+ * Below 640px every size is a full-screen sheet: the dialog fills the frame,
+ * the inputs are 16px so iOS does not zoom, and the footer clears the home
+ * indicator.
+ *
+ * `mobile2` is Storybook's own 414px preset, the nearest one to the 390px frame
+ * this was drawn at. The width is what matters: the sheet is a media query on
+ * the preview frame, so a wrapper `<div>` would not produce it. The dialog
+ * portals to the frame's `<body>` and never sees a wrapper at all.
+ */
+export const PhoneSheet: Story = {
+  globals: { viewport: { value: "mobile2", isRotated: false } },
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
+/** Driven from a trigger, which is how a heading row actually opens it. */
+export const FromTrigger: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+    return (
+      <div className="p-6">
+        <Button variant="primary" onPress={() => setOpen(true)}>
+          Create key
+        </Button>
+        <FormDialog
+          {...args}
+          isOpen={open}
+          onOpenChange={setOpen}
+          onSubmit={() => setOpen(false)}
+        >
+          <KeyFields />
+        </FormDialog>
+      </div>
+    )
+  },
+}

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -53,6 +53,7 @@ function KeyFields() {
           { value: "workspace", label: "This workspace" },
           { value: "organization", label: "Whole organization" },
         ]}
+        reserveMessage={false}
       />
     </>
   )
@@ -250,9 +251,16 @@ function ManyFields() {
               prev.map((item, at) => (at === index ? next : item)),
             )
           }
-          // No description, so no reserved line: the line exists for an error to
-          // replace a description in, and eight of them reserved against nothing
-          // added 8 empty rungs to a body that already scrolls.
+          // No description, so no reserved line: the line exists for an error
+          // to replace a description in, and eight of them reserved against
+          // nothing added eight empty rungs to a body that already scrolls.
+          //
+          // Spelled `={false}` rather than omitted, which reads as redundant
+          // and is not: `FieldMessages` defaults `reserve` to true and `Field`
+          // forwards the prop undefined, so a field that says nothing reserves
+          // a line anyway. Measured, omitting it leaves the row at 83px where
+          // this brings it to 60.
+          reserveMessage={false}
         />
       ))}
     </>

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -1,0 +1,282 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { FormDialog } from "./FormDialog"
+
+const base = {
+  title: "New key",
+  submitLabel: "Create key",
+  isPending: false,
+  onSubmit: vi.fn(),
+  onOpenChange: vi.fn(),
+}
+
+const withField = (
+  <label>
+    Key name
+    <input name="name" />
+  </label>
+)
+
+/**
+ * A textarea, which is where Cmd/Ctrl+Enter is the only submit gesture: Enter
+ * on its own is a newline there, and the browser's implicit form submission
+ * does not fire from a multi-line control.
+ */
+const withTextArea = (
+  <label>
+    Instructions
+    <textarea name="instructions" />
+  </label>
+)
+
+describe("FormDialog", () => {
+  it("renders nothing while closed", () => {
+    render(
+      <FormDialog {...base} isOpen={false}>
+        {withField}
+      </FormDialog>,
+    )
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("is a dialog rather than an alertdialog, because a form is not an alert", () => {
+    render(
+      <FormDialog {...base} isOpen>
+        {withField}
+      </FormDialog>,
+    )
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+  })
+
+  it("names the object in the title and the action on the submit button", () => {
+    render(
+      <FormDialog {...base} isOpen description="Shown once.">
+        {withField}
+      </FormDialog>,
+    )
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toHaveTextContent("New key")
+    expect(dialog).toHaveTextContent("Shown once.")
+    expect(
+      screen.getByRole("button", { name: "Create key" }),
+    ).toBeInTheDocument()
+  })
+
+  it("gives the close control a name rather than leaving it a glyph", () => {
+    render(
+      <FormDialog {...base} isOpen>
+        {withField}
+      </FormDialog>,
+    )
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument()
+  })
+
+  it("submits when the primary is pressed", async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FormDialog {...base} isOpen onSubmit={onSubmit}>
+        {withField}
+      </FormDialog>,
+    )
+    await user.click(screen.getByRole("button", { name: "Create key" }))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("submits on Cmd/Ctrl+Enter from a textarea, where Enter is a newline", async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FormDialog {...base} isOpen onSubmit={onSubmit}>
+        {withTextArea}
+      </FormDialog>,
+    )
+    const field = screen.getByLabelText("Instructions")
+    await user.click(field)
+    // Enter alone belongs to the control. Asserting this first is what keeps
+    // the case below honest: from a single-line input the browser's own
+    // implicit submission fires and the assertion passes with the handler
+    // deleted, which is a green that proves nothing.
+    await user.keyboard("{Enter}")
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(field).toHaveValue("\n")
+    await user.keyboard("{Meta>}{Enter}{/Meta}")
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("submits on Enter from a single-line field, the way every form does", async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FormDialog {...base} isOpen onSubmit={onSubmit}>
+        {withField}
+      </FormDialog>,
+    )
+    await user.click(screen.getByLabelText("Key name"))
+    await user.keyboard("{Enter}")
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes on Cancel and on the close control when nothing is dirty", async () => {
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FormDialog {...base} isOpen onOpenChange={onOpenChange}>
+        {withField}
+      </FormDialog>,
+    )
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    expect(onOpenChange).toHaveBeenLastCalledWith(false)
+    await user.click(screen.getByRole("button", { name: "Close" }))
+    expect(onOpenChange).toHaveBeenCalledTimes(2)
+  })
+
+  describe("while the mutation is in flight", () => {
+    it("keeps the submit label in the DOM, so the button keeps its width", () => {
+      render(
+        <FormDialog {...base} isOpen isPending>
+          {withField}
+        </FormDialog>,
+      )
+      // The spinner replaces the label in place rather than beside it: the
+      // label element is still laid out, only invisible. A spinner appended
+      // next to a removed label is the shape this asserts against, and it
+      // would change the button's resting width mid-submit.
+      const submit = screen.getByRole("button", { name: /Create key/ })
+      const label = within(submit).getByText("Create key")
+      expect(label).toHaveClass("invisible")
+      expect(submit).toHaveAttribute("data-pending", "true")
+    })
+
+    it("disables Cancel and the close control for the same duration", () => {
+      render(
+        <FormDialog {...base} isOpen isPending>
+          {withField}
+        </FormDialog>,
+      )
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Close" })).toBeDisabled()
+    })
+
+    it("does not submit again when the primary is pressed", async () => {
+      const onSubmit = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isPending onSubmit={onSubmit}>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: /Create key/ }))
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("the dirty guard", () => {
+    it("holds the dialog open and swaps the footer instead of closing", async () => {
+      const onOpenChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isDirty onOpenChange={onOpenChange}>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      expect(onOpenChange).not.toHaveBeenCalled()
+      expect(screen.getByRole("dialog")).toHaveTextContent("Unsaved changes")
+      expect(
+        screen.getByRole("button", { name: "Keep editing" }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Discard" }),
+      ).toBeInTheDocument()
+    })
+
+    it("guards inside the one dialog, replacing its actions rather than stacking", async () => {
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isDirty>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      // The guard's controls are in the dialog that was already open, and the
+      // actions they replaced are gone. A second dialog would leave both sets
+      // on the page and two dialog nodes in it.
+      const dialog = screen.getByRole("dialog")
+      expect(screen.getAllByRole("dialog")).toHaveLength(1)
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+      expect(
+        within(dialog).getByRole("button", { name: "Keep editing" }),
+      ).toBeInTheDocument()
+      expect(
+        within(dialog).queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument()
+      expect(
+        within(dialog).queryByRole("button", { name: "Create key" }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("closes on Discard", async () => {
+      const onOpenChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isDirty onOpenChange={onOpenChange}>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      await user.click(screen.getByRole("button", { name: "Discard" }))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+
+    it("returns the footer to its actions on Keep editing", async () => {
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isDirty>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      await user.click(screen.getByRole("button", { name: "Keep editing" }))
+      expect(
+        screen.getByRole("button", { name: "Create key" }),
+      ).toBeInTheDocument()
+      expect(screen.getByRole("dialog")).not.toHaveTextContent(
+        "Unsaved changes",
+      )
+    })
+  })
+
+  it("mounts a request failure at the top of the body, above the fields", () => {
+    render(
+      <FormDialog {...base} isOpen error={new Error("Domain already claimed.")}>
+        {withField}
+      </FormDialog>,
+    )
+    const banner = screen.getByRole("alert")
+    expect(banner).toHaveTextContent("Domain already claimed.")
+    expect(
+      banner.compareDocumentPosition(screen.getByLabelText("Key name")),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it("puts the tab row between the header and the body", () => {
+    render(
+      <FormDialog
+        {...base}
+        isOpen
+        size="lg"
+        tabs={<button type="button">Known</button>}
+      >
+        {withField}
+      </FormDialog>,
+    )
+    const tab = screen.getByRole("button", { name: "Known" })
+    expect(tab.compareDocumentPosition(screen.getByLabelText("Key name"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    )
+  })
+})

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -142,16 +142,39 @@ describe("FormDialog", () => {
         </FormDialog>,
       )
       // The spinner replaces the label in place rather than beside it: the
-      // label element is still laid out, only invisible. A spinner appended
+      // label element is still laid out, only transparent. A spinner appended
       // next to a removed label is the shape this asserts against, and it
       // would change the button's resting width mid-submit.
+      //
+      // `opacity-0` and not `invisible` for a second reason this cannot see:
+      // `visibility: hidden` takes the label out of the accessibility tree,
+      // which would leave the button nameless mid-submit. jsdom loads no
+      // stylesheet, so `getByRole` here would find it either way.
       const submit = screen.getByRole("button", { name: /Create key/ })
       const label = within(submit).getByText("Create key")
-      expect(label).toHaveClass("invisible")
-      expect(submit).toHaveAttribute("data-pending", "true")
+      expect(label).toHaveClass("opacity-0")
     })
 
-    it("disables Cancel and the close control for the same duration", () => {
+    it("says the submit is busy rather than refused, and blocks its own press", () => {
+      render(
+        <FormDialog {...base} isOpen isPending>
+          {withField}
+        </FormDialog>,
+      )
+      // Disabled is one treatment in this product, at 0.4 opacity, and it has
+      // to read as denied. A submit in flight is working, so it keeps its fill
+      // and stops the press itself.
+      const submit = screen.getByRole("button", { name: /Create key/ })
+      expect(submit).not.toBeDisabled()
+      expect(submit).not.toHaveAttribute("data-disabled")
+      expect(submit).not.toHaveAttribute("aria-disabled", "true")
+      expect(submit).toHaveClass("pointer-events-none")
+      // On the form, not the button: react-aria filters unrecognized ARIA off
+      // a Button, so an `aria-busy` there reaches no DOM node.
+      expect(submit.closest("form")).toHaveAttribute("aria-busy", "true")
+    })
+
+    it("disables Cancel and the close control, which genuinely are refused", () => {
       render(
         <FormDialog {...base} isOpen isPending>
           {withField}

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -264,6 +264,36 @@ describe("FormDialog", () => {
       ).not.toBeInTheDocument()
     })
 
+    it("refuses a keyboard submit while it holds the footer", async () => {
+      // The guard has taken the footer, so the submit control is not on screen.
+      // A keyboard submit under it would run the mutation from a footer whose
+      // only actions are Keep editing and Discard, and `isPending` would never
+      // become visible because the guard owns the footer for its duration.
+      const onSubmit = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isDirty onSubmit={onSubmit}>
+          {withField}
+        </FormDialog>,
+      )
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      expect(screen.getByRole("dialog")).toHaveTextContent("Unsaved changes")
+
+      await user.click(screen.getByLabelText("Key name"))
+      await user.keyboard("{Enter}")
+      expect(onSubmit).not.toHaveBeenCalled()
+      await user.keyboard("{Meta>}{Enter}{/Meta}")
+      await user.keyboard("{Control>}{Enter}{/Control}")
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      // And it submits again once the guard is put away, so what is blocked is
+      // the guarded state rather than the gesture.
+      await user.click(screen.getByRole("button", { name: "Keep editing" }))
+      await user.click(screen.getByLabelText("Key name"))
+      await user.keyboard("{Enter}")
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
     it("closes on Discard", async () => {
       const onOpenChange = vi.fn()
       const user = userEvent.setup()
@@ -293,6 +323,33 @@ describe("FormDialog", () => {
         "Unsaved changes",
       )
     })
+  })
+
+  it("returns a scrolled body to the top when a request fails", () => {
+    // The banner mounts at the top of the body, which in a scrolled `lg` body
+    // is above the fold: `role="alert"` reaches a screen reader, and a sighted
+    // operator watches the submit finish and sees nothing change.
+    //
+    // jsdom lays nothing out, so `scrollTop` here is only what a test sets. It
+    // still answers the question this covers, which is whether the effect
+    // writes it, and the assertion fails with the effect removed.
+    const { rerender } = render(
+      <FormDialog {...base} isOpen size="lg">
+        {withField}
+      </FormDialog>,
+    )
+    const body = screen
+      .getByRole("dialog")
+      .querySelector("form > div") as HTMLElement
+    body.scrollTop = 240
+    expect(body.scrollTop).toBe(240)
+
+    rerender(
+      <FormDialog {...base} isOpen size="lg" error={new Error("Refused.")}>
+        {withField}
+      </FormDialog>,
+    )
+    expect(body.scrollTop).toBe(0)
   })
 
   it("mounts a request failure at the top of the body, above the fields", () => {

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -107,6 +107,28 @@ describe("FormDialog", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })
 
+  it("runs the form's validation on Cmd/Ctrl+Enter rather than going around it", async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <FormDialog {...base} isOpen onSubmit={onSubmit}>
+        <label>
+          Instructions
+          <textarea name="instructions" required />
+        </label>
+      </FormDialog>,
+    )
+    await user.click(screen.getByLabelText("Instructions"))
+    // Required and empty. The shortcut goes through requestSubmit, so the
+    // browser refuses it exactly as it refuses the button; calling onSubmit
+    // directly would hand an invalid form to the mutation.
+    await user.keyboard("{Meta>}{Enter}{/Meta}")
+    expect(onSubmit).not.toHaveBeenCalled()
+    await user.keyboard("a")
+    await user.keyboard("{Meta>}{Enter}{/Meta}")
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
   it("submits on Enter from a single-line field, the way every form does", async () => {
     const onSubmit = vi.fn()
     const user = userEvent.setup()

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -1,5 +1,5 @@
 import { Modal, Spinner } from "@heroui/react"
-import { type ReactNode, useEffect, useState } from "react"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 import { FiX } from "react-icons/fi"
 
 import { Button } from "../actions/Button"
@@ -7,18 +7,6 @@ import { ErrorBanner } from "./ErrorBanner"
 
 /** `sm` 440px, `md` 520px (the default), `lg` 640px. */
 export type FormDialogSize = "sm" | "md" | "lg"
-
-/**
- * The widths, as an inline custom property rather than a class: the rule that
- * reads it is unlayered beside the `.modal__dialog` rule it has to outrank, so
- * a `w-[27.5rem]` at this call site would lose and the 448px floor would put
- * `sm` out of reach. Derived on `.otari-form-dialog` in `globals.css`.
- */
-const WIDTH: Record<FormDialogSize, string> = {
-  sm: "27.5rem",
-  md: "32.5rem",
-  lg: "40rem",
-}
 
 export interface FormDialogProps {
   isOpen: boolean
@@ -87,12 +75,22 @@ export function FormDialog({
   // rule between the pinned header and the content passing under it. The footer
   // keeps its rule in every state, so only this end of the body is conditional.
   const [isScrolled, setIsScrolled] = useState(false)
+  const bodyRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!isOpen) {
       setIsGuarding(false)
       setIsScrolled(false)
     }
   }, [isOpen])
+  // A failed submit mounts `ErrorBanner` at the top of the body, which in a
+  // scrolled `lg` body is above the fold: `role="alert"` reaches a screen
+  // reader, and a sighted operator watches the submit finish and sees nothing
+  // change. So the body goes back to the top, where the banner is.
+  useEffect(() => {
+    if (error === undefined || error === null) return
+    if (bodyRef.current) bodyRef.current.scrollTop = 0
+    setIsScrolled(false)
+  }, [error])
 
   const requestClose = () => {
     if (isPending) return
@@ -126,18 +124,17 @@ export function FormDialog({
           placement="top"
           // 120px from the top on a desktop viewport: a dialog optically
           // centered sits high, and a form that grows as fields appear should
-          // grow downward rather than creep up the screen. Below `sm` the
-          // container is the sheet's own frame and takes no padding.
-          className="p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-10"
+          // grow downward rather than creep up the screen. The same 120px below,
+          // because the gap is symmetric by design and the height cap the body
+          // scrolls at is the viewport minus both. Below `sm` the container is
+          // the sheet's own frame and takes no padding.
+          className="p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-[7.5rem]"
         >
           {/* No edge spelled here: globals.css gives every floating surface one
               opaque control-border hairline, unlayered, and argues that tier by
               name, so a `border-border` here would lose to it. */}
           <Modal.Dialog
-            className="otari-form-dialog flex flex-col p-0"
-            style={
-              { "--form-dialog-width": WIDTH[size] } as React.CSSProperties
-            }
+            className={`otari-form-dialog otari-form-dialog--${size} flex flex-col p-0`}
           >
             <header
               className={`flex shrink-0 items-start justify-between gap-4 px-6 pt-5 ${
@@ -180,7 +177,11 @@ export function FormDialog({
               // fields where Enter is a newline.
               onSubmit={(event) => {
                 event.preventDefault()
-                if (!isPending) onSubmit()
+                // `isGuarding` as well as `isPending`: the guard has taken the
+                // footer, so the submit control is not on screen, and a
+                // keyboard submit under it runs the mutation from a footer
+                // offering only Keep editing and Discard.
+                if (!isPending && !isGuarding) onSubmit()
               }}
               onKeyDown={(event) => {
                 if (event.key !== "Enter") return
@@ -190,7 +191,12 @@ export function FormDialog({
                 // constraint validation first, so the shortcut and the button
                 // are one path rather than two, and a required field left empty
                 // cannot reach the mutation through the keyboard alone.
-                if (!isPending) event.currentTarget.requestSubmit()
+                // Guarded here too, and not only in `onSubmit` where every
+                // path funnels: `requestSubmit` runs the form's validation
+                // first, which would focus an invalid field to answer a
+                // shortcut the guard is refusing.
+                if (!isPending && !isGuarding)
+                  event.currentTarget.requestSubmit()
               }}
               aria-busy={isPending}
               className="flex min-h-0 flex-col"
@@ -199,6 +205,7 @@ export function FormDialog({
                   push the footer off the viewport: a flex child's default
                   `min-height: auto` refuses to shrink below its content. */}
               <div
+                ref={bodyRef}
                 onScroll={(event) =>
                   setIsScrolled(event.currentTarget.scrollTop > 0)
                 }

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -1,0 +1,259 @@
+import { Modal, Spinner } from "@heroui/react"
+import { type ReactNode, useEffect, useState } from "react"
+import { FiX } from "react-icons/fi"
+
+import { Button } from "../actions/Button"
+import { ErrorBanner } from "./ErrorBanner"
+
+/** `sm` 440px, `md` 520px (the default), `lg` 640px. */
+export type FormDialogSize = "sm" | "md" | "lg"
+
+/**
+ * The widths, as an inline custom property rather than a class.
+ *
+ * `globals.css` pins `.modal__dialog` to `width: fit-content` with
+ * `min-width: min(28rem, …)`, unlayered so it outranks `@layer utilities`. A
+ * `w-[27.5rem]` here compiles, lints, ships and loses; and even where the width
+ * did land, the 448px floor makes `sm` unreachable. The rule that reads this
+ * property is unlayered beside that one, so the geometry is settled in CSS and
+ * the size a call site picks travels as a value.
+ */
+const WIDTH: Record<FormDialogSize, string> = {
+  sm: "27.5rem",
+  md: "32.5rem",
+  lg: "40rem",
+}
+
+export interface FormDialogProps {
+  isOpen: boolean
+  onOpenChange: (isOpen: boolean) => void
+  /** Names the object being made, not the action: "New key", not "Create key". */
+  title: string
+  /** One line under the title. The consequence, not a restatement of the title. */
+  description?: ReactNode
+  size?: FormDialogSize
+  /**
+   * The submit button's label, and the trigger's, word for word: the control
+   * that opened this dialog and the one that completes it say the same thing.
+   */
+  submitLabel: string
+  onSubmit: () => void
+  isPending: boolean
+  /** The caught value. Rendered by `ErrorBanner` at the top of the body. */
+  error?: unknown
+  /**
+   * Whether the form holds work that closing would lose. Arms the footer guard,
+   * so Escape and a click outside ask before discarding.
+   */
+  isDirty?: boolean
+  /** The footer's left slot: a "Create another" `Checkbox`, or a caption. */
+  footerStart?: ReactNode
+  /** A `TabRow` under the header. `lg` only, where a form has two shapes. */
+  tabs?: ReactNode
+  /** `Field`, `SecretField`, `Select`, `Checkbox`. Each with `reserveMessage`. */
+  children: ReactNode
+}
+
+/**
+ * The surface every create and edit form opens in.
+ *
+ * `ConfirmDialog` is the sibling for a destructive "are you sure", and the
+ * difference is not decorative: that one is an `AlertDialog`, which interrupts
+ * to ask one question, and a form is not an alert. This is a `Modal`.
+ *
+ * Controlled only, like every dialog here: it opens from a trigger elsewhere on
+ * the page (a heading row's Create, an empty state's CTA) and mounts its body
+ * only while open, so one row's draft cannot survive into the next row's.
+ */
+export function FormDialog({
+  isOpen,
+  onOpenChange,
+  title,
+  description,
+  size = "md",
+  submitLabel,
+  onSubmit,
+  isPending,
+  error,
+  isDirty = false,
+  footerStart,
+  tabs,
+  children,
+}: FormDialogProps) {
+  // The dirty guard lives in the footer rather than in a second dialog, because
+  // a dialog never opens a dialog.
+  const [isGuarding, setIsGuarding] = useState(false)
+  // Whether the body has been scrolled away from its top, which is what puts a
+  // rule between the pinned header and the content passing under it. The footer
+  // keeps its rule in every state, so only this end of the body is conditional.
+  const [isScrolled, setIsScrolled] = useState(false)
+  useEffect(() => {
+    if (!isOpen) {
+      setIsGuarding(false)
+      setIsScrolled(false)
+    }
+  }, [isOpen])
+
+  const requestClose = () => {
+    if (isPending) return
+    if (isDirty) {
+      setIsGuarding(true)
+      return
+    }
+    onOpenChange(false)
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(next) => {
+        if (next) {
+          onOpenChange(true)
+          return
+        }
+        requestClose()
+      }}
+    >
+      {/* HeroUI renders a press responder for the trigger slot and warns when
+          nothing fills it. These dialogs are driven from state, so the slot is
+          hidden rather than absent; `WorkspaceSwitcher` does the same. */}
+      <Modal.Trigger className="hidden">{submitLabel}</Modal.Trigger>
+      {/* No `bg-backdrop/50` here, despite the two dialogs that carry it:
+          globals.css dims `.modal__backdrop--opaque` to 50% in an unlayered
+          rule, which outranks the utility. Measured in the built stylesheet,
+          the class changes nothing. */}
+      <Modal.Backdrop isDismissable={!isPending}>
+        <Modal.Container
+          placement="top"
+          // 120px from the top on a desktop viewport: a dialog optically
+          // centered sits high, and a form that grows as fields appear should
+          // grow downward rather than creep up the screen. Below `sm` the
+          // container is the sheet's own frame and takes no padding.
+          className="p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-10"
+        >
+          {/* No edge spelled here. `globals.css` gives every floating surface
+              one opaque control-border hairline, unlayered, in the rule that
+              replaced elevation; a `border-border` at this call site would
+              compile, lint, ship and lose to it, and it argues against that
+              tier by name. */}
+          <Modal.Dialog
+            className="otari-form-dialog flex flex-col p-0"
+            style={
+              { "--form-dialog-width": WIDTH[size] } as React.CSSProperties
+            }
+          >
+            <header
+              className={`flex shrink-0 items-start justify-between gap-4 px-6 pt-5 ${
+                tabs ? "" : "pb-4"
+              } ${!tabs && isScrolled ? "border-border border-b" : ""}`}
+            >
+              <div className="flex flex-col gap-1">
+                <Modal.Heading className="text-heading">{title}</Modal.Heading>
+                {description ? (
+                  <p className="text-body text-muted">{description}</p>
+                ) : null}
+              </div>
+              {/* 32px glyph box lifted 4px so it centers on the title's own
+                  line rather than on the header block, with the 44px target
+                  bled outward so raising it moves no layout. */}
+              <Button
+                aria-label="Close"
+                className="relative -top-1 size-8 min-h-0 min-w-0 shrink-0 justify-center border-0 p-0 before:absolute before:-inset-1.5 before:content-['']"
+                isDisabled={isPending}
+                onPress={requestClose}
+              >
+                <FiX aria-hidden className="text-muted size-3.5" />
+              </Button>
+            </header>
+            {tabs ? (
+              <div className="border-border shrink-0 border-b px-6 pt-4 pb-3">
+                {tabs}
+              </div>
+            ) : null}
+            <form
+              // A real form, so a label associates, a password manager sees a
+              // submit, and Enter in a single-line field submits the way it
+              // does everywhere else. Cmd/Ctrl+Enter is added on top, for the
+              // fields where Enter is a newline.
+              onSubmit={(event) => {
+                event.preventDefault()
+                if (!isPending) onSubmit()
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return
+                if (!event.metaKey && !event.ctrlKey) return
+                event.preventDefault()
+                if (!isPending) onSubmit()
+              }}
+              className="flex min-h-0 flex-col"
+            >
+              {/* `min-h-0` above and here is what lets this scroll rather than
+                  push the footer off the viewport: a flex child's default
+                  `min-height: auto` refuses to shrink below its content. */}
+              <div
+                onScroll={(event) =>
+                  setIsScrolled(event.currentTarget.scrollTop > 0)
+                }
+                className="flex min-h-0 flex-col gap-4 overflow-y-auto px-6 pt-1 pb-6"
+              >
+                <ErrorBanner error={error} />
+                {children}
+              </div>
+              <footer className="border-border flex shrink-0 items-center justify-between gap-2 border-t px-6 py-3">
+                {isGuarding ? (
+                  <>
+                    <p className="text-caption">Unsaved changes</p>
+                    <div className="flex items-center gap-2">
+                      <Button onPress={() => setIsGuarding(false)}>
+                        Keep editing
+                      </Button>
+                      <Button
+                        variant="danger"
+                        onPress={() => {
+                          setIsGuarding(false)
+                          onOpenChange(false)
+                        }}
+                      >
+                        Discard
+                      </Button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="min-w-0">{footerStart}</div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Button isDisabled={isPending} onPress={requestClose}>
+                        Cancel
+                      </Button>
+                      {/* The spinner replaces the label in place rather than
+                          sitting beside it, so the button keeps its resting
+                          width and the footer keeps its height. HeroUI's
+                          `isPending` draws no spinner of its own: it sets
+                          `data-pending`, which the stylesheet answers with
+                          `pointer-events: none` and nothing else. */}
+                      <Button
+                        type="submit"
+                        variant="primary"
+                        isPending={isPending}
+                        className="relative"
+                      >
+                        <span className={isPending ? "invisible" : undefined}>
+                          {submitLabel}
+                        </span>
+                        {isPending ? (
+                          <span className="absolute inset-0 flex items-center justify-center">
+                            <Spinner size="sm" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </footer>
+            </form>
+          </Modal.Dialog>
+        </Modal.Container>
+      </Modal.Backdrop>
+    </Modal>
+  )
+}

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -193,7 +193,11 @@ export function FormDialog({
                 if (event.key !== "Enter") return
                 if (!event.metaKey && !event.ctrlKey) return
                 event.preventDefault()
-                if (!isPending) onSubmit()
+                // `requestSubmit`, not `onSubmit` directly: it runs the form's
+                // constraint validation first, so the shortcut and the button
+                // are one path rather than two, and a required field left empty
+                // cannot reach the mutation through the keyboard alone.
+                if (!isPending) event.currentTarget.requestSubmit()
               }}
               aria-busy={isPending}
               className="flex min-h-0 flex-col"

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -9,14 +9,10 @@ import { ErrorBanner } from "./ErrorBanner"
 export type FormDialogSize = "sm" | "md" | "lg"
 
 /**
- * The widths, as an inline custom property rather than a class.
- *
- * `globals.css` pins `.modal__dialog` to `width: fit-content` with
- * `min-width: min(28rem, …)`, unlayered so it outranks `@layer utilities`. A
- * `w-[27.5rem]` here compiles, lints, ships and loses; and even where the width
- * did land, the 448px floor makes `sm` unreachable. The rule that reads this
- * property is unlayered beside that one, so the geometry is settled in CSS and
- * the size a call site picks travels as a value.
+ * The widths, as an inline custom property rather than a class: the rule that
+ * reads it is unlayered beside the `.modal__dialog` rule it has to outrank, so
+ * a `w-[27.5rem]` at this call site would lose and the 448px floor would put
+ * `sm` out of reach. Derived on `.otari-form-dialog` in `globals.css`.
  */
 const WIDTH: Record<FormDialogSize, string> = {
   sm: "27.5rem",
@@ -122,10 +118,9 @@ export function FormDialog({
           nothing fills it. These dialogs are driven from state, so the slot is
           hidden rather than absent; `WorkspaceSwitcher` does the same. */}
       <Modal.Trigger className="hidden">{submitLabel}</Modal.Trigger>
-      {/* No `bg-backdrop/50` here, despite the two dialogs that carry it:
-          globals.css dims `.modal__backdrop--opaque` to 50% in an unlayered
-          rule, which outranks the utility. Measured in the built stylesheet,
-          the class changes nothing. */}
+      {/* No `bg-backdrop/50`: globals.css dims `.modal__backdrop--opaque` in
+          an unlayered rule that outranks the utility, so the class changes
+          nothing (#1033). */}
       <Modal.Backdrop isDismissable={!isPending}>
         <Modal.Container
           placement="top"
@@ -135,11 +130,9 @@ export function FormDialog({
           // container is the sheet's own frame and takes no padding.
           className="p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-10"
         >
-          {/* No edge spelled here. `globals.css` gives every floating surface
-              one opaque control-border hairline, unlayered, in the rule that
-              replaced elevation; a `border-border` at this call site would
-              compile, lint, ship and lose to it, and it argues against that
-              tier by name. */}
+          {/* No edge spelled here: globals.css gives every floating surface one
+              opaque control-border hairline, unlayered, and argues that tier by
+              name, so a `border-border` here would lose to it. */}
           <Modal.Dialog
             className="otari-form-dialog flex flex-col p-0"
             style={

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -50,7 +50,11 @@ export interface FormDialogProps {
   footerStart?: ReactNode
   /** A `TabRow` under the header. `lg` only, where a form has two shapes. */
   tabs?: ReactNode
-  /** `Field`, `SecretField`, `Select`, `Checkbox`. Each with `reserveMessage`. */
+  /**
+   * `Field`, `SecretField`, `Select`, `Checkbox`. A field with a description
+   * takes `reserveMessage`, so an error replaces that line instead of moving
+   * the footer; one with nothing to say under it reserves nothing.
+   */
   children: ReactNode
 }
 
@@ -153,12 +157,18 @@ export function FormDialog({
                   <p className="text-body text-muted">{description}</p>
                 ) : null}
               </div>
-              {/* 32px glyph box lifted 4px so it centers on the title's own
-                  line rather than on the header block, with the 44px target
-                  bled outward so raising it moves no layout. */}
+              {/* `isIconOnly` at `sm` is what makes this a 32px square with no
+                  edge: the rule that drops a ghost's border is keyed on the
+                  control being icon-only, so a `border-0` here would be a call
+                  site trying to remember something the system already knows.
+                  Lifted 4px to center on the title's own line rather than on
+                  the header block, with the 44px target bled outward so
+                  raising it moves no layout. */}
               <Button
                 aria-label="Close"
-                className="relative -top-1 size-8 min-h-0 min-w-0 shrink-0 justify-center border-0 p-0 before:absolute before:-inset-1.5 before:content-['']"
+                isIconOnly
+                size="sm"
+                className="relative -top-1 shrink-0 before:absolute before:-inset-1.5 before:content-['']"
                 isDisabled={isPending}
                 onPress={requestClose}
               >
@@ -185,6 +195,7 @@ export function FormDialog({
                 event.preventDefault()
                 if (!isPending) onSubmit()
               }}
+              aria-busy={isPending}
               className="flex min-h-0 flex-col"
             >
               {/* `min-h-0` above and here is what lets this scroll rather than
@@ -225,24 +236,45 @@ export function FormDialog({
                       <Button isDisabled={isPending} onPress={requestClose}>
                         Cancel
                       </Button>
-                      {/* The spinner replaces the label in place rather than
+                      {/* Not `isPending`, and not `isDisabled`. Both land on
+                          the product's one disabled treatment, which is 0.4
+                          opacity and has to read as *denied*; a submit in
+                          flight is working, not refused, and the design keeps
+                          its fill. So the press is blocked by hand
+                          (`pointer-events`, plus the guard in `onSubmit` for
+                          the keyboard) and `aria-busy` says what is happening.
+
+                          The spinner replaces the label in place rather than
                           sitting beside it, so the button keeps its resting
-                          width and the footer keeps its height. HeroUI's
-                          `isPending` draws no spinner of its own: it sets
-                          `data-pending`, which the stylesheet answers with
-                          `pointer-events: none` and nothing else. */}
+                          width and the footer keeps its height. `opacity-0`
+                          rather than `invisible`: `visibility: hidden` would
+                          take the label out of the accessibility tree and
+                          leave the button with no name mid-submit.
+
+                          The busy state is announced from the form's
+                          `aria-busy` rather than the button's: react-aria
+                          filters unrecognized ARIA off a Button, so an
+                          `aria-busy` here reaches no DOM node at all. */}
                       <Button
                         type="submit"
                         variant="primary"
-                        isPending={isPending}
-                        className="relative"
+                        className={`relative ${isPending ? "pointer-events-none" : ""}`}
                       >
-                        <span className={isPending ? "invisible" : undefined}>
+                        <span className={isPending ? "opacity-0" : undefined}>
                           {submitLabel}
                         </span>
                         {isPending ? (
                           <span className="absolute inset-0 flex items-center justify-center">
-                            <Spinner size="sm" aria-hidden="true" />
+                            {/* `current`, not the default `accent`: the accent
+                                is this button's own fill, so the default paints
+                                teal on teal. `current` inherits the button's
+                                ink, which is what makes it white here and would
+                                make it right on any other ground. */}
+                            <Spinner
+                              size="sm"
+                              color="current"
+                              aria-hidden="true"
+                            />
                           </span>
                         ) : null}
                       </Button>

--- a/web/src/design-system/overlays/Popover.stories.tsx
+++ b/web/src/design-system/overlays/Popover.stories.tsx
@@ -10,9 +10,9 @@ import { Popover } from "./Popover"
  *
  * The line against `Tooltip`: a tooltip labels, a popover holds content an
  * operator interacts with, so this one takes focus and is dismissed
- * deliberately. The line against `Dialog`: a dialog is modal and centered
- * because it wants the whole screen, a popover stays anchored because what it
- * says is about the thing it points at.
+ * deliberately. The line against `Dialog`: a dialog is modal because it wants
+ * the whole screen, a popover stays anchored because what it says is about the
+ * thing it points at.
  *
  * Uncontrolled by default, which is the opposite of `Dialog` and deliberate: a
  * popover's trigger is inside it, so it can own that state.

--- a/web/src/design-system/overlays/Popover.tsx
+++ b/web/src/design-system/overlays/Popover.tsx
@@ -6,9 +6,9 @@ import type { ReactNode } from "react"
  *
  * The line against `Tooltip`: a tooltip labels, a popover holds content an
  * operator interacts with, so this one takes focus and is dismissed
- * deliberately. The line against `Dialog`: a dialog is modal and centered
- * because it wants the whole screen's attention, a popover stays anchored
- * because what it says is about the thing it points at.
+ * deliberately. The line against `Dialog`: a dialog is modal because it wants
+ * the whole screen's attention, a popover stays anchored because what it says
+ * is about the thing it points at.
  *
  * Uncontrolled by default, which is the opposite of `Dialog` and deliberate: a
  * popover is opened by its own trigger, which is inside it, so it can own that

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2133,6 +2133,43 @@ main {
   overflow: visible;
 }
 
+/* FormDialog's geometry, which cannot live at its call site.
+ *
+ * The `.modal__dialog` rule above is unlayered, so it outranks
+ * `@layer utilities` and a `w-[32.5rem]` on the dialog compiles, lints, ships
+ * and loses; its `min-width` would beat that class even where the width landed,
+ * which is what makes the 440px size unreachable rather than merely fragile.
+ * Both were read out of the emitted stylesheet. So the size travels as a value the
+ * component sets inline (`--form-dialog-width`) and the geometry is settled
+ * here, beside the rule it has to outrank.
+ *
+ * `--visual-viewport-height` is HeroUI's own, already on the container, so the
+ * height budget follows a phone's keyboard rather than the layout viewport.
+ * 15rem is the 120px offset the dialog sits at, twice: what is left is where
+ * the body starts scrolling and the header and footer stay put. */
+.otari-form-dialog {
+  width: var(--form-dialog-width);
+  min-width: 0;
+  max-width: calc(100vw - 2rem);
+  max-height: calc(var(--visual-viewport-height, 100dvh) - 15rem);
+}
+
+/* Below 640px every size is a full-screen sheet: a centered box with a phone's
+ * margins around it wastes the only axis a form needs, and the keyboard takes
+ * half of what is left. The footer clears the home indicator. */
+@media (max-width: 639px) {
+  .otari-form-dialog {
+    width: 100%;
+    max-width: none;
+    height: var(--visual-viewport-height, 100dvh);
+    max-height: none;
+    border: 0;
+  }
+  .otari-form-dialog > form > footer {
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  }
+}
+
 /* Backdrop dimming — HeroUI's default backdrop variant is `opaque`, and that
  * modifier applies `bg-backdrop` at full strength. `--color-backdrop` is pure
  * black in both themes on purpose (see its comment above: a fixed alpha then

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2139,19 +2139,31 @@ main {
  * `@layer utilities` and a `w-[32.5rem]` on the dialog compiles, lints, ships
  * and loses; its `min-width` would beat that class even where the width landed,
  * which is what makes the 440px size unreachable rather than merely fragile.
- * Both were read out of the emitted stylesheet. So the size travels as a value the
- * component sets inline (`--form-dialog-width`) and the geometry is settled
- * here, beside the rule it has to outrank.
+ * Both were read out of the emitted stylesheet.
  *
  * `--visual-viewport-height` is HeroUI's own, already on the container, so the
  * height budget follows a phone's keyboard rather than the layout viewport.
- * 15rem is the 120px offset the dialog sits at, twice: what is left is where
- * the body starts scrolling and the header and footer stay put. */
+ * 15rem is the 120px offset the dialog sits at, twice: the gap above and below
+ * is symmetric by design, and what is left is where the body starts scrolling
+ * while the header and footer stay put. */
 .otari-form-dialog {
-  width: var(--form-dialog-width);
   min-width: 0;
   max-width: calc(100vw - 2rem);
   max-height: calc(var(--visual-viewport-height, 100dvh) - 15rem);
+}
+
+/* The three sizes, as modifiers rather than a value the component sets inline:
+ * what the unlayered rule above beats is a `width`, and nothing declares these,
+ * so a class here has nothing to lose to. The phone block below is later still,
+ * which is what lets a sheet ignore all three. */
+.otari-form-dialog--sm {
+  width: 27.5rem;
+}
+.otari-form-dialog--md {
+  width: 32.5rem;
+}
+.otari-form-dialog--lg {
+  width: 40rem;
 }
 
 /* A field fills this dialog. `Field` and `SecretField` cap themselves at
@@ -2167,7 +2179,12 @@ main {
 
 /* Below 640px every size is a full-screen sheet: a centered box with a phone's
  * margins around it wastes the only axis a form needs, and the keyboard takes
- * half of what is left. The footer clears the home indicator. */
+ * half of what is left.
+ *
+ * The footer takes no rule of its own: `env(safe-area-inset-bottom)` is 0
+ * without `viewport-fit=cover`, which `index.html` leaves off deliberately (the
+ * shell has no insets to sit out of the way), so a safe-area pad here would
+ * read as clearing the home indicator while adding nothing. */
 @media (max-width: 639px) {
   .otari-form-dialog {
     width: 100%;
@@ -2175,9 +2192,6 @@ main {
     height: var(--visual-viewport-height, 100dvh);
     max-height: none;
     border: 0;
-  }
-  .otari-form-dialog > form > footer {
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
   }
 }
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2154,6 +2154,17 @@ main {
   max-height: calc(var(--visual-viewport-height, 100dvh) - 15rem);
 }
 
+/* A field fills this dialog. `Field` and `SecretField` cap themselves at
+ * `max-w-md`, which is right on a page (a 448px measure under a 620px column
+ * keeps a name field from reading as a paragraph) and wrong here: it left a
+ * 448px input in the 638px body of an `lg` dialog, with 190px of nothing beside
+ * it. The dialog is a named place the way a toolbar is, so the override belongs
+ * to the place rather than to every call site inside it, and it is keyed on
+ * HeroUI's own `data-slot` because that is the element carrying the cap. */
+.otari-form-dialog [data-slot="textfield"] {
+  max-width: none;
+}
+
 /* Below 640px every size is a full-screen sheet: a centered box with a phone's
  * margins around it wastes the only axis a form needs, and the keyboard takes
  * half of what is left. The footer clears the home indicator. */


### PR DESCRIPTION
## Description

Every create flow in the dashboard opens in the same surface now, or will: this
adds the surface, and nothing is migrated onto it yet.

The problem it settles is one an operator hits on their second page. The action
that starts a create sits in a page's top right on `/routing` and halfway down
the page on `tools/mcp-servers`; pressing it opens a modal on
`tools/mcp-servers` and appends a whole new section to the page on `/keys`. Two
inconsistencies, so a page has to be learned rather than recognized.
`FormDialog` is the surface half. The placement and label rules are the other
half, and they are written down in `web/design/actions.md` beside it.

It is built on HeroUI's `Modal` rather than `AlertDialog`, which is the
difference between it and `ConfirmDialog` rather than a detail of it: an alert
interrupts to ask one question, and a form is a place to work. `ConfirmDialog`
stays exactly as it is, for "are you sure".

Three things it owns because call sites kept getting them wrong on their own:

- **The footer never changes height, and the primary never changes width.**
  `isPending` replaces the label with a spinner *in place*. That is the
  component's doing, not the library's: HeroUI's `isPending` draws no spinner
  (it sets `data-pending`, which the stylesheet answers with
  `pointer-events: none` and nothing else), so today's forms swap the label for
  "Creating…" and the button changes width mid-submit.
- **`isDirty` arms a guard in the footer, not a second dialog.** Escape and a
  click outside swap the actions for "Unsaved changes · Keep editing ·
  Discard". A dialog never opens a dialog.
- **The widths live in `globals.css`, not at the call site.** `.modal__dialog`
  is pinned there unlayered (`width: fit-content`, `min-width: min(28rem, …)`),
  which outranks `@layer utilities`: a `w-[32.5rem]` on the dialog compiles,
  lints, ships and loses, and the 440px size is unreachable under the 448px
  floor whatever you write. So the size travels as an inline
  `--form-dialog-width` and the geometry is settled beside the rule it has to
  beat. Both facts were read out of the emitted stylesheet rather than reasoned
  about.

Also here: `design/overlays.md` and `design/DESIGN.md` are corrected, because
they told a reader to reach for the bare `Dialog` shell when a dialog holds a
form. That shell has one importer in the tree, its own story, and no product
call site; it is left in place rather than deleted, since removing it is a
separate decision.

## How to test it locally

    pnpm --dir web run storybook

`Design system → Feedback → FormDialog`, ten stories: one per size, one per
state (submitting, request failed, dirty guard, success step), the scrolling
`lg` body, and a phone sheet on the 414px viewport preset.

Worth eyeballing, because no test asserts geometry: that the primary does not
change width between **Medium** and **Submitting**, that **ScrollingBody**
keeps its header and footer put and grows a hairline under the header only once
content is under it, and that **PhoneSheet** fills the frame.

Measured on the rendered page rather than asserted, for the record: widths 440 /
520 / 640, dialog top 120px, header 20/24/16/24, footer 12/24, title 18px at
weight 550, submit button 105.72px both resting and pending, footer 61px in both
states, phone sheet 414x800 at (0,0) with 16px inputs and 44px controls.

Automated, all run on this commit:

- `pnpm --dir web test` — 5288 pass, 152 files, of which 17 are
  `FormDialog.test.tsx`.
- `pnpm --dir web run lint`, `pnpm --dir web run typecheck`,
  `pnpm --dir web run build` — clean.
- `pnpm --dir web run storybook:build`, then
  `pnpm --dir web exec node .storybook/smoke.mjs` — 376 stories x 2 themes, all
  rendered clean.

Each of the 17 cases was checked by removing the behavior it covers and
watching it fail: deleting the dirty guard fails 4, sending the spinner beside
the label instead of over it fails 1, dropping the Cmd/Ctrl+Enter handler fails
1, swapping `Modal` for `AlertDialog` fails 5, un-disabling the close control
while pending fails 1, moving the error banner below the fields fails 1, and
removing the close control's `aria-label` fails 7. The keyboard case needed
that pass to be honest: written against a single-line input it passed with the
handler deleted, because the browser's own implicit form submission fires
there, so it is written against a textarea and asserts that plain Enter inserts
a newline first.

Nothing about backend behavior changes, so no OpenAPI artifact moves.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of #1031

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      17 cases in `web/src/design-system/feedback/FormDialog.test.tsx`, plus ten
      Storybook stories. The dashboard's tests live under `web/src`, next to the
      component, rather than in the repo-root `tests/` the template names.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      The dashboard's counterparts, which is what this diff touches: `make lint`
      does not reach `web/`. Commands and results above.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      The API contract did not change; no route, schema or docstring is touched.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The design was specified in Paper and read out of that file with the MCP server
rather than off screenshots. Two places the specification and this codebase
disagreed are called out in the review comments on the diff rather than settled
quietly here.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added the shared `FormDialog` for create and edit forms.
- Added loading, error, success, scrolling, mobile sheet, and unsaved-changes states.
- Added 17 component tests and 10 Storybook stories.
- Updated design documentation and form styling.
- Kept existing flows, `Dialog`, and `ConfirmDialog` unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->