### PR TITLE
fix(dashboard): put every record deletion behind a confirm dialog

### DIFF
--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -167,7 +167,8 @@ than duplicating their markup. See [design-tokens.md](./design-tokens.md).
 | Error alert from an unknown thrown value | `ErrorBanner` (`feedback/`; pairs with `errorMessage(error)` from `feedback/errorMessage`) |
 | Info/warning callout | `InfoBanner` (`feedback/`; `tone="info" \| "warning"`) |
 | Page title + description + action | `PageIntro` (`layout/`). **Not** `PageHeader`, which is in `deprecated/` |
-| Destructive action without a modal | `ConfirmButton` (`actions/`; two-click arm/confirm), or `ConfirmRowAction` inside a table row |
+| Deleting a record | `ConfirmDialog` (`feedback/`), always, one row or a selection. A neutral `RowAction` or ghost `Button` opens it and the dialog carries the danger confirm; the delete's `isPending` and `error` go to the dialog, not to the page's `ErrorBanner`. See [actions.md](../../../web/design/actions.md) |
+| Destructive action that deletes nothing (regenerate, archive, reset) | `ConfirmButton` (`actions/`; two-click arm/confirm), or `ConfirmRowAction` inside a table row |
 | Filter over a small fixed option set | `FilterSelect` (`navigation/`; a HeroUI `Select`, so the list is a popover anchored under the trigger) |
 | Filter over a large or open option set | `FilterMultiComboBox` (`navigation/`; type-to-filter, holds a set of values; `allowsCustom` when the value space is not enumerable) |
 | Applied filters, each removable | `FilterChips` (`navigation/`); one chip per value, and pass `clearLabel` so several chips of one dimension stay distinguishable |

--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -176,7 +176,7 @@ and [web/AGENTS.md](../AGENTS.md).
 | [colors.md](colors.md) | Surfaces, text ramp, borders, the accent's five jobs, status, chart slots |
 | [typography.md](typography.md) | The 12 type roles, the ladder rule, the three families |
 | [layout.md](layout.md) | Bands, the bleed rule, `Section`, `PageIntro`, `SettingsGroup`, `SettingRow`, page recipes |
-| [actions.md](actions.md) | The three button variants, sizes, places, icon-only, the two-step confirm, and the other action shapes (`RowAction`, `RefreshButton`, `CopyButton`) |
+| [actions.md](actions.md) | The three button variants, sizes, places, icon-only, the delete confirm dialog and the two-step confirm that is left beside it, and the other action shapes (`RowAction`, `RefreshButton`, `CopyButton`) |
 | [forms.md](forms.md) | `Field`, `SecretField`, `Toggle`, `Checkbox`, selects, validation timing |
 | [data.md](data.md) | `DataTable`, pagination, bulk actions |
 | [metrics.md](metrics.md) | KPI strip, trends, meters, status marks, charts |

--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -35,7 +35,9 @@ band" rule wants the friction to point: the accent has to be asked for.
 Is it the single thing this band is for?
  ├── Yes -> variant="primary"          (two in one band means the band has no hierarchy)
  └── No
-      ├── Is it destructive or hard to undo?
+      ├── Does it delete a record?
+      │    └── Yes -> a neutral trigger that opens a ConfirmDialog (see below)
+      ├── Is it destructive or hard to undo, but deletes nothing?
       │    └── Yes -> variant="danger", and reach for ConfirmButton
       └── Default -> variant="ghost"
 ```
@@ -89,10 +91,50 @@ written the same way.
 control *is*, not where it sits: `CopyButton` renders in tables, panels, banners and
 bare pages, so no container can reach it.
 
+## Deleting a record: a dialog, never an in-place confirm
+
+**Every delete of a record goes through `ConfirmDialog`** (otari-ai#2110), whether
+it deletes one row or a selection of them. The trigger is a plain `RowAction` or a
+ghost `Button` that only opens the dialog, and the dialog carries the danger
+confirm. A confirmation that armed inside the row read as part of the table rather
+than as a decision, and it had nowhere to put the consequence: the sentence that
+says what the deletion costs does not fit on a row action.
+
+```tsx
+// Correct: a neutral trigger, and the decision in the dialog
+<RowAction onPress={() => setPendingDelete(row)}>Delete</RowAction>
+…
+<ConfirmDialog
+  isOpen={pendingDelete !== undefined}
+  onOpenChange={(open) => {
+    if (!open) setPendingDelete(undefined)
+  }}
+  heading="Delete rate override"
+  body={pendingDelete ? `${pendingDelete.model_key} returns to the catalog rate…` : null}
+  confirmLabel="Delete override"
+  isPending={remove.isPending}
+  error={remove.error}
+  onConfirm={…}
+/>
+
+// Incorrect: the confirmation arms in the row, so the decision reads as a cell
+<ConfirmRowAction confirmLabel="Delete" onConfirm={remove}>Delete</ConfirmRowAction>
+```
+
+`pendingDelete` holding the target row (`undefined` when closed) is the idiom, and
+the mutation's `onSuccess` clears it. The dialog owns `isPending` and `error`, so
+the page's own `ErrorBanner` drops the delete: a message behind the backdrop is a
+message the operator does not read. See [feedback.md](feedback.md).
+
+The dialog names the object and the consequence, and its confirm names the
+consequence rather than repeating the trigger's word: "Delete permanently", not
+"Delete" under a "Delete".
+
 ## The two-step destructive confirm
 
-`ConfirmButton` for a page-level destructive action, `ConfirmRowAction` for one in
-a table row. Both arm on the first click and destroy on the second.
+For a destructive action that **deletes nothing**: a regenerate, an archive, a
+reset to a default. `ConfirmButton` at page level, `ConfirmRowAction` in a table
+row. Both arm on the first click and destroy on the second.
 
 The resting trigger is **neutral** and the armed confirm is danger. The first click
 is safe, so spending the loudest signal in the product on it wastes it; the danger
@@ -103,12 +145,12 @@ names the consequence.
 
 ```tsx
 // Correct
-<ConfirmButton confirmLabel="Remove permanently" onConfirm={remove}>
-  Remove tool
+<ConfirmButton confirmLabel="Reset to default" onConfirm={reset}>
+  Reset price
 </ConfirmButton>
 
 // Incorrect: the same word twice tells the operator nothing about what changed
-<ConfirmButton confirmLabel="Remove" onConfirm={remove}>Remove</ConfirmButton>
+<ConfirmButton confirmLabel="Reset" onConfirm={reset}>Reset</ConfirmButton>
 ```
 
 **The Cancel that appears when armed is load-bearing. Do not simplify it away.**
@@ -125,8 +167,8 @@ hides.
 | `RowAction` | `onPress`, `isDanger?`, `isDisabled?`, `ariaLabel?`, children | An action in a table row. Caption-sized, not a `Button` |
 | `RowActionRow` | children | The trailing lane those sit in. **Use this one** |
 | `RowActions` | children | A near-duplicate with a tighter gap, on 2 call sites. Do not reach for it in new code |
-| `ConfirmButton` | `confirmLabel`, `onConfirm`, `isPending?`, children | The page-level two-step confirm |
-| `ConfirmRowAction` | `confirmLabel`, `onConfirm`, `isPending?`, children | The same two-step inside a row. It supplies its own `isDanger` and its own Cancel |
+| `ConfirmButton` | `confirmLabel`, `onConfirm`, `isPending?`, children | The page-level two-step confirm, for a destructive action that deletes nothing |
+| `ConfirmRowAction` | `confirmLabel`, `onConfirm`, `isPending?`, children | The same two-step inside a row. It supplies its own `isDanger` and its own Cancel. Not for a delete |
 | `RefreshButton` | `onRefresh`, `isFetching?`, `updatedAt?`, `label?` | A refetch, with its own freshness caption. Pass `updatedAt` or the caption reads nothing |
 | `CopyButton` | `value`, `label` | Copy one value. Icon-only, 44x44 hit area |
 | `CopyField` | `label`, `value`, `multiline?`, `concealed?`, `action?` | A readonly field of a value to paste elsewhere. `concealed` is what it shows until the operator asks for the value, for a credential: Copy copies the real one either way, so a key is handed over without being read off the screen |

--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -107,7 +107,9 @@ says what the deletion costs does not fit on a row action.
 <ConfirmDialog
   isOpen={pendingDelete !== undefined}
   onOpenChange={(open) => {
-    if (!open) setPendingDelete(undefined)
+    if (open) return
+    setPendingDelete(undefined)
+    remove.reset()
   }}
   heading="Delete rate override"
   body={pendingDelete ? `${pendingDelete.model_key} returns to the catalog rate…` : null}
@@ -125,6 +127,12 @@ says what the deletion costs does not fit on a row action.
 the mutation's `onSuccess` clears it. The dialog owns `isPending` and `error`, so
 the page's own `ErrorBanner` drops the delete: a message behind the backdrop is a
 message the operator does not read. See [feedback.md](feedback.md).
+
+**Reset the mutation when the dialog closes.** A refusal stays on it until the next
+call, and the dialog reads it on open, so without this the next row's confirm opens
+already reporting a failure that was about the row before it. On close rather than
+on open, so the trigger in the row stays a bare `setPendingDelete` and a memoized
+column keeps its per-row cache.
 
 The dialog names the object and the consequence, and its confirm names the
 consequence rather than repeating the trigger's word: "Delete permanently", not

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -25,8 +25,10 @@ Is it loading?
  └── One section    -> the section's own isLoading, which keeps the heading
 Did the page fail to render at all?
  └── PageError             (the catch boundaries' panel; see below)
-Is the action destructive and does it need more than a second click?
- └── ConfirmDialog          (otherwise ConfirmButton; see actions.md)
+Does the action delete a record?
+ └── ConfirmDialog          (always, one row or many; see actions.md)
+Is it destructive but deletes nothing (regenerate, archive, reset)?
+ └── ConfirmButton          (the two-step confirm; see actions.md)
 ```
 
 ## Signatures
@@ -105,12 +107,15 @@ hidden is carrying that meaning on its own, at `opacity: 0.4`.
 
 ## ConfirmDialog
 
-For a destructive action that needs a sentence of context, or that has to report an
-error in place. `confirmVariant` defaults to `danger`. It owns `isPending` and
-`error` so the caller does not build a second error surface inside a modal.
+**Every delete of a record**, and any other destructive action that needs a
+sentence of context or has to report an error in place. `confirmVariant` defaults
+to `danger`. It owns `isPending` and `error` so the caller does not build a second
+error surface inside a modal, which is also why the page's own `ErrorBanner` stops
+carrying that mutation: reporting it in both puts the message the operator needs
+behind the backdrop they are looking at.
 
-Prefer `ConfirmButton` when the label alone is enough: a modal for a revoke that
-takes one click to undo is a wall.
+`ConfirmButton`'s two-step is what is left, for a destructive action that deletes
+nothing. See [actions.md](actions.md) for both.
 
 ## Copy
 

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -79,8 +79,8 @@ Modal and centered. `Dialog` is the shell; `ConfirmDialog` is its
 specialization for a destructive action, with the two buttons and the error line
 built in.
 
-Reach for `ConfirmDialog` when the dialog's whole job is "are you sure", and for
-`Dialog` when it holds a form.
+Reach for `ConfirmDialog` when the dialog's whole job is "are you sure", which
+includes every delete of a record, and for `Dialog` when it holds a form.
 
 Both are controlled only, because a dialog opens from something elsewhere on the
 page (a row's Edit, a toolbar's Add) rather than from a trigger inside itself.

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -8,7 +8,6 @@ import {
   openNested,
   openOrganization,
   pageHeading,
-  table,
   tableRows,
 } from "./helpers"
 import { PARITY } from "./parity-data"
@@ -117,14 +116,16 @@ test.describe("standalone provider setup", () => {
     )
     await page.getByRole("button", { name: "Cancel" }).click()
 
-    // Two presses on the same control: the first arms it, the second confirms
-    // (ConfirmButton, whose confirm label here is also "Delete").
-    const deleteProvider = row(page, "Providers", PROVIDER).getByRole(
-      "button",
-      { name: "Delete" },
-    )
-    await deleteProvider.click()
-    await deleteProvider.click()
+    // The confirmation is a modal, so it names the provider rather than relying
+    // on the row behind the backdrop to say which one this is about.
+    await row(page, "Providers", PROVIDER)
+      .getByRole("button", { name: "Delete" })
+      .click()
+    const confirmProvider = page.getByRole("alertdialog")
+    await expect(confirmProvider).toContainText(PROVIDER)
+    await confirmProvider
+      .getByRole("button", { name: "Delete provider" })
+      .click()
     await expect(row(page, "Providers", PROVIDER)).toHaveCount(0)
   })
 })
@@ -166,14 +167,11 @@ test.describe("api keys", () => {
     await expect(key.getByRole("button", { name: "Enable" })).toBeVisible()
 
     await key.getByRole("button", { name: "Delete" }).click()
-    // Scoped to the table rather than to `key`: arming a row now renders the
-    // confirmation as a strip in its own row beside it, not inside the cell, so
-    // a row-scoped locator cannot see the control it arms. `table` rather than
-    // `tableRows`, because that helper keeps only rows carrying a row header and
-    // the strip is a detail row with none.
-    await table(page, "API keys")
-      .getByRole("button", { name: "Delete permanently" })
-      .click()
+    // Scoped to the dialog rather than to `key`: the confirmation is a modal
+    // now, outside the table entirely.
+    const confirmKey = page.getByRole("alertdialog")
+    await expect(confirmKey).toContainText(KEY_NAME)
+    await confirmKey.getByRole("button", { name: "Delete permanently" }).click()
     await expect(row(page, "API keys", KEY_NAME)).toHaveCount(0)
   })
 })
@@ -225,12 +223,17 @@ test.describe("budgets", () => {
     await expect(page.getByText(`Reset history — ${BUDGET}`)).toBeVisible()
     await page.getByRole("button", { name: "Close" }).click()
 
-    // Deleting is armed first, and the confirmation names the budget it is about
-    // to drop rather than asking in the abstract.
-    const budgetRow = row(page, "Budgets", BUDGET)
-    await budgetRow.getByRole("button", { name: "Delete", exact: true }).click()
-    await expect(budgetRow).toContainText(`Delete ${BUDGET}?`)
-    await budgetRow.getByRole("button", { name: "Delete permanently" }).click()
+    // The confirmation names the budget it is about to drop rather than asking
+    // in the abstract, which is half of why it is a modal: the row it names is
+    // behind the backdrop.
+    await row(page, "Budgets", BUDGET)
+      .getByRole("button", { name: "Delete", exact: true })
+      .click()
+    const confirmBudget = page.getByRole("alertdialog")
+    await expect(confirmBudget).toContainText(BUDGET)
+    await confirmBudget
+      .getByRole("button", { name: "Delete permanently" })
+      .click()
     await expect(row(page, "Budgets", BUDGET)).toHaveCount(0)
   })
 })
@@ -288,7 +291,9 @@ test.describe("fallback routing", () => {
     await row(page, "Routing policies", POLICY)
       .getByRole("button", { name: "Delete" })
       .click()
-    await page.getByRole("button", { name: "Confirm" }).click()
+    const confirmPolicy = page.getByRole("alertdialog")
+    await expect(confirmPolicy).toContainText(POLICY)
+    await confirmPolicy.getByRole("button", { name: "Delete policy" }).click()
     await expect(row(page, "Routing policies", POLICY)).toHaveCount(0)
   })
 })

--- a/web/src/design-system/actions/ConfirmButton.stories.tsx
+++ b/web/src/design-system/actions/ConfirmButton.stories.tsx
@@ -6,8 +6,8 @@ const meta = {
   title: "Design system/Actions/ConfirmButton",
   component: ConfirmButton,
   args: {
-    children: "Revoke",
-    confirmLabel: "Revoke key",
+    children: "Reset price",
+    confirmLabel: "Reset to default",
     onConfirm: () => {},
   },
 } satisfies Meta<typeof ConfirmButton>
@@ -17,25 +17,25 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Press once to arm, again to confirm. Two clicks instead of a modal, which is
- * what keeps a revoke or delete in a table row from pulling a dialog in with it.
- * Press it to see the armed pair.
+ * Press once to arm, again to confirm. For a destructive action that deletes
+ * nothing: a regenerate, an archive, a reset to a default. A delete goes through
+ * `ConfirmDialog` instead. Press it to see the armed pair.
  */
 export const Default: Story = {}
 
 /**
  * While the mutation is in flight both armed buttons are disabled, so a second
- * press cannot fire the same revoke twice.
+ * press cannot fire the same reset twice.
  */
 export const Pending: Story = {
   args: { isPending: true },
 }
 
-/** In a row of actions, which is where it lives. */
+/** Beside the thing it acts on, which is where it lives. */
 export const InRowActions: Story = {
   render: (args) => (
     <div className="flex w-[24rem] items-center justify-between rounded-lg border border-border bg-surface px-4 py-3">
-      <span className="font-mono text-caption">otari_sk_…4f2a</span>
+      <span className="font-mono text-caption">openai:gpt-5-mini</span>
       <ConfirmButton {...args} />
     </div>
   ),

--- a/web/src/design-system/actions/ConfirmButton.tsx
+++ b/web/src/design-system/actions/ConfirmButton.tsx
@@ -4,8 +4,9 @@ import { useState } from "react"
 import { useConfirmationFocus } from "@/design-system/hooks/useConfirmationFocus"
 
 /**
- * A destructive button that requires a second click to confirm, avoiding a
- * modal dependency for revoke/delete actions.
+ * A destructive button that requires a second click to confirm, for an action
+ * that deletes nothing: a regenerate, an archive, a reset to a default. A
+ * record's deletion goes through `ConfirmDialog` instead (otari-ai#2110).
  *
  * Neutral, then danger. The first click is SAFE: it arms this control and
  * destroys nothing, so spending the danger hue on it would spend the loudest

--- a/web/src/design-system/actions/ConfirmRowAction.stories.tsx
+++ b/web/src/design-system/actions/ConfirmRowAction.stories.tsx
@@ -6,8 +6,10 @@ import { RowAction, RowActionRow } from "./RowAction"
 /**
  * The two-step destructive confirm, inside a table row.
  *
- * `ConfirmButton`'s sibling for a row. It supplies its own danger styling and
- * its own Cancel, so a call site cannot paint the hue at rest.
+ * `ConfirmButton`'s sibling for a row, for a destructive action that deletes
+ * nothing: archiving a provider key is the one left. A delete goes through
+ * `ConfirmDialog` (otari-ai#2110). It supplies its own danger styling and its
+ * own Cancel, so a call site cannot paint the hue at rest.
  *
  * **The Cancel that appears when armed is load-bearing. Do not simplify it
  * away.** The escalation is hue-only, and hue is the one channel a red-green
@@ -20,9 +22,9 @@ const meta = {
   title: "Design system/Actions/ConfirmRowAction",
   component: ConfirmRowAction,
   args: {
-    confirmLabel: "Revoke permanently",
+    confirmLabel: "Archive",
     onConfirm: () => {},
-    children: "Revoke",
+    children: "Archive",
   },
   parameters: { layout: "padded" },
 } satisfies Meta<typeof ConfirmRowAction>

--- a/web/src/design-system/actions/ConfirmRowAction.tsx
+++ b/web/src/design-system/actions/ConfirmRowAction.tsx
@@ -9,6 +9,11 @@ import { RowAction } from "./RowAction"
  * beside it. It replaces `ConfirmButton` on a table row for the same reason the
  * other actions lost their boxes; `ConfirmButton` stays for the forms and cards
  * where a destructive control is the only control and a button is right.
+ *
+ * Neither is for a delete: a record's deletion goes through `ConfirmDialog`,
+ * because a confirmation armed inside the row reads as part of the table rather
+ * than as a decision, and has nowhere to say what the deletion costs
+ * (otari-ai#2110).
  */
 export function ConfirmRowAction({
   confirmLabel,

--- a/web/src/design-system/data/BulkActionBar.stories.tsx
+++ b/web/src/design-system/data/BulkActionBar.stories.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@heroui/react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { ConfirmButton } from "../actions/ConfirmButton"
 import { BulkActionBar } from "./BulkActionBar"
 
 const meta = {
@@ -13,14 +12,16 @@ const meta = {
     canSelectAllMatching: true,
     onSelectAllMatching: () => {},
     onClear: () => {},
+    // The delete opens a `ConfirmDialog`, as every delete does; the bar holds
+    // the trigger, not the confirmation.
     children: (
       <>
         <Button size="sm" variant="ghost">
           Export
         </Button>
-        <ConfirmButton confirmLabel="Delete 3 rows" onConfirm={() => {}}>
+        <Button size="sm" variant="danger">
           Delete
-        </ConfirmButton>
+        </Button>
       </>
     ),
   },
@@ -43,9 +44,9 @@ export const SingleSelection: Story = {
   args: {
     selectedCount: 1,
     children: (
-      <ConfirmButton confirmLabel="Delete 1 row" onConfirm={() => {}}>
+      <Button size="sm" variant="danger">
         Delete
-      </ConfirmButton>
+      </Button>
     ),
   },
 }

--- a/web/src/design-system/data/BulkActionBar.stories.tsx
+++ b/web/src/design-system/data/BulkActionBar.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
         <Button size="sm" variant="ghost">
           Export
         </Button>
-        <Button size="sm" variant="danger">
+        <Button size="sm" variant="ghost">
           Delete
         </Button>
       </>
@@ -44,7 +44,7 @@ export const SingleSelection: Story = {
   args: {
     selectedCount: 1,
     children: (
-      <Button size="sm" variant="danger">
+      <Button size="sm" variant="ghost">
         Delete
       </Button>
     ),

--- a/web/src/design-system/feedback/ConfirmDialog.stories.tsx
+++ b/web/src/design-system/feedback/ConfirmDialog.stories.tsx
@@ -23,9 +23,9 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Controlled and open. This is the dialog for a *bulk* destructive action; a
- * single row's revoke uses `ConfirmButton`'s two-click arming instead, so a table
- * row does not pull a modal in with it.
+ * Controlled and open. This is the dialog for every delete of a record, one row
+ * or a selection of them (otari-ai#2110). `ConfirmButton`'s two-click arming is
+ * what is left, for a destructive action that deletes nothing.
  */
 export const Danger: Story = {}
 

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -591,9 +591,10 @@ describe("BudgetsPage", () => {
 
     const row = (await screen.findByText("11111111")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Delete" }))
-    expect(within(row).getByText(/lose this limit/)).toBeInTheDocument()
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).getByText(/lose this limit/)).toBeInTheDocument()
     await user.click(
-      within(row).getByRole("button", { name: "Delete permanently" }),
+      within(dialog).getByRole("button", { name: "Delete permanently" }),
     )
 
     const del = fetchMock.mock.calls.find(

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -455,45 +455,6 @@ function ResetHistory({ budgetId }: { budgetId: string }) {
 
 // ---------- onboarding ----------
 
-// ---------- inline confirm (names the target, no modal) ----------
-
-function InlineDelete({
-  label,
-  isPending,
-  onConfirm,
-}: {
-  label: string
-  isPending: boolean
-  onConfirm: () => void
-}) {
-  const [armed, setArmed] = useState(false)
-
-  if (!armed) {
-    return <RowAction onPress={() => setArmed(true)}>Delete</RowAction>
-  }
-  // Armed, this one keeps its sentence: a budget's deletion has a consequence
-  // the label cannot carry, and a row action that only said "Delete permanently"
-  // would be asking for a decision without the fact behind it. The tinted box is
-  // gone with every other box on the row; the words and the danger ink are what
-  // is left, and they were doing the work anyway.
-  return (
-    <span className="flex flex-col items-end gap-1 text-right">
-      <span className="max-w-xs text-xs text-muted">
-        Delete <strong className="font-medium">{label}</strong>? Users keep
-        their spend but lose this limit. Cannot be undone.
-      </span>
-      <span className="flex items-center gap-4">
-        <RowAction isDanger isDisabled={isPending} onPress={onConfirm}>
-          Delete permanently
-        </RowAction>
-        <RowAction isDisabled={isPending} onPress={() => setArmed(false)}>
-          Cancel
-        </RowAction>
-      </span>
-    </span>
-  )
-}
-
 // ---------- page ----------
 
 // A short, stable fingerprint for a budget id (its leading segment), shown when a
@@ -543,6 +504,7 @@ function DeploymentBudgetsPage() {
   const [addOpen, setAddOpen] = useState(false)
   const [editing, setEditing] = useState<string | null>(null)
   const [historyOpen, setHistoryOpen] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<Budget>()
   const [assignmentError, setAssignmentError] = useState<Error | null>(null)
   const [pendingAssignments, setPendingAssignments] = useState<{
     budgetId: string
@@ -720,16 +682,12 @@ function DeploymentBudgetsPage() {
             >
               Edit
             </RowAction>
-            <InlineDelete
-              label={budgetLabel(b)}
-              isPending={deleteBudget.isPending}
-              onConfirm={() => deleteBudget.mutate(b.budget_id)}
-            />
+            <RowAction onPress={() => setPendingDelete(b)}>Delete</RowAction>
           </RowActionRow>
         ),
       },
     ],
-    [historyOpen, deleteBudget.isPending, deleteBudget.mutate, defaultFor],
+    [historyOpen, defaultFor],
   )
 
   /**
@@ -838,7 +796,6 @@ function DeploymentBudgetsPage() {
           budgets.error ??
           createBudget.error ??
           updateBudget.error ??
-          deleteBudget.error ??
           updateUser.error ??
           // Without this a failed roster silently withholds the assignment
           // control and the "Default for" column, with nothing saying why.
@@ -989,6 +946,34 @@ function DeploymentBudgetsPage() {
           <ResetHistory budgetId={historyBudget.budget_id} />
         </Section>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          deleteBudget.reset()
+        }}
+        heading="Delete budget"
+        body={
+          pendingDelete
+            ? `${budgetLabel(pendingDelete)} stops existing. Users on it keep the spend they have already recorded but lose this limit, so nothing caps them until another budget does.`
+            : null
+        }
+        confirmLabel="Delete permanently"
+        isPending={deleteBudget.isPending}
+        error={deleteBudget.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          deleteBudget.mutate(pendingDelete.budget_id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
 
       <ConfirmDialog
         isOpen={bulkDeleteOpen}

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -453,8 +453,6 @@ function ResetHistory({ budgetId }: { budgetId: string }) {
   )
 }
 
-// ---------- onboarding ----------
-
 // ---------- page ----------
 
 // A short, stable fingerprint for a budget id (its leading segment), shown when a
@@ -949,10 +947,8 @@ function DeploymentBudgetsPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -601,13 +601,15 @@ describe("KeysPage", () => {
 
     const row = (await screen.findByText("legacy")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Delete" }))
-    const armed = screen
-      .getByText(/unlinks its usage history/)
-      .closest("tr") as HTMLTableRowElement
-    expect(row.nextElementSibling).toBe(armed)
-    expect(within(armed).getByText("legacy")).toBeInTheDocument()
+    const dialog = await screen.findByRole("alertdialog")
+    expect(
+      within(dialog).getByText(/unlinks its usage history/),
+    ).toBeInTheDocument()
+    // The key is named in the dialog, so the operator is not confirming against
+    // a row they can no longer see.
+    expect(within(dialog).getByText("legacy")).toBeInTheDocument()
     await user.click(
-      within(armed).getByRole("button", { name: "Delete permanently" }),
+      within(dialog).getByRole("button", { name: "Delete permanently" }),
     )
 
     const del = fetchMock.mock.calls.find(

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -888,33 +888,25 @@ export function KeysPage() {
     }
   }
 
-  // Memoized on the values the cells actually read (mutation pending flags and
-  // Which row is armed, and for what. Page state rather than per-button state,
-  // because the confirmation is a strip under the row now and only one may be
-  // open at a time.
-  const [armed, setArmed] = useState<{
-    id: string
-    kind: "regenerate" | "delete"
-  } | null>(null)
+  // Which row is armed to regenerate. Page state rather than per-button state,
+  // because the confirmation is a strip under the row and only one may be open
+  // at a time.
+  const [armed, setArmed] = useState<string | null>(null)
   // Which row was armed last, kept after `armed` clears. Cancelling unmounts the
   // strip that had focus, so the caret has to go back to the action that armed
   // it, and `useConfirmationFocus` reads its `triggerRef` in an effect that runs
-  // *after* the commit that cleared `armed`. A ref attached on `armed?.id === k.id`
+  // *after* the commit that cleared `armed`. A ref attached on `armed === k.id`
   // would already have been detached by then and the restore would find null, so
   // the trigger is identified by a value that outlives the transition.
-  const [lastArmed, setLastArmed] = useState<{
-    id: string
-    kind: "regenerate" | "delete"
-  } | null>(null)
-  const arm = useCallback(
-    (next: { id: string; kind: "regenerate" | "delete" }) => {
-      setLastArmed(next)
-      setArmed(next)
-    },
-    [],
-  )
+  const [lastArmed, setLastArmed] = useState<string | null>(null)
+  const arm = useCallback((id: string) => {
+    setLastArmed(id)
+    setArmed(id)
+  }, [])
   const { triggerRef, confirmRef } = useConfirmationFocus(armed !== null)
+  const [pendingDelete, setPendingDelete] = useState<ApiKey>()
 
+  // Memoized on the values the cells actually read (mutation pending flags and
   // the stable handlers) so DataTable's per-row cache holds across selection
   // clicks; see the DataTable docstring.
   const columns = useMemo<DataTableColumn<ApiKey>[]>(
@@ -1045,30 +1037,16 @@ export function KeysPage() {
               Edit
             </RowAction>
             <RowAction
-              ref={
-                lastArmed?.id === k.id && lastArmed.kind === "regenerate"
-                  ? triggerRef
-                  : undefined
-              }
-              isDanger={armed?.id === k.id && armed.kind === "regenerate"}
-              onPress={() => arm({ id: k.id, kind: "regenerate" })}
+              ref={lastArmed === k.id ? triggerRef : undefined}
+              isDanger={armed === k.id}
+              onPress={() => arm(k.id)}
             >
               Regenerate
             </RowAction>
             {/* Permanent delete is only offered once a key is disabled, so a live
               caller can't be broken (and its audit trail erased) in one click. */}
             {k.is_active ? null : (
-              <RowAction
-                ref={
-                  lastArmed?.id === k.id && lastArmed.kind === "delete"
-                    ? triggerRef
-                    : undefined
-                }
-                isDanger={armed?.id === k.id && armed.kind === "delete"}
-                onPress={() => arm({ id: k.id, kind: "delete" })}
-              >
-                Delete
-              </RowAction>
+              <RowAction onPress={() => setPendingDelete(k)}>Delete</RowAction>
             )}
           </RowActionRow>
         ),
@@ -1096,41 +1074,21 @@ export function KeysPage() {
   // inside the actions cell. Referentially stable per the DataTable docstring.
   const renderArmed = useCallback(
     (k: ApiKey) => {
-      if (!armed || armed.id !== k.id) return null
-      if (armed.kind === "regenerate") {
-        return (
-          <ArmedStrip
-            confirmRef={confirmRef}
-            confirmLabel="Regenerate"
-            isPending={rotateKey.isPending}
-            message={
-              <>
-                Regenerate the secret for <strong>{label(k)}</strong>? The
-                current secret stops working immediately, with no grace period.
-              </>
-            }
-            onConfirm={() => {
-              setArmed(null)
-              regenerate(k)
-            }}
-            onCancel={() => setArmed(null)}
-          />
-        )
-      }
+      if (armed !== k.id) return null
       return (
         <ArmedStrip
           confirmRef={confirmRef}
-          confirmLabel="Delete permanently"
-          isPending={deleteKey.isPending}
+          confirmLabel="Regenerate"
+          isPending={rotateKey.isPending}
           message={
             <>
-              Permanently delete <strong>{label(k)}</strong>? This removes the
-              key and unlinks its usage history. Cannot be undone.
+              Regenerate the secret for <strong>{label(k)}</strong>? The current
+              secret stops working immediately, with no grace period.
             </>
           }
           onConfirm={() => {
             setArmed(null)
-            deleteKey.mutate(k.id)
+            regenerate(k)
           }}
           onCancel={() => setArmed(null)}
         />
@@ -1138,14 +1096,7 @@ export function KeysPage() {
     },
     // Neither memberLabels nor isDeploymentWide is read here any more: the
     // strip's copy names the key, not its owner.
-    [
-      armed,
-      rotateKey.isPending,
-      deleteKey.isPending,
-      deleteKey.mutate,
-      regenerate,
-      confirmRef,
-    ],
+    [armed, rotateKey.isPending, regenerate, confirmRef],
   )
 
   // Bulk delete targets only already-disabled keys, mirroring the per-row rule
@@ -1178,11 +1129,8 @@ export function KeysPage() {
           : "Create and manage your own keys for calling this gateway. Secrets are shown once at creation."}
       </PageIntro>
 
-      <ErrorBanner
-        error={
-          keys.error ?? updateKey.error ?? rotateKey.error ?? deleteKey.error
-        }
-      />
+      {/* Not the deletes: each reports inside its own confirm dialog. */}
+      <ErrorBanner error={keys.error ?? updateKey.error ?? rotateKey.error} />
 
       {/* A key's owner and its spending limit are both set elsewhere now, on the
           organization rail. This page is where an operator arrives looking for
@@ -1329,11 +1277,42 @@ export function KeysPage() {
             selectionMode="multiple"
             selectedKeys={selection.selectedKeys}
             onSelectionChange={selection.onSelectionChange}
-            detailKey={armed?.id ?? null}
+            detailKey={armed}
             renderDetail={renderArmed}
           />
         </TableScrollFrame>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          deleteKey.reset()
+        }}
+        heading="Delete API key"
+        body={
+          pendingDelete ? (
+            <>
+              Permanently delete <strong>{label(pendingDelete)}</strong>? This
+              removes the key and unlinks its usage history. Cannot be undone.
+            </>
+          ) : null
+        }
+        confirmLabel="Delete permanently"
+        isPending={deleteKey.isPending}
+        error={deleteKey.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          deleteKey.mutate(pendingDelete.id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
 
       <ConfirmDialog
         isOpen={bulkDeleteOpen}

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -1285,10 +1285,8 @@ export function KeysPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/organization/OrganizationDomainsPage.test.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -94,6 +94,33 @@ describe("OrganizationDomainsPage", () => {
     expect(
       screen.getByRole("button", { name: "Remove domain" }),
     ).toBeInTheDocument()
+  })
+
+  it("removes a claim only through the confirm dialog", async () => {
+    // otari-ai#2110. The dialog names the domain and says what survives the
+    // removal, which the two-click button had no room to.
+    const requests = mockApi({ domains: [organizationDomain()] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationDomainsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Remove domain" }),
+    )
+    const dialog = await screen.findByRole("alertdialog")
+    expect(
+      within(dialog).getByText(/acme.example stops admitting anyone/),
+    ).toBeVisible()
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false)
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Remove claim" }),
+    )
+
+    await waitFor(() =>
+      expect(requests.some((request) => request.method === "DELETE")).toBe(
+        true,
+      ),
+    )
   })
 
   it("shows a verified, enabled claim as active and pausable", async () => {

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -5,9 +5,9 @@ import type {
   CreateOrganizationDomainRequest,
   OrganizationDomain,
 } from "@/client"
-import { ConfirmButton } from "@/design-system/actions/ConfirmButton"
 import { CopyField } from "@/design-system/actions/CopyField"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
@@ -191,6 +191,7 @@ export function OrganizationDomainsPage() {
   const update = useUpdateOrganizationDomain()
   const remove = useDeleteOrganizationDomain()
   const [adding, setAdding] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<OrganizationDomain>()
 
   const rows = domains.data?.data ?? []
   // Both states need the same card: one has never had a proof, the other's has
@@ -268,13 +269,13 @@ export function OrganizationDomainsPage() {
               {row.enabled ? "Pause" : "Resume"}
             </Button>
           ) : null}
-          <ConfirmButton
-            confirmLabel="Remove claim"
-            isPending={remove.isPending}
-            onConfirm={() => remove.mutate(row.id)}
+          <Button
+            size="sm"
+            variant="ghost"
+            onPress={() => setPendingDelete(row)}
           >
             Remove domain
-          </ConfirmButton>
+          </Button>
         </div>
       ),
     })
@@ -298,9 +299,7 @@ export function OrganizationDomainsPage() {
         record is verified.
       </PageIntro>
 
-      <ErrorBanner
-        error={context.error ?? domains.error ?? update.error ?? remove.error}
-      />
+      <ErrorBanner error={context.error ?? domains.error ?? update.error} />
 
       {/* Held back until the context has answered, so an admin is not told for
           one paint that they may not be here. */}
@@ -328,6 +327,34 @@ export function OrganizationDomainsPage() {
           />
         </TableScrollFrame>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          remove.reset()
+        }}
+        heading="Remove email domain"
+        body={
+          pendingDelete
+            ? `${pendingDelete.domain} stops admitting anyone to this organization. Members who already joined through it keep their membership, and claiming it again means proving the DNS record over.`
+            : null
+        }
+        confirmLabel="Remove claim"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          remove.mutate(pendingDelete.id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -330,10 +330,8 @@ export function OrganizationDomainsPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -428,6 +428,43 @@ describe("OrganizationProviderKeysPage", () => {
     expect(await screen.findByText("Retired")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Restore" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument()
+  })
+
+  it("deletes an archived key only through the confirm dialog", async () => {
+    // otari-ai#2110. Archive keeps its two-click row confirm, because it is the
+    // reversible step; the delete that follows it is the one behind a modal.
+    const requests = mockApi({
+      keys: [
+        orgProviderKey({
+          id: "88888888-8888-8888-8888-888888888888",
+          name: "Retired",
+          archived_at: "2026-08-20T00:00:00+00:00",
+        }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(await screen.findByText("Show archived (1)"))
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).getByText(/Retired and its stored/)).toBeVisible()
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false)
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Delete permanently" }),
+    )
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "DELETE" &&
+            request.url.includes("88888888-8888-8888-8888-888888888888"),
+        ),
+      ).toBe(true),
+    )
   })
 
   it("withholds the keys and their read from a member who cannot manage the organization", async () => {

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -9,6 +9,7 @@ import type {
 import { ConfirmRowAction } from "@/design-system/actions/ConfirmRowAction"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
@@ -304,6 +305,7 @@ export function OrganizationProviderKeysPage() {
   const [adding, setAdding] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [showArchived, setShowArchived] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<OrgProviderKey>()
 
   const editing = keys.data?.find((key) => key.id === editingId) ?? null
   const archivedCount = (keys.data ?? []).filter((key) =>
@@ -389,13 +391,9 @@ export function OrganizationProviderKeysPage() {
               </RowAction>
               {/* Permanent, and the only place it is offered: the API
                     accepts a delete for an archived key alone. */}
-              <ConfirmRowAction
-                confirmLabel="Delete"
-                isPending={remove.isPending}
-                onConfirm={() => remove.mutate(row.id)}
-              >
+              <RowAction onPress={() => setPendingDelete(row)}>
                 Delete
-              </ConfirmRowAction>
+              </RowAction>
             </>
           ) : (
             <>
@@ -467,7 +465,6 @@ export function OrganizationProviderKeysPage() {
           keys.error ??
           archive.error ??
           restore.error ??
-          remove.error ??
           setDefault.error
         }
       />
@@ -536,6 +533,34 @@ export function OrganizationProviderKeysPage() {
           />
         </TableScrollFrame>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          remove.reset()
+        }}
+        heading="Delete provider key"
+        body={
+          pendingDelete
+            ? `${pendingDelete.name} and its stored ${pendingDelete.provider} credential are removed for good. Archiving is the reversible step; this one cannot be undone.`
+            : null
+        }
+        confirmLabel="Delete permanently"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          remove.mutate(pendingDelete.id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -536,10 +536,8 @@ export function OrganizationProviderKeysPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -1257,7 +1257,11 @@ describe("ProvidersPage", () => {
     ).toBeInTheDocument()
 
     await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(screen.getByRole("button", { name: "Delete" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Delete provider",
+      }),
+    )
     await screen.findByText("Welcome to Otari")
 
     await user.click(
@@ -1305,7 +1309,11 @@ describe("ProvidersPage", () => {
     expect(await screen.findByText("Testing…")).toBeInTheDocument()
 
     await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(screen.getByRole("button", { name: "Delete" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Delete provider",
+      }),
+    )
     await screen.findByText("Welcome to Otari")
 
     await user.click(

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -9,9 +9,9 @@ import type {
   TestProviderResult,
   UpdateStoredProviderRequest,
 } from "@/client"
-import { ConfirmRowAction } from "@/design-system/actions/ConfirmRowAction"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { Field } from "@/design-system/forms/Field"
@@ -911,6 +911,7 @@ export function ProvidersPage() {
 
   const [addOpen, setAddOpen] = useState(false)
   const [editing, setEditing] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<string>()
   const [tests, setTests] = useState<Record<string, TestState>>({})
 
   const rows = buildRows(meta.data?.providers, stored.data)
@@ -1090,19 +1091,9 @@ export function ProvidersPage() {
               >
                 Edit
               </RowAction>
-              <ConfirmRowAction
-                confirmLabel="Delete"
-                isPending={deleteProvider.isPending}
-                // Clear the verdict too: a provider re-added under the same name
-                // is a different provider, and would otherwise inherit it.
-                onConfirm={() =>
-                  deleteProvider.mutate(row.instance, {
-                    onSuccess: () => clearTest(row.instance),
-                  })
-                }
-              >
+              <RowAction onPress={() => setPendingDelete(row.instance)}>
                 Delete
-              </ConfirmRowAction>
+              </RowAction>
             </RowActionRow>
             <TestOutcome state={tests[row.instance]} />
           </div>
@@ -1163,8 +1154,7 @@ export function ProvidersPage() {
           stored.error ??
           context.error ??
           health.error ??
-          updateSettings.error ??
-          deleteProvider.error
+          updateSettings.error
         }
       />
 
@@ -1255,6 +1245,39 @@ export function ProvidersPage() {
           />
         </TableScrollFrame>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          deleteProvider.reset()
+        }}
+        heading="Delete provider"
+        body={
+          pendingDelete
+            ? `${pendingDelete} and the credential stored with it are removed. A request routed to it fails until another provider serves its models.`
+            : null
+        }
+        confirmLabel="Delete provider"
+        isPending={deleteProvider.isPending}
+        error={deleteProvider.error}
+        onConfirm={() => {
+          if (pendingDelete === undefined) return
+          deleteProvider.mutate(pendingDelete, {
+            // Clear the verdict too: a provider re-added under the same name is
+            // a different provider, and would otherwise inherit it.
+            onSuccess: () => {
+              clearTest(pendingDelete)
+              setPendingDelete(undefined)
+            },
+          })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -1248,10 +1248,8 @@ export function ProvidersPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -101,6 +101,8 @@ function mockApi(
       user_id: string | null
       workspace_id?: string
     }[]
+    // What a delete of a deployment-wide policy answers, for the error path.
+    deleteBody?: { status: number; detail: string }
   } = {},
 ) {
   let list = [...policies]
@@ -238,6 +240,16 @@ function mockApi(
           return jsonResponse(row)
         }
         if (method === "DELETE") {
+          if (opts.deleteBody) {
+            // Not `jsonResponse`, which is a 200 by construction.
+            return new Response(
+              JSON.stringify({ detail: opts.deleteBody.detail }),
+              {
+                status: opts.deleteBody.status,
+                headers: { "Content-Type": "application/json" },
+              },
+            )
+          }
           const name = decodeURIComponent(
             url.split("?")[0].split("/").pop() ?? "",
           )
@@ -640,6 +652,98 @@ describe("RoutingPage", () => {
     ).toBeInTheDocument()
   })
 
+  it("names the policy in a confirm dialog before deleting it", async () => {
+    // otari-ai#2110: the confirmation used to arm inside the row, where it read
+    // as part of the table rather than as a decision. It is a modal now, and
+    // the policy it is about has to be named in it: the row is behind the
+    // backdrop, so the name on the row is no longer the operator's reference.
+    const { calls } = mockApi([policy("fast", CHAIN)])
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    const row = (await screen.findByText("fast")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Delete" }))
+
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).getByText(/^fast stops resolving/)).toBeVisible()
+    // Nothing is sent by opening it.
+    expect(calls.some((call) => call.method === "DELETE")).toBe(false)
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Delete policy" }),
+    )
+
+    const deletes = calls.filter((call) => call.method === "DELETE")
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0].url).toContain("/v1/routing/policies/fast")
+  })
+
+  it("deletes nothing when the confirm dialog is cancelled", async () => {
+    const { calls } = mockApi([policy("fast", CHAIN)])
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    const row = (await screen.findByText("fast")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Delete" }))
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }))
+
+    expect(calls.some((call) => call.method === "DELETE")).toBe(false)
+    expect(screen.getByText("fast")).toBeInTheDocument()
+  })
+
+  it("reports a refused delete inside the dialog, leaving the row", async () => {
+    // The page banner no longer carries this: the operator is looking at the
+    // modal, and a message behind the backdrop is a message they do not read.
+    mockApi([policy("fast", CHAIN)], "http://guardrails:8000", [], {
+      deleteBody: { status: 409, detail: "fast is referenced by an alias" },
+    })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    const row = (await screen.findByText("fast")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Delete" }))
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(
+      within(dialog).getByRole("button", { name: "Delete policy" }),
+    )
+
+    expect(
+      await within(dialog).findByText(/referenced by an alias/),
+    ).toBeVisible()
+    // Still open, so the operator can retry or back out rather than being
+    // returned to a table that looks unchanged for no stated reason.
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument()
+    expect(screen.getByText("fast")).toBeInTheDocument()
+  })
+
+  it("does not greet the next row's confirm with the last row's refusal", async () => {
+    // The mutation holds its error until the next call, and the dialog reads it,
+    // so without clearing it on close the second row opens already reporting a
+    // failure that was about the first.
+    mockApi([policy("fast", CHAIN), policy("smart", LEARNED)], undefined, [], {
+      deleteBody: { status: 409, detail: "fast is referenced by an alias" },
+    })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    const fast = (await screen.findByText("fast")).closest("tr")!
+    await user.click(within(fast).getByRole("button", { name: "Delete" }))
+    const first = await screen.findByRole("alertdialog")
+    await user.click(
+      within(first).getByRole("button", { name: "Delete policy" }),
+    )
+    await within(first).findByText(/referenced by an alias/)
+    await user.click(within(first).getByRole("button", { name: "Cancel" }))
+
+    const smart = screen.getByText("smart").closest("tr")!
+    await user.click(within(smart).getByRole("button", { name: "Delete" }))
+
+    const second = await screen.findByRole("alertdialog")
+    expect(within(second).getByText(/^smart stops resolving/)).toBeVisible()
+    expect(within(second).queryByText(/referenced by an alias/)).toBeNull()
+  })
+
   it("deletes an alias through the alias endpoint, not the policy one", async () => {
     const { calls } = mockApi([], "http://guardrails:8000", [
       {
@@ -654,7 +758,11 @@ describe("RoutingPage", () => {
 
     const row = (await screen.findByText("legacy")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Delete" }))
-    await user.click(within(row).getByRole("button", { name: "Confirm" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Delete alias",
+      }),
+    )
 
     const deletes = calls.filter((call) => call.method === "DELETE")
     expect(deletes).toHaveLength(1)
@@ -1495,7 +1603,11 @@ describe("RoutingPage for an organization admin", () => {
 
     await screen.findByText("doomed")
     await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(screen.getByRole("button", { name: "Confirm" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Delete policy",
+      }),
+    )
 
     const deleted = calls.find((call) => call.method === "DELETE")
     expect(deleted?.url).toContain("/v1/organizations/me/routing-policies/")
@@ -1600,7 +1712,11 @@ describe("RoutingPage for an organization admin", () => {
 
     await screen.findByText("doomed-alias")
     await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(screen.getByRole("button", { name: "Confirm" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Delete alias",
+      }),
+    )
 
     const deleted = calls.find((call) => call.method === "DELETE")
     expect(deleted?.url).toContain("/v1/organizations/me/aliases/")

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -1669,10 +1669,8 @@ export function RoutingPage() {
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -8,10 +8,10 @@ import type {
   PolicySpec,
   RoutingPolicyResponse,
 } from "@/client"
-import { ConfirmRowAction } from "@/design-system/actions/ConfirmRowAction"
 import { CopyableValue } from "@/design-system/actions/CopyField"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { EmptyState } from "@/design-system/feedback/EmptyState"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { Field } from "@/design-system/forms/Field"
@@ -1333,13 +1333,12 @@ export function RoutingPage() {
   // selected one, so a write to an existing row goes back to the workspace that
   // row lives in (`rowWorkspace` below, and the Edit form's `workspaceId`).
   // Using the selection would create a second policy of the same name in the
-  // selected workspace and leave the edited one untouched. Written inline at
-  // both sites rather than as a helper, so the columns memo keeps depending on
-  // two stable values instead of a function rebuilt every render.
+  // selected workspace and leave the edited one untouched.
   // A deep link may pre-fill the add form with ?target=provider:model.
   const initialTarget = useUrlValue("target")
   const [adding, setAdding] = useState(initialTarget !== "")
   const [editing, setEditing] = useState<RoutingRow | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<RoutingRow>()
   // Readiness opens inline under its own row (DataTable's accordion), because it
   // describes one policy and the operator clicked that policy. A card above the
   // table would put the panel nowhere near the control that opened it.
@@ -1533,54 +1532,35 @@ export function RoutingPage() {
                 so nothing is lost.
               </span>
             )}
-            <ConfirmRowAction
-              confirmLabel="Confirm"
-              isPending={
-                deletePolicy.isPending ||
-                deleteAlias.isPending ||
-                deleteOrgPolicy.isPending ||
-                deleteOrgAlias.isPending
-              }
-              onConfirm={() => {
-                // The tenant surface names the workspace and has no user scope;
-                // the deployment-wide one defaults the workspace and keeps it.
-                const rowWorkspace = isOperator
-                  ? null
-                  : (policy.workspace_id ?? writeWorkspaceId)
-                if (rowWorkspace !== null) {
-                  const scoped = {
-                    name: policy.name,
-                    workspaceId: rowWorkspace,
-                  }
-                  if (policy.kind === "alias") deleteOrgAlias.mutate(scoped)
-                  else deleteOrgPolicy.mutate(scoped)
-                  return
-                }
-                const deployment = {
-                  name: policy.name,
-                  userId: policy.user_id,
-                }
-                if (policy.kind === "alias") deleteAlias.mutate(deployment)
-                else deletePolicy.mutate(deployment)
-              }}
-            >
+            <RowAction onPress={() => setPendingDelete(policy)}>
               Delete
-            </ConfirmRowAction>
+            </RowAction>
           </RowActionRow>
         )
       },
     })
     return base
-  }, [
-    canEdit,
-    deleteAlias,
-    deleteOrgAlias,
-    deleteOrgPolicy,
-    deletePolicy,
-    expanded,
-    isOperator,
-    writeWorkspaceId,
-  ])
+  }, [canEdit, expanded, isOperator])
+
+  // Which of the four delete surfaces a row goes to. The tenant one names the
+  // workspace and has no user scope; the deployment-wide one defaults the
+  // workspace and keeps it.
+  const deleteWorkspaceFor = (row: RoutingRow) =>
+    isOperator ? null : (row.workspace_id ?? writeWorkspaceId)
+  const deleteMutationFor = (row: RoutingRow) =>
+    deleteWorkspaceFor(row) !== null
+      ? row.kind === "alias"
+        ? deleteOrgAlias
+        : deleteOrgPolicy
+      : row.kind === "alias"
+        ? deleteAlias
+        : deletePolicy
+  // Resolved for the pending row alone, not as a chain over all four: a refusal
+  // stays on its mutation until the next call, so reading every one of them
+  // would report the last row's failure over this row's confirm.
+  const pendingDeleteMutation = pendingDelete
+    ? deleteMutationFor(pendingDelete)
+    : undefined
 
   return (
     <div className="flex flex-col gap-6">
@@ -1612,16 +1592,14 @@ export function RoutingPage() {
             : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the ones in force in your workspaces; your organization's admins manage them."}
       </PageIntro>
 
+      {/* The reads only. Every delete on this page reports inside its own
+          confirm dialog, which is where the operator is looking. */}
       <ErrorBanner
         error={
           policies.error ??
           memberPolicies.error ??
           aliases.error ??
-          memberAliases.error ??
-          deletePolicy.error ??
-          deleteAlias.error ??
-          deleteOrgPolicy.error ??
-          deleteOrgAlias.error
+          memberAliases.error
         }
       />
 
@@ -1688,6 +1666,57 @@ export function RoutingPage() {
           />
         </TableScrollFrame>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          deletePolicy.reset()
+          deleteAlias.reset()
+          deleteOrgPolicy.reset()
+          deleteOrgAlias.reset()
+        }}
+        heading={
+          pendingDelete?.kind === "alias" ? "Delete alias" : "Delete policy"
+        }
+        body={
+          pendingDelete
+            ? `${pendingDelete.name} stops resolving. A request that still sends it as its model is refused, so update the callers that name it.`
+            : null
+        }
+        confirmLabel={
+          pendingDelete?.kind === "alias" ? "Delete alias" : "Delete policy"
+        }
+        isPending={pendingDeleteMutation?.isPending ?? false}
+        error={pendingDeleteMutation?.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          const onSuccess = () => setPendingDelete(undefined)
+          const rowWorkspace = deleteWorkspaceFor(pendingDelete)
+          if (rowWorkspace !== null) {
+            const scoped = {
+              name: pendingDelete.name,
+              workspaceId: rowWorkspace,
+            }
+            if (pendingDelete.kind === "alias")
+              deleteOrgAlias.mutate(scoped, { onSuccess })
+            else deleteOrgPolicy.mutate(scoped, { onSuccess })
+            return
+          }
+          const deployment = {
+            name: pendingDelete.name,
+            userId: pendingDelete.user_id,
+          }
+          if (pendingDelete.kind === "alias")
+            deleteAlias.mutate(deployment, { onSuccess })
+          else deletePolicy.mutate(deployment, { onSuccess })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -204,9 +204,13 @@ describe("OrganizationGuardrailsCard", () => {
       await screen.findByRole("button", { name: "Remove prompt-injection" }),
     )
     const dialog = await screen.findByRole("alertdialog")
+    // The fixture monitors rather than blocks, so the consequence is that
+    // requests go unchecked. Saying they would have been blocked would describe
+    // a guardrail that never blocked one.
     expect(
       within(dialog).getByText(/prompt-injection stops running/),
     ).toBeVisible()
+    expect(within(dialog).getByText(/go unchecked/)).toBeVisible()
     expect(calls.some((call) => call.method === "DELETE")).toBe(false)
 
     await userEvent.click(
@@ -216,6 +220,26 @@ describe("OrganizationGuardrailsCard", () => {
     await waitFor(() =>
       expect(calls.some((call) => call.method === "DELETE")).toBe(true),
     )
+  })
+
+  it("says what a blocking guardrail's removal serves, not what it records", async () => {
+    mockApi({
+      guardrails: [
+        organizationGuardrail({
+          mode: "block",
+          applies_to_all_workspaces: true,
+        }),
+      ],
+    })
+    renderCard()
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Remove prompt-injection" }),
+    )
+    const dialog = await screen.findByRole("alertdialog")
+    expect(
+      within(dialog).getByText(/would have blocked are served/),
+    ).toBeVisible()
   })
 
   it("rewrites the endpoint in place, so a typo is not a delete and recreate", async () => {

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -201,7 +201,7 @@ describe("OrganizationGuardrailsCard", () => {
     renderCard()
 
     await userEvent.click(
-      await screen.findByRole("button", { name: "Remove guardrail" }),
+      await screen.findByRole("button", { name: "Remove prompt-injection" }),
     )
     const dialog = await screen.findByRole("alertdialog")
     expect(

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -193,6 +193,31 @@ describe("OrganizationGuardrailsCard", () => {
     })
   })
 
+  it("removes a guardrail only through the confirm dialog", async () => {
+    // otari-ai#2110.
+    const calls = mockApi({
+      guardrails: [organizationGuardrail({ applies_to_all_workspaces: true })],
+    })
+    renderCard()
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Remove guardrail" }),
+    )
+    const dialog = await screen.findByRole("alertdialog")
+    expect(
+      within(dialog).getByText(/prompt-injection stops running/),
+    ).toBeVisible()
+    expect(calls.some((call) => call.method === "DELETE")).toBe(false)
+
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Remove permanently" }),
+    )
+
+    await waitFor(() =>
+      expect(calls.some((call) => call.method === "DELETE")).toBe(true),
+    )
+  })
+
   it("rewrites the endpoint in place, so a typo is not a delete and recreate", async () => {
     const calls = mockApi({
       guardrails: [

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -301,6 +301,9 @@ function GuardrailRow({
         <Button
           size="sm"
           variant="ghost"
+          // Named per row, as the Save beside it is: the card is a list of
+          // profiles, so a bare "Remove guardrail" is the same name N times.
+          aria-label={`Remove ${guardrail.profile}`}
           isDisabled={busy}
           onPress={() => setDeleteOpen(true)}
         >

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -323,7 +323,13 @@ function GuardrailRow({
           if (!open) remove.reset()
         }}
         heading="Remove guardrail"
-        body={`${guardrail.profile} stops running on every request it covers, and its stored credential is removed with it. The prompts it would have blocked are served.`}
+        // The stored mode, not the row's unsaved `mode`: this describes what is
+        // in force, and a monitoring guardrail never blocked anything.
+        body={
+          guardrail.mode === "block"
+            ? `${guardrail.profile} stops running on every request it covers, and its stored credential is removed with it. Requests it would have blocked are served.`
+            : `${guardrail.profile} stops running on every request it covers, and its stored credential is removed with it. Requests it would have recorded go unchecked.`
+        }
         confirmLabel="Remove permanently"
         isPending={remove.isPending}
         error={remove.error}

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -2,7 +2,7 @@ import { Button } from "@heroui/react"
 import { useEffect, useState } from "react"
 
 import type { OrganizationGuardrail, Workspace } from "@/client"
-import { ConfirmButton } from "@/design-system/actions/ConfirmButton"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
@@ -147,6 +147,7 @@ function GuardrailRow({
   // never shows what is stored, only whether something is.
   const [credential, setCredential] = useState("")
   const [error, setError] = useState("")
+  const [isDeleteOpen, setDeleteOpen] = useState(false)
 
   // Rehydrate from whatever the server last said, so the row never drifts from
   // the stored entry after a save.
@@ -297,23 +298,42 @@ function GuardrailRow({
         >
           {update.isPending ? "Saving…" : "Save"}
         </Button>
-        <ConfirmButton
-          confirmLabel="Remove permanently"
-          isPending={busy}
-          onConfirm={() => {
-            setError("")
-            remove.mutate(guardrail.id, {
-              onSuccess: () => onSaved(`${guardrail.profile} removed`),
-              onError: (err) => setError(errorMessage(err)),
-            })
-          }}
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={busy}
+          onPress={() => setDeleteOpen(true)}
         >
           Remove guardrail
-        </ConfirmButton>
+        </Button>
       </div>
       {error ? (
         <span className="break-words text-caption text-danger">{error}</span>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        // Cleared on the way out: a refusal otherwise sits on the mutation
+        // and greets the next open as if it had just happened.
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) remove.reset()
+        }}
+        heading="Remove guardrail"
+        body={`${guardrail.profile} stops running on every request it covers, and its stored credential is removed with it. The prompts it would have blocked are served.`}
+        confirmLabel="Remove permanently"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          setError("")
+          remove.mutate(guardrail.id, {
+            onSuccess: () => {
+              setDeleteOpen(false)
+              onSaved(`${guardrail.profile} removed`)
+            },
+          })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -332,7 +332,7 @@ describe("SearchToolsCard", () => {
     await renderOpened(user)
     await screen.findByText("local")
 
-    await user.click(screen.getByRole("button", { name: "Remove" }))
+    await user.click(screen.getByRole("button", { name: "Remove local" }))
     const dialog = await screen.findByRole("alertdialog")
     expect(
       within(dialog).getByText(/local and the key stored with it/),

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -324,16 +324,28 @@ describe("SearchToolsCard", () => {
     expect(bodies[1].api_key).toBe("sk-second")
   })
 
-  it("removes a tool after the confirm step", async () => {
+  it("removes a tool only through the confirm dialog", async () => {
+    // otari-ai#2110. The trigger names the object and the dialog names the
+    // consequence, which the armed button had no room to say.
     const fetchMock = mockApi()
     const user = userEvent.setup()
     await renderOpened(user)
     await screen.findByText("local")
 
-    // The two steps read differently now: the trigger names the object and the
-    // armed confirm names the consequence, which is what the second click does.
     await user.click(screen.getByRole("button", { name: "Remove" }))
-    await user.click(screen.getByRole("button", { name: "Remove permanently" }))
+    const dialog = await screen.findByRole("alertdialog")
+    expect(
+      within(dialog).getByText(/local and the key stored with it/),
+    ).toBeVisible()
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) => (init?.method ?? "") === "DELETE",
+      ),
+    ).toBe(false)
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Remove permanently" }),
+    )
 
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -148,6 +148,9 @@ function StoredToolLine({
         <Button
           size="sm"
           variant="ghost"
+          // Named per row, as this row's fields are: the card is a list of
+          // tools, so a bare "Remove" is the same name on every one of them.
+          aria-label={`Remove ${tool.name}`}
           isDisabled={busy}
           onPress={() => setDeleteOpen(true)}
         >

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -6,7 +6,7 @@ import type {
   UpdateSearchToolRequest,
 } from "@/client"
 import { Button } from "@/design-system/actions/Button"
-import { ConfirmButton } from "@/design-system/actions/ConfirmButton"
+import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { INPUT_CLASS } from "@/design-system/forms/inputClass"
@@ -62,12 +62,12 @@ function StoredToolLine({
   const remove = useDeleteSearchTool()
   const urlSave = useAutosave()
   const keySave = useAutosave()
-  const removal = useAutosave()
   const [apiBase, setApiBase] = useState(tool.api_base ?? "")
   const [syncedBase, setSyncedBase] = useState(tool.api_base ?? "")
   // Blank means "keep the stored key". The field is write-only, so it never
   // shows what is stored, only the last four of it in its own placeholder.
   const [apiKey, setApiKey] = useState("")
+  const [isDeleteOpen, setDeleteOpen] = useState(false)
 
   const committedBase = tool.api_base ?? ""
   // Re-synced from the server's answer, in render rather than an effect, which
@@ -145,15 +145,14 @@ function StoredToolLine({
           }}
           className={`otari-machine-field w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
-        <ConfirmButton
-          confirmLabel="Remove permanently"
-          isPending={busy}
-          onConfirm={() =>
-            void removal.run(() => remove.mutateAsync(tool.name))
-          }
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={busy}
+          onPress={() => setDeleteOpen(true)}
         >
           Remove
-        </ConfirmButton>
+        </Button>
       </div>
       {tool.decryptable ? null : (
         <p className="text-caption text-warning">
@@ -165,11 +164,29 @@ function StoredToolLine({
           Overrides the config-file tool of this name
         </p>
       ) : null}
-      {urlSave.error || keySave.error || removal.error ? (
+      {urlSave.error || keySave.error ? (
         <p role="alert" className="break-words text-caption text-danger">
-          {urlSave.error || keySave.error || removal.error}
+          {urlSave.error || keySave.error}
         </p>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={isDeleteOpen}
+        // Cleared on the way out: a refusal otherwise sits on the mutation
+        // and greets the next open as if it had just happened.
+        onOpenChange={(open) => {
+          setDeleteOpen(open)
+          if (!open) remove.reset()
+        }}
+        heading="Remove search tool"
+        body={`${tool.name} and the key stored with it are removed. A request that still names it as a tool is refused, so update the callers that use it.`}
+        confirmLabel="Remove permanently"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          remove.mutate(tool.name, { onSuccess: () => setDeleteOpen(false) })
+        }}
+      />
     </div>
   )
 }

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -401,7 +401,9 @@ describe("WorkspacesPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Edit" }))
     await screen.findByText("Per-provider defaults")
-    await user.click(screen.getByRole("button", { name: "Remove" }))
+    await user.click(
+      screen.getByRole("button", { name: "Remove default for openai" }),
+    )
 
     // The click opens the dialog and sends nothing.
     const dialog = await screen.findByRole("alertdialog")
@@ -434,7 +436,9 @@ describe("WorkspacesPage", () => {
 
     await user.click(await screen.findByRole("button", { name: "Edit" }))
     await screen.findByText("Per-provider defaults")
-    await user.click(screen.getByRole("button", { name: "Remove" }))
+    await user.click(
+      screen.getByRole("button", { name: "Remove default for openai" }),
+    )
     await user.click(
       within(await screen.findByRole("alertdialog")).getByRole("button", {
         name: "Cancel",

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -380,6 +380,70 @@ describe("WorkspacesPage", () => {
     ).toBe(false)
   })
 
+  it("confirms before removing a per-provider budget default", async () => {
+    // otari-ai#2110: this Remove used to delete on the click, with no
+    // confirmation of any kind. It was the only delete in the dashboard that
+    // asked nothing.
+    const requests = mockApi({
+      budgets: [budget({ budget_id: "bud-team", name: "Team standard" })],
+      budgetDefaults: {
+        "44444444-4444-4444-4444-444444444444": [
+          workspaceBudgetDefault({
+            id: "default-openai",
+            budget_id: "bud-team",
+            provider_key_id: "openai",
+          }),
+        ],
+      },
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+    await screen.findByText("Per-provider defaults")
+    await user.click(screen.getByRole("button", { name: "Remove" }))
+
+    // The click opens the dialog and sends nothing.
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).getByText(/openai fall back to/)).toBeVisible()
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false)
+
+    await user.click(
+      within(dialog).getByRole("button", { name: "Remove default" }),
+    )
+
+    const removed = requests.find((request) => request.method === "DELETE")
+    expect(removed?.url).toContain("default-openai")
+  })
+
+  it("keeps a per-provider default when the confirm is cancelled", async () => {
+    const requests = mockApi({
+      budgets: [budget({ budget_id: "bud-team", name: "Team standard" })],
+      budgetDefaults: {
+        "44444444-4444-4444-4444-444444444444": [
+          workspaceBudgetDefault({
+            id: "default-openai",
+            budget_id: "bud-team",
+            provider_key_id: "openai",
+          }),
+        ],
+      },
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+    await screen.findByText("Per-provider defaults")
+    await user.click(screen.getByRole("button", { name: "Remove" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Cancel",
+      }),
+    )
+
+    expect(requests.some((request) => request.method === "DELETE")).toBe(false)
+  })
+
   it("withholds the default-budget controls from a non-operator's edit form", async () => {
     const requests = mockApi({
       context: organizationContext({ deployment_operator: false }),

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -157,6 +157,9 @@ function NarrowedDefaults({
               <Button
                 size="sm"
                 variant="ghost"
+                // Named per row, as the picker beside it is: this is a list of
+                // providers, not a table with a row header to lean on.
+                aria-label={`Remove default for ${row.provider_key_id}`}
                 isDisabled={pending}
                 onPress={() => setPendingDelete(row)}
               >

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -218,10 +218,8 @@ function NarrowedDefaults({
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}
-        // Cleared on the way out rather than on the way in, so the trigger in
-        // the row stays a bare `setPendingDelete` and the column memo keeps its
-        // per-row cache: a refusal otherwise sits on the mutation and greets
-        // the next row's confirm as if that row had failed.
+        // Cleared on the way out: a refusal otherwise sits on the mutation and
+        // greets the next row's confirm as if that row had failed.
         onOpenChange={(open) => {
           if (open) return
           setPendingDelete(undefined)

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -117,6 +117,7 @@ function NarrowedDefaults({
   const deleteDefault = useDeleteWorkspaceBudgetDefault()
   const [provider, setProvider] = useState("")
   const [budgetId, setBudgetId] = useState("")
+  const [pendingDelete, setPendingDelete] = useState<WorkspaceBudgetDefault>()
 
   const taken = new Set(narrowed.map((row) => row.provider_key_id))
   const available = providers.filter((instance) => !taken.has(instance))
@@ -128,11 +129,7 @@ function NarrowedDefaults({
   return (
     <div className="flex flex-col gap-2">
       <span className="text-body">Per-provider defaults</span>
-      <ErrorBanner
-        error={
-          createDefault.error ?? updateDefault.error ?? deleteDefault.error
-        }
-      />
+      <ErrorBanner error={createDefault.error ?? updateDefault.error} />
       {narrowed.length === 0 ? (
         <span className="text-caption">
           None. The budget above applies on every provider.
@@ -159,11 +156,9 @@ function NarrowedDefaults({
               />
               <Button
                 size="sm"
-                variant="danger"
+                variant="ghost"
                 isDisabled={pending}
-                onPress={() =>
-                  deleteDefault.mutate({ workspaceId, defaultId: row.id })
-                }
+                onPress={() => setPendingDelete(row)}
               >
                 Remove
               </Button>
@@ -217,6 +212,35 @@ function NarrowedDefaults({
           </Button>
         </div>
       ) : null}
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        // Cleared on the way out rather than on the way in, so the trigger in
+        // the row stays a bare `setPendingDelete` and the column memo keeps its
+        // per-row cache: a refusal otherwise sits on the mutation and greets
+        // the next row's confirm as if that row had failed.
+        onOpenChange={(open) => {
+          if (open) return
+          setPendingDelete(undefined)
+          deleteDefault.reset()
+        }}
+        heading="Remove per-provider default"
+        body={
+          pendingDelete
+            ? `Requests to ${pendingDelete.provider_key_id} fall back to the workspace default above. Nothing caps them separately on that provider any more.`
+            : null
+        }
+        confirmLabel="Remove default"
+        isPending={deleteDefault.isPending}
+        error={deleteDefault.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          deleteDefault.mutate(
+            { workspaceId, defaultId: pendingDelete.id },
+            { onSuccess: () => setPendingDelete(undefined) },
+          )
+        }}
+      />
     </div>
   )
 }

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1081,10 +1081,6 @@ describe("content text wears a type role", () => {
       "a table head row, an empty state, and fieldset prose",
     ],
     [
-      "features/budgets/BudgetsPage.tsx",
-      "the delete confirmation's consequence text",
-    ],
-    [
       "features/activity/ActivityTimeline.tsx",
       "the brush's drag hint beside the chart",
     ],


### PR DESCRIPTION
## Description

Deleting a policy used to happen inside its own table row: the Delete action turned into a red
"Confirm" with a Cancel beside it, two cells wide, in a table that is otherwise inert text. It read
as part of the table rather than as a decision, and a row action has nowhere to put the sentence
that says what the deletion actually costs.

Every deletion in the dashboard now opens a confirmation dialog. The control in the row just opens
it; the dialog names the record, says what changes once it is gone, and carries the red confirm
button. Nine actions moved: routing policies and aliases (the one in the issue), stored providers,
archived organization provider keys, email domain claims, guardrails, search tools, budgets, API
keys, and a workspace's per-provider budget default. That last one is worth calling out: it deleted
on the click, with no confirmation of any kind.

Confirming twice in place survives where nothing is deleted, because the consequence fits in a
label there: archiving a provider key, regenerating a key's secret, and resetting a model's price.
Reversible or restoring-a-default actions are not deletions, so a modal for each would be a wall.

Two smaller things came out of it. A failed deletion now reports inside the dialog the operator is
looking at rather than in a banner behind it, and a failure on one row no longer greets the next
row's confirmation as though that row had failed. And the delete control in the three places that
are a list rather than a table now says which row it acts on, so a screen reader does not read the
same name on every row.

The design system said the opposite of all this, so its guidance changed with the code.

## How to test it locally

```sh
make dashboard && uv run otari serve   # or your usual local gateway
```

Then, signed in:

1. **Routing → Policies** (the issue). Create a policy, press Delete on its row. A dialog opens
   naming the policy and what stops resolving. Cancel: nothing happens, the row is still there.
   Delete again and confirm: the row goes.
2. **Spend & budgets**, **API keys** (disable a key first), **Providers**, **Tools** (guardrails and
   search tools), **Organization → Email domains** and **Provider keys** (show archived, then
   Delete): same journey on each.
3. **Workspaces → Edit → Per-provider defaults**, the one that used to delete instantly. Add a
   default, press Remove, and note that it now asks first.
4. Confirm the two-step is still there where nothing is deleted: **Models → Reset price**, and
   **Organization → Provider keys → Archive** on a live key.

Already proven by automated checks:

- `pnpm --dir web test` (5279 pass). Adds coverage for the dialog on each moved site, plus the
  cancel path, the refusal-reported-in-the-dialog path, and a regression test for the stale error
  carrying to the next row.
- `pnpm --dir web run e2e` (43 pass). Four parity flows now drive the modal for providers, keys,
  budgets and policies.
- `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `make lint`.
- The Storybook catalog builds and all 366 stories render clean in both themes.

Left to eyeball: the Remove button on a workspace's per-provider defaults changed from red to
neutral, since the dialog carries the red now. Screenshot baselines are gitignored and that suite
runs on demand, so no PNGs are in this PR.

One thing deliberately not in scope. About ten deletions already used a dialog before this change
and still do not reset their mutation on close, so they can show a previous refusal when reopened.
That is the pre-existing pattern rather than anything this PR introduces; the new guidance in
`web/design/actions.md` describes the reset, and a follow-up can bring those sites to it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2110

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) in Claude Code.

**Any additional AI details you'd like to share:**

The change is dashboard-only, so `make test` was not the relevant suite; the dashboard's Vitest,
Playwright and Storybook checks listed above were run instead, along with `make lint`. The OpenAPI
checklist line is ticked as not applicable: no route, schema or route docstring changed, and
`web/src/client/schema.ts` and `web/src/routeTree.gen.ts` are unchanged.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Record deletions now require confirmation dialogs across dashboard areas.
- Dialogs identify the record, explain the consequence, and show deletion errors in context.
- Delete controls now include accessible record names.
- Existing two-step confirmations remain for archive, regenerate, and reset actions.
- Updated design guidance, unit tests, end-to-end tests, and documentation.

## Technical notes

- Dialog state and mutation errors reset when dialogs close.
- Added coverage for confirmation, cancellation, failed deletion, and stale-error cases.
- Reported checks include 5,279 unit tests, 43 end-to-end tests, lint, type checking, and Storybook rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->