### PR TITLE
feat(dashboard): move the keys page's one-time secret into FormDialog

### DIFF
--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -143,7 +143,7 @@ one question; a form is a place to work.
   onSubmit={submit}
   isPending={create.isPending}
   error={create.error}
-  isDirty={name !== ""}
+  isDirty={isDirty}
 >
   <Field
     label="Key name"
@@ -229,26 +229,36 @@ its state, and a failed create's banner survives into a fresh form. `close()`
 only sets `isOpen` false; a `requestAnimationFrame` does not cover the exit,
 which is an animation rather than a frame.
 
-**`isDirty` is `draft !== seed`**: one snapshot of every field the form owns,
-seeded once on mount beside the reset, and compared against the live one.
+**`isDirty` comes from `useDirtySnapshot`**: hand it every field the form owns
+and it snapshots them on mount, so dirty means "differs from what was seeded".
 
 ```tsx
-// Correct: a snapshot, so dirty means "differs from what was seeded"
-const draft = JSON.stringify({ name, target, chain, conditions, guardrails })
-const seed = useRef(draft)
+// Correct: the whole draft, and the hook holds the seed
+const { isDirty } = useDirtySnapshot({
+  name,
+  target,
+  chain,
+  conditions,
+  guardrails,
+})
 …
-<FormDialog isDirty={draft !== seed.current} … />
+<FormDialog isDirty={isDirty} … />
 
 // Incorrect: a predicate of empties, which reports an edit form dirty on arrival
 const isPristine = name === "" && target === "" && chain.length === 0
 ```
 
+A field whose default arrives after mount (the first budget in a list, a
+workspace roster) is part of the seed, not a change: seed the state from the
+resolved value, or call the hook's `reset` when it lands. The hook cannot tell
+that default from a keystroke, and deliberately does not try.
+
 Dirty means "differs from what was seeded", and a create form is the case where
 the seed happens to be all empties. So a hand-listed predicate of empties is the
 create-only degenerate form: it is right until the same component edits
 something, and it drifts, because a field added to the form has to be remembered
-in a second place. The snapshot cannot omit a field the reset does not, since
-both read one list.
+in a second place. The hook cannot omit a field, because it is handed the draft
+rather than a list of the fields to compare.
 
 A guard that lies lets Escape discard work it cannot see. That has happened here
 in both directions: a reopened dialog dirty on arrival, and a half-filled one

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -193,13 +193,22 @@ A dialog never opens a dialog.
 **A draft is fresh on every open and untouched through the exit.** Reset on the
 way in, never on the way out. The frame keeps its content while it animates out,
 so clearing state when `isOpen` goes false blanks the body for the length of the
-exit, and a success step blanks to an empty form in front of the operator. The
-component holding the draft stays mounted through that, and the page remounts it
-on each open by keying it on a counter it bumps where the trigger opens the
-dialog:
+exit, and a success step blanks to an empty form in front of the operator.
+
+**The component that renders the `FormDialog` owns everything that resets
+between opens: the draft *and* its mutation**, meaning the hook that yields
+`isPending` and `error`. Both live below the key. The page owns only `isOpen`,
+the open counter that keys the mount, and the list the mutation refreshes.
 
 ```tsx
-// Correct: the page owns isOpen and the mutation, the draft lives below the key
+// Correct: the mutation is inside the component the key remounts
+function CreateKeyDialog({ isOpen, onOpenChange }: …) {
+  const create = useCreateKey()
+  const [keyName, setKeyName] = useState("")
+  …
+}
+
+// and the page holds only what does not reset
 const [isOpen, setIsOpen] = useState(false)
 const [openCount, setOpenCount] = useState(0)
 …
@@ -208,15 +217,28 @@ const [openCount, setOpenCount] = useState(0)
 </Button>
 <CreateKeyDialog key={openCount} isOpen={isOpen} onOpenChange={setIsOpen} />
 
-// Incorrect: the close handler clears what is still on screen
-const close = () => { setIsOpen(false); setCreated(null); resetForm() }
+// Incorrect: the mutation sits above the key, so the key cannot reset it
+const createBudget = useCreateBudget()          // page level
+…
+<BudgetForm key={openCount} error={createBudget.error} … />
 ```
 
-`close()` then only sets `isOpen` false. A `requestAnimationFrame` does not
-cover it, because the exit is an animation and not a frame. The remount is also
-what keeps one row's draft out of the next row's dialog, which is the promise
-this component's own docstring makes; a page that holds the draft above the
-dialog defeats it, and holding it above is what every page does.
+A mutation above the key is the shape to watch for, because the draft looks
+right and the error does not: the key remounts the fields, the mutation keeps
+its state, and a failed create's banner survives into a fresh form. `close()`
+only sets `isOpen` false; a `requestAnimationFrame` does not cover the exit,
+which is an animation rather than a frame.
+
+**`isDirty` is the negation of one `isPristine` predicate**, declared beside
+`resetForm`, that names every field the form owns. A field added to the form is
+added there or the guard lies: it will let Escape discard work it cannot see.
+Reading the two lists as one is what keeps them from drifting apart, which they
+have done in both directions, leaving a reopened dialog dirty on arrival and a
+half-filled one discarded without a word.
+
+The remount is also what keeps one row's draft out of the next row's dialog,
+which is the promise this component's own docstring makes; a page that holds the
+draft above the dialog defeats it.
 
 **The success step is not a prop.** When a mutation has something to hand back
 (a key's secret), the caller swaps the children and the submit label to "Done"

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -229,12 +229,30 @@ its state, and a failed create's banner survives into a fresh form. `close()`
 only sets `isOpen` false; a `requestAnimationFrame` does not cover the exit,
 which is an animation rather than a frame.
 
-**`isDirty` is the negation of one `isPristine` predicate**, declared beside
-`resetForm`, that names every field the form owns. A field added to the form is
-added there or the guard lies: it will let Escape discard work it cannot see.
-Reading the two lists as one is what keeps them from drifting apart, which they
-have done in both directions, leaving a reopened dialog dirty on arrival and a
-half-filled one discarded without a word.
+**`isDirty` is `draft !== seed`**: one snapshot of every field the form owns,
+seeded once on mount beside the reset, and compared against the live one.
+
+```tsx
+// Correct: a snapshot, so dirty means "differs from what was seeded"
+const draft = JSON.stringify({ name, target, chain, conditions, guardrails })
+const seed = useRef(draft)
+…
+<FormDialog isDirty={draft !== seed.current} … />
+
+// Incorrect: a predicate of empties, which reports an edit form dirty on arrival
+const isPristine = name === "" && target === "" && chain.length === 0
+```
+
+Dirty means "differs from what was seeded", and a create form is the case where
+the seed happens to be all empties. So a hand-listed predicate of empties is the
+create-only degenerate form: it is right until the same component edits
+something, and it drifts, because a field added to the form has to be remembered
+in a second place. The snapshot cannot omit a field the reset does not, since
+both read one list.
+
+A guard that lies lets Escape discard work it cannot see. That has happened here
+in both directions: a reopened dialog dirty on arrival, and a half-filled one
+discarded without a word.
 
 The remount is also what keeps one row's draft out of the next row's dialog,
 which is the promise this component's own docstring makes; a page that holds the

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -190,6 +190,34 @@ disabled, because they genuinely are refused until it lands.
 click outside swap the actions for "Unsaved changes · Keep editing · Discard".
 A dialog never opens a dialog.
 
+**A draft is fresh on every open and untouched through the exit.** Reset on the
+way in, never on the way out. The frame keeps its content while it animates out,
+so clearing state when `isOpen` goes false blanks the body for the length of the
+exit, and a success step blanks to an empty form in front of the operator. The
+component holding the draft stays mounted through that, and the page remounts it
+on each open by keying it on a counter it bumps where the trigger opens the
+dialog:
+
+```tsx
+// Correct: the page owns isOpen and the mutation, the draft lives below the key
+const [isOpen, setIsOpen] = useState(false)
+const [openCount, setOpenCount] = useState(0)
+…
+<Button onPress={() => { setOpenCount((n) => n + 1); setIsOpen(true) }}>
+  Create key
+</Button>
+<CreateKeyDialog key={openCount} isOpen={isOpen} onOpenChange={setIsOpen} />
+
+// Incorrect: the close handler clears what is still on screen
+const close = () => { setIsOpen(false); setCreated(null); resetForm() }
+```
+
+`close()` then only sets `isOpen` false. A `requestAnimationFrame` does not
+cover it, because the exit is an animation and not a frame. The remount is also
+what keeps one row's draft out of the next row's dialog, which is the promise
+this component's own docstring makes; a page that holds the draft above the
+dialog defeats it, and holding it above is what every page does.
+
 **The success step is not a prop.** When a mutation has something to hand back
 (a key's secret), the caller swaps the children and the submit label to "Done"
 and the frame stays where it was. `footerStart` is where "Create another" goes.

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -176,14 +176,18 @@ test.describe("dashboard core flows", () => {
     await nav(page).getByRole("link", { name: "API keys" }).click()
     // A bootstrap key already exists, so use the header action, not onboarding.
     await page.getByRole("button", { name: "Create key" }).click()
-    await page.getByLabel("Name").fill("ci-bot")
+    // Scoped from here on, because "Create key" is now on screen twice: the
+    // heading's trigger stays visible while the dialog is open, and the labels
+    // rule makes the dialog's submit say the same words.
+    const dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Name").fill("ci-bot")
     // Owner is required (user-first). Reuse the user created earlier; type it and
     // close the combobox popover so it does not aria-hide the submit button.
-    await page
+    await dialog
       .getByPlaceholder("Pick a user, or type a new id…")
       .fill("alice@example.com")
     await page.keyboard.press("Escape")
-    await page.getByRole("button", { name: "Create key" }).click()
+    await dialog.getByRole("button", { name: "Create key" }).click()
 
     // The one-time reveal appears; acknowledge it.
     await page.getByRole("button", { name: /saved this key/i }).click()

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test"
 import { API_ROOT } from "@/shared/api/client"
 import {
   dismissComboBox,
+  dismissComboBoxInDialog,
   login,
   MASTER_KEY,
   nav,
@@ -183,10 +184,9 @@ test.describe("dashboard core flows", () => {
     await dialog.getByLabel("Name").fill("ci-bot")
     // Owner is required (user-first). Reuse the user created earlier; type it and
     // close the combobox popover so it does not aria-hide the submit button.
-    await dialog
-      .getByPlaceholder("Pick a user, or type a new id…")
-      .fill("alice@example.com")
-    await page.keyboard.press("Escape")
+    const ownerBox = dialog.getByPlaceholder("Pick a user, or type a new id…")
+    await ownerBox.fill("alice@example.com")
+    await dismissComboBoxInDialog(ownerBox)
     await dialog.getByRole("button", { name: "Create key" }).click()
 
     // The one-time reveal appears; acknowledge it.

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -180,18 +180,23 @@ export async function dismissComboBox(box: Locator): Promise<void> {
   await expect(box).not.toHaveAttribute("aria-expanded", "true")
 }
 
-// The same, for a combobox inside a dialog, which is the only difference that
-// matters: a modal contains focus, so the `blur()` above lands straight back on
-// the box and the box re-opens on focus. Escape alone closes the popover.
+// The same, for a combobox inside a dialog. Two differences, and the second one
+// is why this is a separate helper rather than a flag.
 //
-// The wait stays, because it is what makes either of these deterministic, and
-// dropping it here is worse than dropping it on a page. If the popover is
-// already closed when the key lands (react-aria closes it on an empty filtered
-// list) the Escape reaches the dialog instead, and a dirty form answers that by
-// arming its unsaved-changes guard, which takes the submit out of the footer.
-// The next lookup then fails on a missing button rather than on the real cause.
+// No `blur()`: a modal contains focus, so it lands straight back on the box and
+// the box re-opens on focus. Escape alone closes the popover.
+//
+// And the Escape is sent only when there is a popover to close. Otherwise it
+// reaches the dialog, and a dirty form answers that by arming its
+// unsaved-changes guard, which takes the submit out of the footer, so the next
+// lookup fails on a missing button rather than on the real cause. The wait
+// cannot prevent that: a closed popover satisfies it instantly, by which point
+// the keystroke has already landed. It is kept for what it does cover, a
+// popover that closes asynchronously.
 export async function dismissComboBoxInDialog(box: Locator): Promise<void> {
-  await box.press("Escape")
+  if ((await box.getAttribute("aria-expanded")) === "true") {
+    await box.press("Escape")
+  }
   await expect(box).not.toHaveAttribute("aria-expanded", "true")
 }
 

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -180,6 +180,21 @@ export async function dismissComboBox(box: Locator): Promise<void> {
   await expect(box).not.toHaveAttribute("aria-expanded", "true")
 }
 
+// The same, for a combobox inside a dialog, which is the only difference that
+// matters: a modal contains focus, so the `blur()` above lands straight back on
+// the box and the box re-opens on focus. Escape alone closes the popover.
+//
+// The wait stays, because it is what makes either of these deterministic, and
+// dropping it here is worse than dropping it on a page. If the popover is
+// already closed when the key lands (react-aria closes it on an empty filtered
+// list) the Escape reaches the dialog instead, and a dirty form answers that by
+// arming its unsaved-changes guard, which takes the submit out of the footer.
+// The next lookup then fails on a missing button rather than on the real cause.
+export async function dismissComboBoxInDialog(box: Locator): Promise<void> {
+  await box.press("Escape")
+  await expect(box).not.toHaveAttribute("aria-expanded", "true")
+}
+
 // Pick an option from a FilterSelect. It is a HeroUI Select, so the control is a
 // button that opens a listbox popover: there is no native <select> to
 // `selectOption` on, and the option is named by its visible label. React-aria

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -147,9 +147,9 @@ test.describe("api keys", () => {
     // anonymous virtual users an omitted id would.
     const ownerBox = dialog.getByPlaceholder("Pick a user, or type a new id…")
     await ownerBox.fill(PARITY.users.heavy)
-    // A bare Escape rather than `dismissComboBox`: that helper waits for
-    // `aria-expanded` to clear on the box, and inside a dialog the key closes
-    // the popover without the box reporting it.
+    // A bare Escape rather than `dismissComboBox`: that helper follows the key
+    // with a `blur()`, and a modal contains focus, so it lands back on the box
+    // and the box re-opens on focus. Escape alone puts the popover away.
     await page.keyboard.press("Escape")
     await dialog.getByRole("button", { name: "Create key" }).click()
 

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -138,22 +138,32 @@ test.describe("api keys", () => {
     await openPage(page, "API keys", "API keys")
 
     await page.getByRole("button", { name: "Create key" }).click()
-    await page.getByLabel("Name").fill(KEY_NAME)
+    // Scoped from here on, because "Create key" is now on screen twice: the
+    // heading's trigger stays visible while the dialog is open, and the labels
+    // rule makes the dialog's submit say the same words.
+    const dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Name").fill(KEY_NAME)
     // Owner is required: this is what keeps the dashboard from minting the
     // anonymous virtual users an omitted id would.
-    const ownerBox = page.getByPlaceholder("Pick a user, or type a new id…")
+    const ownerBox = dialog.getByPlaceholder("Pick a user, or type a new id…")
     await ownerBox.fill(PARITY.users.heavy)
-    await dismissComboBox(ownerBox)
-    await page.getByRole("button", { name: "Create key" }).click()
+    // A bare Escape rather than `dismissComboBox`: that helper waits for
+    // `aria-expanded` to clear on the box, and inside a dialog the key closes
+    // the popover without the box reporting it.
+    await page.keyboard.press("Escape")
+    await dialog.getByRole("button", { name: "Create key" }).click()
 
-    // The secret is shown exactly once, behind an explicit acknowledgement that
-    // Esc deliberately does not dismiss. A strip with `role="alert"` rather than
-    // a dialog: the modal's focus trap and swallowed Esc went with the redesign,
-    // and the acknowledgement is still the only thing that dismisses it.
+    // The secret is shown exactly once, behind an acknowledgement that is the
+    // only way out: the dialog is `isDismissable={false}`, so Escape and the
+    // close control are gone. The reveal keeps its own `role="alert"` inside
+    // the dialog body, which is what the first two assertions read.
     const reveal = page.getByRole("alert", { name: /API key created/ })
     await expect(reveal).toBeVisible()
     await expect(reveal).toContainText("shown only once")
-    await reveal.getByRole("button", { name: /saved this key/i }).click()
+    // Scoped to the dialog rather than to the reveal: the acknowledgement is
+    // the dialog's own submit, in the footer, so it sits outside the alert
+    // region the announcement covers.
+    await dialog.getByRole("button", { name: /saved this key/i }).click()
 
     const key = row(page, "API keys", KEY_NAME)
     await expect(key).toContainText("Active")

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page, test } from "@playwright/test"
 
 import {
   dismissComboBox,
+  dismissComboBoxInDialog,
   gotoRoute,
   login,
   nav,
@@ -147,10 +148,7 @@ test.describe("api keys", () => {
     // anonymous virtual users an omitted id would.
     const ownerBox = dialog.getByPlaceholder("Pick a user, or type a new id…")
     await ownerBox.fill(PARITY.users.heavy)
-    // A bare Escape rather than `dismissComboBox`: that helper follows the key
-    // with a `blur()`, and a modal contains focus, so it lands back on the box
-    // and the box re-opens on focus. Escape alone puts the popover away.
-    await page.keyboard.press("Escape")
+    await dismissComboBoxInDialog(ownerBox)
     await dialog.getByRole("button", { name: "Create key" }).click()
 
     // The secret is shown exactly once, behind an acknowledgement that is the

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -331,3 +331,41 @@ test.describe("organization admin", () => {
     await captureScreenshot(page, "organization-spend-budgets")
   })
 })
+
+test.describe("the keys page's one-time secret", () => {
+  // The dialog at rest, which the matrix above cannot reach: its entries open a
+  // route and capture it, and this is a state the page has to be put into.
+  // Captured on every viewport and both themes like the rest, which is how the
+  // phone gets covered: below 640px the dialog is a full-screen sheet, so the
+  // mobile project is the only place that shape appears at all.
+  test("the create dialog, on the form step", async ({ page }) => {
+    await login(page)
+    await gotoRoute(page, "/keys")
+    await expect(
+      page.getByRole("heading", { name: /keys/i }).first(),
+    ).toBeVisible()
+    // The heading's own action, not the empty state's: the seeded database has
+    // rows, so there is no empty state, and this is the placement the whole
+    // change is about.
+    await page.getByRole("button", { name: "Create key" }).first().click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByLabel("Name")).toBeVisible()
+    await captureScreenshot(page, "keys-create-dialog")
+  })
+
+  // The same dialog with its disclosure open, which is what makes the body
+  // scroll: header and footer pinned, content moving between them.
+  test("the create dialog, with Advanced open", async ({ page }) => {
+    await login(page)
+    await gotoRoute(page, "/keys")
+    await expect(
+      page.getByRole("heading", { name: /keys/i }).first(),
+    ).toBeVisible()
+    await page.getByRole("button", { name: "Create key" }).first().click()
+    const dialog = page.getByRole("dialog")
+    await dialog.getByRole("button", { name: "Advanced" }).click()
+    await expect(dialog.getByText("Restrict this key's models")).toBeVisible()
+    await captureScreenshot(page, "keys-create-dialog-advanced")
+  })
+})

--- a/web/src/design-system/actions/CopyField.test.tsx
+++ b/web/src/design-system/actions/CopyField.test.tsx
@@ -326,6 +326,84 @@ describe("CopyField, concealed", () => {
     expect(field).toHaveValue(snippet)
   })
 
+  it("opens revealed on `defaultRevealed`, and keeps the toggle", async () => {
+    const user = userEvent.setup()
+    render(
+      <CopyField
+        label="Secret key"
+        value="gw-shown-at-once"
+        concealed={CONCEALED_SECRET}
+        defaultRevealed
+      />,
+    )
+
+    // Revealed on arrival, which is what the one-time secret step needs, and
+    // still able to conceal: the toggle is the affordance, not the default.
+    expect(screen.getByLabelText("Secret key")).toHaveValue("gw-shown-at-once")
+    await user.click(screen.getByRole("button", { name: "Hide Secret key" }))
+    expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+  })
+
+  it("takes its reveal from the caller when controlled, and reports the press", async () => {
+    const onRevealChange = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <CopyField
+        label="Secret key"
+        value="gw-controlled"
+        concealed={CONCEALED_SECRET}
+        isRevealed={false}
+        onRevealChange={onRevealChange}
+      />,
+    )
+
+    expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+    await user.click(screen.getByRole("button", { name: "Show Secret key" }))
+    // Reported rather than acted on: a controlled field shows what the caller
+    // says, which is what lets several fields on one credential move together.
+    expect(onRevealChange).toHaveBeenCalledWith(true)
+    expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+
+    rerender(
+      <CopyField
+        label="Secret key"
+        value="gw-controlled"
+        concealed={CONCEALED_SECRET}
+        isRevealed
+        onRevealChange={onRevealChange}
+      />,
+    )
+    expect(screen.getByLabelText("Secret key")).toHaveValue("gw-controlled")
+  })
+
+  it("leaves a controlled field revealed across a new value, which is the caller's to conceal", () => {
+    // The counterpart of the uncontrolled case below, and the reason the prop
+    // says so: keyed-to-value re-concealing is what a controlled caller gives
+    // up, so this pins the behavior rather than leaving it to be discovered by
+    // a rotation showing a key nobody asked for.
+    const { rerender } = render(
+      <CopyField
+        label="Secret key"
+        value="gw-first-secret"
+        concealed={CONCEALED_SECRET}
+        isRevealed
+        onRevealChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText("Secret key")).toHaveValue("gw-first-secret")
+
+    rerender(
+      <CopyField
+        label="Secret key"
+        value="gw-second-secret"
+        concealed={CONCEALED_SECRET}
+        isRevealed
+        onRevealChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText("Secret key")).toHaveValue("gw-second-secret")
+  })
+
   it("conceals a second value, rather than inheriting the first one's reveal", async () => {
     const user = userEvent.setup()
     const { rerender } = render(

--- a/web/src/design-system/actions/CopyField.test.tsx
+++ b/web/src/design-system/actions/CopyField.test.tsx
@@ -470,6 +470,48 @@ describe("CopyField, concealed", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("asks for no reveal when a controlled field's value changed mid-copy", async () => {
+    // The controlled twin of the case above, and the one the value keying does
+    // not cover: `onRevealChange` carries a bare boolean, so a caller told to
+    // reveal has no way to know which value the reveal was for and would put
+    // the replacement on screen unasked.
+    const user = userEvent.setup()
+    let refuse: (reason: Error) => void = () => {}
+    vi.spyOn(navigator.clipboard, "writeText").mockReturnValue(
+      new Promise((_resolve, reject) => {
+        refuse = reject
+      }),
+    )
+    const onRevealChange = vi.fn()
+    const { rerender } = render(
+      <CopyField
+        label="Secret key"
+        value="gw-first-secret"
+        concealed={CONCEALED_SECRET}
+        isRevealed={false}
+        onRevealChange={onRevealChange}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Copy" }))
+    rerender(
+      <CopyField
+        label="Secret key"
+        value="gw-second-secret"
+        concealed={CONCEALED_SECRET}
+        isRevealed={false}
+        onRevealChange={onRevealChange}
+      />,
+    )
+    refuse(new Error("not a secure context"))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Secret key")).toHaveValue(CONCEALED_SECRET)
+    })
+    expect(onRevealChange).not.toHaveBeenCalled()
+    expect(document.body.textContent).not.toContain("gw-second-secret")
+  })
+
   it("rejects concealing a field that carries an action, at the type level", () => {
     render(
       // @ts-expect-error nothing hands out a credential beside a

--- a/web/src/design-system/actions/CopyField.tsx
+++ b/web/src/design-system/actions/CopyField.tsx
@@ -197,6 +197,16 @@ export function CopyField({
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   )
+  // The value on screen right now, which is not what `copy` below closes over:
+  // that is the value of the render the press happened in, and a credential can
+  // arrive while the attempt is in flight. Controlled mode needs it because
+  // `onRevealChange` carries a bare boolean and cannot say which value a reveal
+  // was asked for; uncontrolled mode keys on the value itself through
+  // `revealedValue`.
+  const latestValue = useRef(value)
+  useEffect(() => {
+    latestValue.current = value
+  }, [value])
   // The value a failed copy asked to have selected, once revealing it has put
   // it on the field: `select()` in the failure's own tick would span the
   // stand-in, and the value React writes on the revealing render discards a
@@ -246,7 +256,7 @@ export function CopyField({
       if (ref.current?.value === copying) {
         ref.current.focus()
         ref.current.select()
-      } else {
+      } else if (latestValue.current === copying) {
         selectOnReveal.current = copying
         setRevealed(true)
       }

--- a/web/src/design-system/actions/CopyField.tsx
+++ b/web/src/design-system/actions/CopyField.tsx
@@ -112,6 +112,13 @@ type CopyFieldProps = {
        * `onRevealChange` and shows what the caller says. Several fields sharing
        * one credential share one of these, so they reveal and conceal together
        * rather than one at a time.
+       *
+       * **A controlled field does not re-conceal on a new value.** Uncontrolled,
+       * the reveal is keyed to the value it was asked for (see the comment on
+       * `revealedValue` below), so a rotation arriving into a revealed field
+       * conceals itself. A controlled caller owns that instead: conceal on a
+       * value change, or the replacement is on screen without anyone having
+       * asked to see it.
        */
       isRevealed?: boolean
       /** The toggle's press, for a controlled field. */

--- a/web/src/design-system/actions/CopyField.tsx
+++ b/web/src/design-system/actions/CopyField.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@heroui/react"
 import type { ReactElement, ReactNode } from "react"
-import { useEffect, useId, useRef, useState } from "react"
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react"
 import { FiEye, FiEyeOff } from "react-icons/fi"
 import { CopyButton } from "@/design-system/actions/CopyButton"
 import { copyToClipboard } from "@/design-system/helpers/clipboard"
@@ -204,7 +204,12 @@ export function CopyField({
   // was asked for; uncontrolled mode keys on the value itself through
   // `revealedValue`.
   const latestValue = useRef(value)
-  useEffect(() => {
+  // `useLayoutEffect`, not `useEffect`: the reader is a rejected-promise
+  // handler, so it runs as a microtask, and a passive effect is scheduled
+  // rather than run at commit. A rejection landing after the render that
+  // carries the new credential but before that effect would read the old one
+  // here and pass the gate below, which is the case this exists to refuse.
+  useLayoutEffect(() => {
     latestValue.current = value
   }, [value])
   // The value a failed copy asked to have selected, once revealing it has put

--- a/web/src/design-system/actions/CopyField.tsx
+++ b/web/src/design-system/actions/CopyField.tsx
@@ -95,11 +95,32 @@ type CopyFieldProps = {
        * has been asked for, while Copy copies the real value either way, so a
        * key can be handed over without being read off the screen (otari-ai#2111).
        *
+       * The one-time secret step is the exception and opens revealed, by product
+       * ruling: that screen exists to hand the key over, and there is no second
+       * chance to read it. The toggle and copying without reading survive there,
+       * which is what otari-ai#2111 asked for.
+       *
        * A whole-value field passes `CONCEALED_SECRET`. A snippet passes the same
        * snippet built around that stand-in, so what is hidden is the key rather
        * than the request that explains it.
        */
       concealed?: string
+      /**
+       * Whether the value is revealed, for a caller that owns the state.
+       *
+       * Passing it makes the field controlled: the toggle reports through
+       * `onRevealChange` and shows what the caller says. Several fields sharing
+       * one credential share one of these, so they reveal and conceal together
+       * rather than one at a time.
+       */
+      isRevealed?: boolean
+      /** The toggle's press, for a controlled field. */
+      onRevealChange?: (next: boolean) => void
+      /**
+       * Whether an uncontrolled field starts revealed. Concealed by default,
+       * and a later value arrives concealed whatever this said.
+       */
+      defaultRevealed?: boolean
       /**
        * Excluded here rather than guarded at runtime, so a call site that passes
        * both fails to compile. The multiline field is a `<textarea>`, where the
@@ -112,6 +133,9 @@ type CopyFieldProps = {
       multiline?: false
       /** Nothing hands out a credential beside a domain-verification action. */
       concealed?: never
+      isRevealed?: never
+      onRevealChange?: never
+      defaultRevealed?: never
       /**
        * A control to sit beside the field, which moves the copy affordance
        * inside the field and drops the button from the label row. Absent, the
@@ -132,6 +156,9 @@ export function CopyField({
   fieldRef,
   action,
   concealed,
+  isRevealed,
+  onRevealChange,
+  defaultRevealed = false,
 }: CopyFieldProps) {
   const internalRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(
     null,
@@ -146,12 +173,16 @@ export function CopyField({
   // copying: a rotation with the previous key still on screen would otherwise
   // publish the replacement without anyone asking to see it.
   const [revealedValue, setRevealedValue] = useState<string | undefined>(
-    undefined,
+    defaultRevealed ? value : undefined,
   )
   const [selectHintFor, setSelectHintFor] = useState<string | undefined>(
     undefined,
   )
-  const revealed = revealedValue === value
+  const revealed = isRevealed ?? revealedValue === value
+  const setRevealed = (next: boolean) => {
+    onRevealChange?.(next)
+    if (isRevealed === undefined) setRevealedValue(next ? value : undefined)
+  }
   const selectHint = selectHintFor === value
   // Same shape as CopyButton's below: the acknowledgement clears itself on a
   // timer, so the timer has to die with the component (and be replaced rather
@@ -174,10 +205,10 @@ export function CopyField({
     // Only once the reveal has landed on the value the copy was for. Another
     // credential arriving in the meantime is concealed, and selecting its
     // stand-in is exactly what this is here to avoid.
-    if (revealedValue !== wanted || value !== wanted) return
+    if (!revealed || value !== wanted) return
     ref.current?.focus()
     ref.current?.select()
-  }, [revealedValue, value, ref])
+  }, [revealed, value, ref])
 
   const isConcealed = concealed !== undefined && !revealed
   const shown = isConcealed ? concealed : value
@@ -210,7 +241,7 @@ export function CopyField({
         ref.current.select()
       } else {
         selectOnReveal.current = copying
-        setRevealedValue(copying)
+        setRevealed(true)
       }
       setSelectHintFor(copying)
       return
@@ -303,7 +334,7 @@ export function CopyField({
       variant="ghost"
       isIconOnly
       aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
-      onPress={() => setRevealedValue(revealed ? undefined : value)}
+      onPress={() => setRevealed(!revealed)}
     >
       {revealed ? (
         <FiEyeOff aria-hidden="true" className="h-3.5 w-3.5" />

--- a/web/src/design-system/actions/copy.stories.tsx
+++ b/web/src/design-system/actions/copy.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { useRef } from "react"
+import { useRef, useState } from "react"
 
 import { Button as ActionButton } from "./Button"
 import { CopyButton } from "./CopyButton"
@@ -175,6 +175,64 @@ export const Concealed: Story = {
  * dashboard is routinely served from, which is the same reason the field
  * selects on click.
  */
+/**
+ * A field that opens revealed, for the one screen that exists to hand a
+ * credential over.
+ *
+ * `defaultRevealed` is the uncontrolled form of it. The toggle still works and
+ * Copy still copies the real value, so nothing otari-ai#2111 asked for is given
+ * up; what changes is which state the field starts in. Reach for it only where
+ * there is no second chance to read the value.
+ */
+export const RevealedOnArrival: Story = {
+  render: () => (
+    <div className="flex w-[34rem] flex-col gap-4">
+      <CopyField
+        label="Secret key"
+        value="otari-sk-9f3a1c77b0e244d1e8a972fc0a3bc5d8"
+        concealed={CONCEALED_SECRET}
+        defaultRevealed
+      />
+    </div>
+  ),
+}
+
+/**
+ * Several fields carrying one credential, revealing and concealing together.
+ *
+ * `isRevealed` and `onRevealChange` make the field controlled, so the caller
+ * holds one piece of state and the key and the requests that embed it cannot
+ * end up in two states on one screen. The eye stays on every field: whichever
+ * one is pressed moves all of them.
+ */
+export const CoupledReveal: Story = {
+  render: function CoupledRevealStory() {
+    const [isRevealed, setIsRevealed] = useState(true)
+    const key = "otari-sk-9f3a1c77b0e244d1e8a972fc0a3bc5d8"
+    const request = (secret: string) =>
+      `curl https://gateway.example.com/v1/chat/completions \\\n  -H "Authorization: Bearer ${secret}"`
+    return (
+      <div className="flex w-[34rem] flex-col gap-4">
+        <CopyField
+          label="Secret key"
+          value={key}
+          concealed={CONCEALED_SECRET}
+          isRevealed={isRevealed}
+          onRevealChange={setIsRevealed}
+        />
+        <CopyField
+          label="Example request"
+          multiline
+          value={request(key)}
+          concealed={request(CONCEALED_SECRET)}
+          isRevealed={isRevealed}
+          onRevealChange={setIsRevealed}
+        />
+      </div>
+    )
+  },
+}
+
 export const WithFieldRef: Story = {
   render: () => {
     const fieldRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -286,6 +286,52 @@ export const PhoneSheet: Story = {
   ),
 }
 
+/**
+ * A submit the form is not ready for. Shown disabled rather than allowed to
+ * fail, with the reason beside the control that is missing: a press that does
+ * nothing teaches nothing.
+ */
+export const SubmitBlocked: Story = {
+  args: { isSubmitDisabled: true },
+  render: (args) => (
+    <FormDialog {...args}>
+      <Field
+        label="Key name"
+        value=""
+        onChange={() => {}}
+        description="Required. Lowercase, hyphens, no spaces."
+        isInvalid
+        errorMessage="Give the key a name."
+        reserveMessage
+      />
+    </FormDialog>
+  ),
+}
+
+/**
+ * Content that cannot be recovered once the frame closes, which is the one case
+ * for taking the dismiss away: a key's plaintext secret is shown once. There is
+ * no close control and no Cancel, because both are dismissals; the footer's one
+ * action is the acknowledgement and the only way out.
+ */
+export const NotDismissable: Story = {
+  args: {
+    isDismissable: false,
+    title: "Key created",
+    description: "Copy it now. Otari stores a hash and cannot show it again.",
+    submitLabel: "I\u2019ve saved this key",
+    footerStart: <Button>Create another</Button>,
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <CopyField
+        label="Secret key"
+        value="otari-sk-9f3a1c77b0e244d1e8a972fc0a3bc5d86e10f4b2"
+      />
+    </FormDialog>
+  ),
+}
+
 /** Driven from a trigger, which is how a heading row actually opens it. */
 export const FromTrigger: Story = {
   render: (args) => {

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -279,10 +279,14 @@ function ManyFields() {
  */
 /**
  * The same sheet, landscape. `isRotated` puts the phone at 844x390, which is
- * wider than 640 and shorter than it: the sheet keys on either dimension, so a
- * viewport that cannot afford the 120px gap vertically gets the sheet rather
- * than a third layout. Without that this was a 150px dialog with 137px of
- * header and footer in it.
+ * wider than 640 and shorter than it: the sheet's geometry keys on either
+ * dimension, so a viewport that cannot afford the 120px gap vertically gets the
+ * sheet rather than a third layout. Without that this was a 150px dialog with
+ * 137px of header and footer in it.
+ *
+ * The footer stays a row here, unlike the portrait story below: stacking is
+ * keyed on width alone, because 844px affords a row and `(height <= 639px)`
+ * also matches an unmaximized desktop window.
  */
 export const PhoneSheetLandscape: Story = {
   globals: { viewport: { value: "mobile2", isRotated: true } },

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -279,6 +279,14 @@ function ManyFields() {
  */
 export const PhoneSheet: Story = {
   globals: { viewport: { value: "mobile2", isRotated: false } },
+  // With a `footerStart` caption, which is the case that does not fit a row:
+  // beside two buttons in a 390px sheet this wrapped to three lines, so below
+  // 640px the footer stacks and each control takes the full width.
+  args: {
+    footerStart: (
+      <p className="text-caption">In effect for new requests within 30s.</p>
+    ),
+  },
   render: (args) => (
     <FormDialog {...args}>
       <KeyFields />

--- a/web/src/design-system/feedback/FormDialog.stories.tsx
+++ b/web/src/design-system/feedback/FormDialog.stories.tsx
@@ -277,6 +277,27 @@ function ManyFields() {
  * the preview frame, so a wrapper `<div>` would not produce it. The dialog
  * portals to the frame's `<body>` and never sees a wrapper at all.
  */
+/**
+ * The same sheet, landscape. `isRotated` puts the phone at 844x390, which is
+ * wider than 640 and shorter than it: the sheet keys on either dimension, so a
+ * viewport that cannot afford the 120px gap vertically gets the sheet rather
+ * than a third layout. Without that this was a 150px dialog with 137px of
+ * header and footer in it.
+ */
+export const PhoneSheetLandscape: Story = {
+  globals: { viewport: { value: "mobile2", isRotated: true } },
+  args: {
+    footerStart: (
+      <p className="text-caption">In effect for new requests within 30s.</p>
+    ),
+  },
+  render: (args) => (
+    <FormDialog {...args}>
+      <KeyFields />
+    </FormDialog>
+  ),
+}
+
 export const PhoneSheet: Story = {
   globals: { viewport: { value: "mobile2", isRotated: false } },
   // With a `footerStart` caption, which is the case that does not fit a row:

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -219,6 +219,29 @@ describe("FormDialog", () => {
     })
   })
 
+  it("keeps Cancel before the submit in the DOM, which is the stacking order", async () => {
+    // The footer stacks below 640px and nothing reorders it, so DOM order *is*
+    // the visual order and the focus order: Cancel above, the primary lowest,
+    // which is the control nearest the thumb on a sheet. An earlier version
+    // moved Cancel with CSS `order`, which left the visual and focus orders
+    // disagreeing.
+    //
+    // DOM order is the half jsdom can see. The stacking itself is a media query
+    // and is measured on a build, not here.
+    render(
+      <FormDialog {...base} isOpen>
+        {withField}
+      </FormDialog>,
+    )
+
+    const footer = screen.getByRole("dialog").querySelector("footer")
+    if (!footer) throw new Error("the footer is gone")
+    const buttons = [...footer.querySelectorAll("button")].map(
+      (b) => b.textContent,
+    )
+    expect(buttons).toEqual(["Cancel", "Create key"])
+  })
+
   describe("isSubmitDisabled", () => {
     it("blocks the button, plain Enter, and Cmd/Ctrl+Enter alike", async () => {
       // `requestSubmit` does not consult the submit button's `disabled` state,

--- a/web/src/design-system/feedback/FormDialog.test.tsx
+++ b/web/src/design-system/feedback/FormDialog.test.tsx
@@ -219,6 +219,87 @@ describe("FormDialog", () => {
     })
   })
 
+  describe("isSubmitDisabled", () => {
+    it("blocks the button, plain Enter, and Cmd/Ctrl+Enter alike", async () => {
+      // `requestSubmit` does not consult the submit button's `disabled` state,
+      // it only runs constraint validation, so the shortcut reached `onSubmit`
+      // while the button and plain Enter were both refused. Every reason the
+      // button is not pressable has to hold for the keyboard too.
+      const onSubmit = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen isSubmitDisabled onSubmit={onSubmit}>
+          {withTextArea}
+        </FormDialog>,
+      )
+
+      await user.click(screen.getByRole("button", { name: "Create key" }))
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      await user.click(screen.getByLabelText("Instructions"))
+      await user.keyboard("{Meta>}{Enter}{/Meta}")
+      await user.keyboard("{Control>}{Enter}{/Control}")
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it("submits once it is not disabled, so the gate is the prop and not the gesture", async () => {
+      const onSubmit = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <FormDialog {...base} isOpen onSubmit={onSubmit}>
+          {withTextArea}
+        </FormDialog>,
+      )
+
+      await user.click(screen.getByLabelText("Instructions"))
+      await user.keyboard("{Meta>}{Enter}{/Meta}")
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+
+    it("renders the submit disabled rather than letting a press fail", () => {
+      render(
+        <FormDialog {...base} isOpen isSubmitDisabled>
+          {withField}
+        </FormDialog>,
+      )
+
+      expect(screen.getByRole("button", { name: "Create key" })).toBeDisabled()
+    })
+  })
+
+  describe("isDismissable", () => {
+    it("drops the close control and Cancel together when it is off", () => {
+      // One way out, and the submit is it: the content behind this cannot be
+      // recovered once the frame closes, so a dismiss would lose it.
+      render(
+        <FormDialog {...base} isOpen isDismissable={false}>
+          {withField}
+        </FormDialog>,
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "Close" }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: "Cancel" }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Create key" }),
+      ).toBeInTheDocument()
+    })
+
+    it("offers both when it is on, which is the default", () => {
+      render(
+        <FormDialog {...base} isOpen>
+          {withField}
+        </FormDialog>,
+      )
+
+      expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+    })
+  })
+
   describe("the dirty guard", () => {
     it("holds the dialog open and swaps the footer instead of closing", async () => {
       const onOpenChange = vi.fn()

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -30,6 +30,25 @@ export interface FormDialogProps {
    * so Escape and a click outside ask before discarding.
    */
   isDirty?: boolean
+  /**
+   * Whether Escape, a backdrop click and the close control can dismiss it.
+   *
+   * On by default, and `isDirty` is the answer for a form holding unsaved
+   * input: the guard asks rather than refusing. The one case for turning it off
+   * is content that cannot be recovered once the frame closes, which is a
+   * different thing from unsaved: a key's plaintext secret is shown once and is
+   * gone forever, so the acknowledgement is the only way out.
+   */
+  isDismissable?: boolean
+  /**
+   * Whether the form is not yet in a state that can be submitted.
+   *
+   * The submit is shown disabled rather than allowed to fail: a press that does
+   * nothing teaches nothing, and the reason belongs beside the control that is
+   * missing. Reserve it for what the browser cannot check itself; `required` on
+   * a field is better than a boolean here, because it also says which field.
+   */
+  isSubmitDisabled?: boolean
   /** The footer's left slot: a "Create another" `Checkbox`, or a caption. */
   footerStart?: ReactNode
   /** A `TabRow` under the header. `lg` only, where a form has two shapes. */
@@ -64,6 +83,8 @@ export function FormDialog({
   isPending,
   error,
   isDirty = false,
+  isDismissable = true,
+  isSubmitDisabled = false,
   footerStart,
   tabs,
   children,
@@ -93,7 +114,7 @@ export function FormDialog({
   }, [error])
 
   const requestClose = () => {
-    if (isPending) return
+    if (isPending || !isDismissable) return
     if (isDirty) {
       setIsGuarding(true)
       return
@@ -114,12 +135,19 @@ export function FormDialog({
     >
       {/* HeroUI renders a press responder for the trigger slot and warns when
           nothing fills it. These dialogs are driven from state, so the slot is
-          hidden rather than absent; `WorkspaceSwitcher` does the same. */}
-      <Modal.Trigger className="hidden">{submitLabel}</Modal.Trigger>
+          filled and hidden rather than absent; `WorkspaceSwitcher` does the
+          same. `aria-hidden` as well as the class, because the label rule puts
+          the same string on the real trigger and on the submit, and a third
+          copy of it in the accessibility tree makes all three ambiguous to a
+          screen reader and to a test. `display: none` would do it in a browser;
+          this also does it in jsdom, which loads no stylesheet. */}
+      <Modal.Trigger aria-hidden className="hidden">
+        {submitLabel}
+      </Modal.Trigger>
       {/* No `bg-backdrop/50`: globals.css dims `.modal__backdrop--opaque` in
           an unlayered rule that outranks the utility, so the class changes
           nothing (#1033). */}
-      <Modal.Backdrop isDismissable={!isPending}>
+      <Modal.Backdrop isDismissable={isDismissable && !isPending}>
         <Modal.Container
           placement="top"
           // 120px from the top on a desktop viewport: a dialog optically
@@ -154,16 +182,21 @@ export function FormDialog({
                   Lifted 4px to center on the title's own line rather than on
                   the header block, with the 44px target bled outward so
                   raising it moves no layout. */}
-              <Button
-                aria-label="Close"
-                isIconOnly
-                size="sm"
-                className="relative -top-1 shrink-0 before:absolute before:-inset-1.5 before:content-['']"
-                isDisabled={isPending}
-                onPress={requestClose}
-              >
-                <FiX aria-hidden className="text-muted size-3.5" />
-              </Button>
+              {/* Absent rather than dead when the dialog cannot be dismissed:
+                  a close control that refuses is worse than none, and the
+                  footer's one action is the way out in that case. */}
+              {isDismissable ? (
+                <Button
+                  aria-label="Close"
+                  isIconOnly
+                  size="sm"
+                  className="relative -top-1 shrink-0 before:absolute before:-inset-1.5 before:content-['']"
+                  isDisabled={isPending}
+                  onPress={requestClose}
+                >
+                  <FiX aria-hidden className="text-muted size-3.5" />
+                </Button>
+              ) : null}
             </header>
             {tabs ? (
               <div className="border-border shrink-0 border-b px-6 pt-4 pb-3">
@@ -237,9 +270,14 @@ export function FormDialog({
                   <>
                     <div className="min-w-0">{footerStart}</div>
                     <div className="flex shrink-0 items-center gap-2">
-                      <Button isDisabled={isPending} onPress={requestClose}>
-                        Cancel
-                      </Button>
+                      {/* Cancel IS the dismiss, so it goes with it: a dialog
+                          that cannot be dismissed has one way out and the
+                          primary is it. */}
+                      {isDismissable ? (
+                        <Button isDisabled={isPending} onPress={requestClose}>
+                          Cancel
+                        </Button>
+                      ) : null}
                       {/* Not `isPending`, and not `isDisabled`. Both land on
                           the product's one disabled treatment, which is 0.4
                           opacity and has to read as *denied*; a submit in
@@ -262,6 +300,7 @@ export function FormDialog({
                       <Button
                         type="submit"
                         variant="primary"
+                        isDisabled={isSubmitDisabled}
                         className={`relative ${isPending ? "pointer-events-none" : ""}`}
                       >
                         <span className={isPending ? "opacity-0" : undefined}>

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -280,11 +280,7 @@ export function FormDialog({
                           that cannot be dismissed has one way out and the
                           primary is it. */}
                       {isDismissable ? (
-                        <Button
-                          className="otari-form-dialog__cancel"
-                          isDisabled={isPending}
-                          onPress={requestClose}
-                        >
+                        <Button isDisabled={isPending} onPress={requestClose}>
                           Cancel
                         </Button>
                       ) : null}

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -252,11 +252,11 @@ export function FormDialog({
                 <ErrorBanner error={error} />
                 {children}
               </div>
-              <footer className="border-border flex shrink-0 items-center justify-between gap-2 border-t px-6 py-3">
+              <footer className="otari-form-dialog__footer border-border flex shrink-0 items-center justify-between gap-2 border-t px-6 py-3">
                 {isGuarding ? (
                   <>
                     <p className="text-caption">Unsaved changes</p>
-                    <div className="flex items-center gap-2">
+                    <div className="otari-form-dialog__actions flex items-center gap-2">
                       <Button onPress={() => setIsGuarding(false)}>
                         Keep editing
                       </Button>
@@ -274,12 +274,16 @@ export function FormDialog({
                 ) : (
                   <>
                     <div className="min-w-0">{footerStart}</div>
-                    <div className="flex shrink-0 items-center gap-2">
+                    <div className="otari-form-dialog__actions flex shrink-0 items-center gap-2">
                       {/* Cancel IS the dismiss, so it goes with it: a dialog
                           that cannot be dismissed has one way out and the
                           primary is it. */}
                       {isDismissable ? (
-                        <Button isDisabled={isPending} onPress={requestClose}>
+                        <Button
+                          className="otari-form-dialog__cancel"
+                          isDisabled={isPending}
+                          onPress={requestClose}
+                        >
                           Cancel
                         </Button>
                       ) : null}

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -210,11 +210,12 @@ export function FormDialog({
               // fields where Enter is a newline.
               onSubmit={(event) => {
                 event.preventDefault()
-                // `isGuarding` as well as `isPending`: the guard has taken the
-                // footer, so the submit control is not on screen, and a
-                // keyboard submit under it runs the mutation from a footer
-                // offering only Keep editing and Discard.
-                if (!isPending && !isGuarding) onSubmit()
+                // Every reason the button is not pressable has to hold for the
+                // keyboard too. The guard has taken the footer, so the submit
+                // control is not even on screen; `isSubmitDisabled` renders it
+                // disabled, which stops a click and a plain Enter but is not
+                // consulted by `requestSubmit`.
+                if (!isPending && !isGuarding && !isSubmitDisabled) onSubmit()
               }}
               onKeyDown={(event) => {
                 if (event.key !== "Enter") return
@@ -224,11 +225,11 @@ export function FormDialog({
                 // constraint validation first, so the shortcut and the button
                 // are one path rather than two, and a required field left empty
                 // cannot reach the mutation through the keyboard alone.
-                // Guarded here too, and not only in `onSubmit` where every
-                // path funnels: `requestSubmit` runs the form's validation
-                // first, which would focus an invalid field to answer a
-                // shortcut the guard is refusing.
-                if (!isPending && !isGuarding)
+                //
+                // Gated here as well as in `onSubmit`, where every path funnels,
+                // because `requestSubmit` validates before it submits and would
+                // focus an invalid field to answer a gesture that is refused.
+                if (!isPending && !isGuarding && !isSubmitDisabled)
                   event.currentTarget.requestSubmit()
               }}
               aria-busy={isPending}

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -1,5 +1,5 @@
 import { Modal, Spinner } from "@heroui/react"
-import { type ReactNode, useEffect, useRef, useState } from "react"
+import { type ReactNode, useEffect, useId, useRef, useState } from "react"
 import { FiX } from "react-icons/fi"
 
 import { Button } from "../actions/Button"
@@ -91,6 +91,7 @@ export function FormDialog({
 }: FormDialogProps) {
   // The dirty guard lives in the footer rather than in a second dialog, because
   // a dialog never opens a dialog.
+  const descriptionId = useId()
   const [isGuarding, setIsGuarding] = useState(false)
   // Whether the body has been scrolled away from its top, which is what puts a
   // rule between the pinned header and the content passing under it. The footer
@@ -162,6 +163,12 @@ export function FormDialog({
               opaque control-border hairline, unlayered, and argues that tier by
               name, so a `border-border` here would lose to it. */}
           <Modal.Dialog
+            // The description is the dialog's accessible description rather
+            // than a paragraph that happens to sit under the title: what a
+            // screen reader announces on open is the dialog, and the object
+            // this form is about is in here. Verified in the DOM, because
+            // react-aria filters unrecognized ARIA off some components.
+            aria-describedby={description ? descriptionId : undefined}
             className={`otari-form-dialog otari-form-dialog--${size} flex flex-col p-0`}
           >
             <header
@@ -172,7 +179,9 @@ export function FormDialog({
               <div className="flex flex-col gap-1">
                 <Modal.Heading className="text-heading">{title}</Modal.Heading>
                 {description ? (
-                  <p className="text-body text-muted">{description}</p>
+                  <p id={descriptionId} className="text-body text-muted">
+                    {description}
+                  </p>
                 ) : null}
               </div>
               {/* `isIconOnly` at `sm` is what makes this a 32px square with no

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -232,7 +232,12 @@ export function FormDialog({
                   event.currentTarget.requestSubmit()
               }}
               aria-busy={isPending}
-              className="flex min-h-0 flex-col"
+              // `flex-1` as well as `min-h-0`: on a phone the dialog is the height of
+              // the viewport rather than of its content, so without this the form
+              // sizes to its fields and the footer sits halfway up an empty sheet.
+              // On a desktop the dialog has a max-height and no height, so there is
+              // no free space to claim and this changes nothing.
+              className="flex min-h-0 flex-1 flex-col"
             >
               {/* `min-h-0` above and here is what lets this scroll rather than
                   push the footer off the viewport: a flex child's default
@@ -242,7 +247,7 @@ export function FormDialog({
                 onScroll={(event) =>
                   setIsScrolled(event.currentTarget.scrollTop > 0)
                 }
-                className="flex min-h-0 flex-col gap-4 overflow-y-auto px-6 pt-1 pb-6"
+                className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 pt-1 pb-6"
               >
                 <ErrorBanner error={error} />
                 {children}

--- a/web/src/design-system/feedback/FormDialog.tsx
+++ b/web/src/design-system/feedback/FormDialog.tsx
@@ -156,7 +156,7 @@ export function FormDialog({
           // because the gap is symmetric by design and the height cap the body
           // scrolls at is the viewport minus both. Below `sm` the container is
           // the sheet's own frame and takes no padding.
-          className="p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-[7.5rem]"
+          className="otari-form-dialog__container p-0 sm:px-4 sm:pt-[7.5rem] sm:pb-[7.5rem]"
         >
           {/* No edge spelled here: globals.css gives every floating surface one
               opaque control-border hairline, unlayered, and argues that tier by

--- a/web/src/design-system/forms/useDirtySnapshot.test.ts
+++ b/web/src/design-system/forms/useDirtySnapshot.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { useDirtySnapshot } from "./useDirtySnapshot"
+
+describe("useDirtySnapshot", () => {
+  it("reports a draft that has not moved as clean", () => {
+    const { result } = renderHook(() =>
+      useDirtySnapshot({ name: "", role: "member" }),
+    )
+
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it("sees a field the caller did not have to name", () => {
+    // The point of the snapshot: the guard cannot be one edit behind the form,
+    // because it holds the whole draft rather than a list of fields.
+    const { result, rerender } = renderHook(
+      (draft: Record<string, unknown>) => useDirtySnapshot(draft),
+      { initialProps: { name: "", role: "member" } },
+    )
+
+    rerender({ name: "", role: "viewer" })
+
+    expect(result.current.isDirty).toBe(true)
+  })
+
+  it("reports clean again once the draft returns to its seed", () => {
+    const { result, rerender } = renderHook(
+      (draft: Record<string, unknown>) => useDirtySnapshot(draft),
+      { initialProps: { name: "" } },
+    )
+
+    rerender({ name: "typed" })
+    expect(result.current.isDirty).toBe(true)
+
+    rerender({ name: "" })
+    expect(result.current.isDirty).toBe(false)
+  })
+
+  it("keeps the seed it was mounted with, so a late default is a change", () => {
+    // Deliberate, and the reason a form whose seed resolves after mount has to
+    // seed from the resolved value instead: this hook cannot tell an operator's
+    // first keystroke from a list arriving.
+    const { result, rerender } = renderHook(
+      (draft: Record<string, unknown>) => useDirtySnapshot(draft),
+      { initialProps: { budgetId: "" } },
+    )
+
+    rerender({ budgetId: "budget-1" })
+
+    expect(result.current.isDirty).toBe(true)
+  })
+
+  it("re-seeds on reset, for a form that stays open past a save", () => {
+    const { result, rerender } = renderHook(
+      (draft: Record<string, unknown>) => useDirtySnapshot(draft),
+      { initialProps: { name: "" } },
+    )
+
+    rerender({ name: "saved" })
+    act(() => result.current.reset())
+    rerender({ name: "saved" })
+
+    expect(result.current.isDirty).toBe(false)
+  })
+})

--- a/web/src/design-system/forms/useDirtySnapshot.ts
+++ b/web/src/design-system/forms/useDirtySnapshot.ts
@@ -1,0 +1,31 @@
+import { useRef } from "react"
+
+/**
+ * Whether a form's draft still matches what it was seeded with.
+ *
+ * One snapshot of the whole draft, rather than a predicate naming each field:
+ * a hand-listed predicate is one edit behind the form the moment a field is
+ * added, and every guard in this dashboard that silently discarded a choice
+ * had drifted that way (a default member budget, a role, a provider, a pasted
+ * key). Pass everything the operator can change; the shape is the guard.
+ *
+ * The seed is the draft on mount, so the component that owns the draft has to
+ * be the one that remounts per open. See feedback.md, "A draft is fresh on
+ * every open and untouched through the exit".
+ *
+ * `reset` re-seeds to the draft as it stands, for a form that stays open past
+ * a save and should read clean again afterwards.
+ */
+export function useDirtySnapshot(draft: unknown): {
+  isDirty: boolean
+  reset: () => void
+} {
+  const snapshot = JSON.stringify(draft)
+  const seeded = useRef(snapshot)
+  return {
+    isDirty: snapshot !== seeded.current,
+    reset: () => {
+      seeded.current = snapshot
+    },
+  }
+}

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -645,6 +645,28 @@ describe("KeysPage", () => {
     expect(trigger).toBeInTheDocument()
   })
 
+  it("does not walk /v1/users until the create dialog is opened", async () => {
+    // The dialog stays mounted while closed so it can animate out, which left
+    // its owner picker's roster fetching on every visit to the page.
+    // `fetchAllUsers` walks up to 100 pages of 1000, so this is the page's
+    // cost, not the dialog's. The same shape is waiting on every other page
+    // this series migrates.
+    const fetchMock = mockApi({ keys: [] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    const usersCalls = () =>
+      fetchMock.mock.calls.filter(([u]) => String(u).includes("/v1/users"))
+    expect(usersCalls()).toHaveLength(0)
+
+    await user.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    await screen.findByRole("dialog")
+    await waitFor(() => expect(usersCalls().length).toBeGreaterThan(0))
+  })
+
   it("hands over the secret with no way for the form to skip it", async () => {
     // The one chance to read the key is not something the form can waive. The
     // only "Create another" is on the secret step, where it is reached by

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { screen, waitFor, within } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
+import userEvent, { type UserEvent } from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -181,6 +181,18 @@ function renderPage(
   )
 }
 
+/**
+ * Press the create dialog's submit.
+ *
+ * Scoped to the dialog because "Create key" is deliberately on screen twice
+ * while it is open: the labels rule makes the page's trigger and the dialog's
+ * submit the same string, and the trigger no longer hides behind the form.
+ */
+async function submitTheCreateDialog(user: UserEvent) {
+  const dialog = await screen.findByRole("dialog")
+  await user.click(within(dialog).getByRole("button", { name: "Create key" }))
+}
+
 describe("KeysPage", () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -248,7 +260,7 @@ describe("KeysPage", () => {
     await user.type(screen.getByLabelText("Name"), "deploy-key")
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
     // The strip offers the secret and a runnable curl snippet with the key
     // injected, both concealed until asked for: a key nobody has asked to see
@@ -277,8 +289,10 @@ describe("KeysPage", () => {
       `${window.location.origin}${API_ROOT}/chat/completions`,
     )
 
+    // The acknowledgement is the dialog's footer action, so it is outside the
+    // alert that holds the key. It is unique on screen either way.
     await user.click(
-      within(reveal).getByRole("button", { name: /I.?ve saved this key/ }),
+      screen.getByRole("button", { name: /I.?ve saved this key/ }),
     )
 
     // After closing, the list shows only the prefix and the secret is gone from the DOM.
@@ -362,9 +376,9 @@ describe("KeysPage", () => {
     )
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
-    const reveal = await screen.findByRole("alert", {
+    await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
     await user.keyboard("{Escape}")
@@ -372,21 +386,23 @@ describe("KeysPage", () => {
       screen.getByRole("alert", { name: /API key created|New secret for/ }),
     ).toBeInTheDocument()
 
+    // The acknowledgement is the dialog's footer action, so it is outside the
+    // alert that holds the key. It is unique on screen either way.
     await user.click(
-      within(reveal).getByRole("button", { name: /I.?ve saved this key/ }),
+      screen.getByRole("button", { name: /I.?ve saved this key/ }),
     )
     expect(
       screen.queryByRole("alert", { name: /API key created|New secret for/ }),
     ).not.toBeInTheDocument()
   })
 
-  // The reveal is a strip, not a modal: it has no backdrop to press and does
-  // not take the page out of the accessibility tree. Both would be a dialog
-  // fighting its own conventions, as the reveal's own docstring argues.
-  // What has to survive is the part that mattered, that nothing incidental can
-  // dismiss a secret shown once, so that is what this asserts now. The page
-  // behind staying reachable is a deliberate change and not covered here.
-  it("keeps the reveal up through a press elsewhere on the page", async () => {
+  // The reveal is a modal again, and the objection its docstring used to raise
+  // is answered rather than ignored: Escape and the backdrop work everywhere in
+  // this dialog EXCEPT here, where the content cannot be recovered. So the press
+  // that must not dismiss it is the backdrop, which is the only "elsewhere" a
+  // modal has; the page behind is deliberately out of the accessibility tree now
+  // and there is nothing on it to click.
+  it("keeps the reveal up through a press on the backdrop", async () => {
     mockApi({ keys: [] })
     const user = userEvent.setup()
     renderPage(<KeysPage />)
@@ -397,18 +413,22 @@ describe("KeysPage", () => {
     )
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
-    const reveal = await screen.findByRole("alert", {
+    await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
-    await user.click(screen.getByRole("heading", { name: "API keys" }))
+    const backdrop = document.querySelector('[class*="modal__backdrop"]')
+    expect(backdrop).not.toBeNull()
+    await user.click(backdrop as Element)
     expect(
       screen.getByRole("alert", { name: /API key created|New secret for/ }),
     ).toBeInTheDocument()
 
+    // The acknowledgement is the dialog's footer action, so it is outside the
+    // alert that holds the key. It is unique on screen either way.
     await user.click(
-      within(reveal).getByRole("button", { name: /I.?ve saved this key/ }),
+      screen.getByRole("button", { name: /I.?ve saved this key/ }),
     )
     await waitFor(() =>
       expect(
@@ -430,13 +450,15 @@ describe("KeysPage", () => {
     )
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
-    const reveal = await screen.findByRole("alert", {
+    await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
+    // The acknowledgement is the dialog's footer action, so it is outside the
+    // alert that holds the key. It is unique on screen either way.
     await user.click(
-      within(reveal).getByRole("button", { name: /I.?ve saved this key/ }),
+      screen.getByRole("button", { name: /I.?ve saved this key/ }),
     )
 
     // The form that opened the reveal is gone by now, so nothing else has a
@@ -517,7 +539,7 @@ describe("KeysPage", () => {
     )
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
@@ -595,6 +617,89 @@ describe("KeysPage", () => {
     expect(within(reveal).getByDisplayValue(REGEN_SECRET)).toBeInTheDocument()
   })
 
+  it("keeps the page's create action visible while the dialog is open", async () => {
+    // It used to hide itself while the inline form was on the page. The form is
+    // over the page now, so hiding the control that opened it would take the
+    // heading's action away mid-task for no reason, and it is also where focus
+    // returns.
+    mockApi({ keys: [] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    const trigger = screen.getByRole("button", { name: "Create key" })
+    await user.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+
+    await screen.findByRole("dialog")
+    expect(trigger).toBeInTheDocument()
+  })
+
+  it("clears the form instead of showing the secret when Create another is checked", async () => {
+    // The row lands in the table either way. What is given up is the one chance
+    // to read this key, which is why the checkbox is a deliberate press.
+    const fetchMock = mockApi({ keys: [] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    await user.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    const dialog = await screen.findByRole("dialog")
+    await user.type(screen.getByLabelText("Name"), "first-key")
+    await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
+    await user.keyboard("{Escape}")
+    await user.click(within(dialog).getByLabelText("Create another"))
+    await submitTheCreateDialog(user)
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.filter(
+          ([u, init]) =>
+            String(u).endsWith("/v1/keys") && (init?.method ?? "") === "POST",
+        ),
+      ).toHaveLength(1),
+    )
+    // No secret step, and the name is cleared for the next one.
+    expect(
+      screen.queryByRole("alert", { name: /API key created/ }),
+    ).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByLabelText("Name")).toHaveValue(""))
+    expect(document.body.textContent).not.toContain(NEW_SECRET)
+  })
+
+  it("shows a regenerated secret in the same dialog a created one arrives in", async () => {
+    // Create and regenerate hand over the same thing, so they hand it over the
+    // same way. Before this they were a dialog and a full-width strip on one
+    // page.
+    mockApi({
+      keys: [apiKey({ id: "key-1", key_name: "ci-bot", is_active: true })],
+    })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    const row = (await screen.findByText("ci-bot")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Regenerate" }))
+    const armed = screen
+      .getByText(/stops working immediately/)
+      .closest("tr") as HTMLTableRowElement
+    await user.click(within(armed).getByRole("button", { name: "Regenerate" }))
+
+    const dialog = await screen.findByRole("dialog")
+    expect(
+      within(dialog).getByRole("alert", { name: /New secret for ci-bot/ }),
+    ).toBeInTheDocument()
+    // No form step and nothing to create again: the key already exists.
+    expect(
+      within(dialog).queryByLabelText("Create another"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(dialog).getByRole("button", { name: /I.?ve saved this key/ }),
+    ).toBeInTheDocument()
+  })
+
   it("permanently deletes a disabled key after confirm", async () => {
     const fetchMock = mockApi({
       keys: [apiKey({ id: "key-1", key_name: "legacy", is_active: false })],
@@ -645,7 +750,7 @@ describe("KeysPage", () => {
     )
     // Close the combobox popover, which otherwise aria-hides the submit button.
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
     const post = fetchMock.mock.calls.find(
       ([u, init]) =>
@@ -719,7 +824,7 @@ describe("KeysPage", () => {
     )
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Create key" }))
+    await submitTheCreateDialog(user)
 
     const post = fetchMock.mock.calls.find(
       ([u, init]) =>
@@ -788,8 +893,10 @@ describe("KeysPage", () => {
     await usr.click(
       await screen.findByRole("option", { name: "alice (Alice)" }),
     )
-    await usr.keyboard("{Escape}")
-    await usr.click(screen.getByRole("button", { name: "Create key" }))
+    // No Escape here any more. Picking an option closes the combo box's own
+    // popover, so the keystroke would reach the dialog instead and arm its
+    // unsaved-changes guard, which swaps the submit out of the footer.
+    await submitTheCreateDialog(usr)
 
     const post = fetchMock.mock.calls.find(
       ([u, init]) =>

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -657,7 +657,9 @@ describe("KeysPage", () => {
 
     await screen.findByText("No API keys yet")
     const usersCalls = () =>
-      fetchMock.mock.calls.filter(([u]) => String(u).includes("/v1/users"))
+      fetchMock.mock.calls.filter(([u]) =>
+        String(u).includes(`${API_ROOT}/users`),
+      )
     expect(usersCalls()).toHaveLength(0)
 
     await user.click(
@@ -919,9 +921,13 @@ describe("KeysPage", () => {
     await usr.click(
       await screen.findByRole("option", { name: "alice (Alice)" }),
     )
-    // No Escape here any more. Picking an option closes the combo box's own
-    // popover, so the keystroke would reach the dialog instead and arm its
-    // unsaved-changes guard, which swaps the submit out of the footer.
+    // Focus goes to another field rather than Escape putting the popover away.
+    // The box is `menuTrigger="focus"`, so selecting an option hands focus back
+    // to the input and the popover reopens, and react-aria marks the rest of the
+    // page `aria-hidden` while it is open, which is what puts the submit out of
+    // reach. Escape would close it and then reach the dialog, arming the
+    // unsaved-changes guard and taking the submit out of the footer instead.
+    await usr.click(screen.getByLabelText("Name"))
     await submitTheCreateDialog(usr)
 
     const post = fetchMock.mock.calls.find(

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -645,6 +645,57 @@ describe("KeysPage", () => {
     expect(trigger).toBeInTheDocument()
   })
 
+  it("clears the owner and the budget exemption when it reopens", async () => {
+    // `resetForm` left both behind, so the next key silently inherited the
+    // previous owner and its exemption. The owner surviving also made a
+    // reopened dialog dirty on arrival, which armed the guard on a form nobody
+    // had touched.
+    mockApi({ keys: [], users: [user({ user_id: "alice", alias: "Alice" })] })
+    const usr = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    await usr.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    await usr.type(screen.getByPlaceholderText(/Pick a user/), "alice")
+    // Focus off the picker before reaching for anything else: its popover is
+    // open and react-aria aria-hides the rest of the dialog while it is.
+    await usr.click(screen.getByLabelText("Name"))
+    await usr.click(screen.getByRole("button", { name: "Advanced" }))
+    await usr.click(screen.getByLabelText("Exempt from budget"))
+
+    // Out through the guard, which is the only way out of a dirty form.
+    await usr.keyboard("{Escape}")
+    await usr.click(screen.getByRole("button", { name: "Discard" }))
+
+    await usr.click(screen.getByRole("button", { name: "Create key" }))
+    expect(screen.getByPlaceholderText(/Pick a user/)).toHaveValue("")
+    await usr.click(screen.getByRole("button", { name: "Advanced" }))
+    expect(screen.getByLabelText("Exempt from budget")).not.toBeChecked()
+    // And nothing is unsaved on arrival, so Escape closes rather than guarding.
+    await usr.keyboard("{Escape}")
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("guards a field the old dirty check did not know about", async () => {
+    // The check read three of the seven values the form owns, so a backdrop
+    // press or Escape discarded the rest without asking.
+    mockApi({ keys: [] })
+    const usr = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    await usr.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    await usr.click(screen.getByRole("button", { name: "Advanced" }))
+    await usr.click(screen.getByLabelText("Exempt from budget"))
+
+    await usr.keyboard("{Escape}")
+    expect(screen.getByRole("dialog")).toHaveTextContent("Unsaved changes")
+  })
+
   it("does not walk /v1/users until the create dialog is opened", async () => {
     // The dialog stays mounted while closed so it can animate out, which left
     // its owner picker's roster fetching on every visit to the page.

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -262,32 +262,39 @@ describe("KeysPage", () => {
     await user.keyboard("{Escape}")
     await submitTheCreateDialog(user)
 
-    // The strip offers the secret and a runnable curl snippet with the key
-    // injected, both concealed until asked for: a key nobody has asked to see
-    // is not on screen, and neither is the snippet that carries it (otari-ai#2111).
+    // Open revealed: this screen exists to hand the key over, and there is no
+    // second chance to read it.
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
+    expect(within(reveal).getByLabelText("Secret key")).toHaveValue(NEW_SECRET)
+    const curl = within(reveal).getByLabelText("curl") as HTMLTextAreaElement
+    const python = within(reveal).getByLabelText(
+      "Python (OpenAI SDK)",
+    ) as HTMLTextAreaElement
+    expect(curl.value).toContain(`Otari-Key: ${NEW_SECRET}`)
+    expect(curl.value).toContain(
+      `${window.location.origin}${API_ROOT}/chat/completions`,
+    )
+    expect(python.value).toContain(NEW_SECRET)
+
+    // One credential, one reveal: concealing the key conceals the requests that
+    // carry it, rather than leaving it in plain sight twice over.
+    await user.click(
+      within(reveal).getByRole("button", { name: "Hide Secret key" }),
+    )
     expect(within(reveal).getByLabelText("Secret key")).not.toHaveValue(
       NEW_SECRET,
     )
-    const concealedCurl = within(reveal).getByLabelText(
-      "curl",
-    ) as HTMLTextAreaElement
-    expect(concealedCurl.value).not.toContain(NEW_SECRET)
+    expect(curl.value).not.toContain(NEW_SECRET)
+    expect(python.value).not.toContain(NEW_SECRET)
 
-    await user.click(
-      within(reveal).getByRole("button", { name: "Show Secret key" }),
-    )
-    expect(within(reveal).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
+    // And the affordance is on each field, not only on the key: the snippet's
+    // own toggle brings all three back (otari-ai#2111).
     await user.click(within(reveal).getByRole("button", { name: "Show curl" }))
-    const curl = within(reveal).getByDisplayValue(
-      new RegExp(`Otari-Key: ${NEW_SECRET}`),
-    )
-    expect(curl).toBeInTheDocument()
-    expect((curl as HTMLTextAreaElement).value).toContain(
-      `${window.location.origin}${API_ROOT}/chat/completions`,
-    )
+    expect(within(reveal).getByLabelText("Secret key")).toHaveValue(NEW_SECRET)
+    expect(curl.value).toContain(NEW_SECRET)
+    expect(python.value).toContain(NEW_SECRET)
 
     // The acknowledgement is the dialog's footer action, so it is outside the
     // alert that holds the key. It is unique on screen either way.
@@ -343,8 +350,6 @@ describe("KeysPage", () => {
       `https://gateway.otari.ai${API_ROOT}/chat/completions`,
     )
     expect(curl.value).not.toContain(window.location.origin)
-    // Concealed, so the address it names is readable while the key is not.
-    expect(curl.value).not.toContain(NEW_SECRET)
   })
 
   it("shows no snippet when a hosted deployment published no data plane", async () => {
@@ -544,11 +549,16 @@ describe("KeysPage", () => {
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
+    // Concealed first, because copying without reading is what has to keep
+    // working once the operator puts the key away (otari-ai#2111). The step
+    // opens revealed, so the toggle is how that state is reached now.
+    await user.click(
+      within(reveal).getByRole("button", { name: "Hide Secret key" }),
+    )
     const copyButtons = within(reveal).getAllByRole("button", { name: "Copy" })
     await user.click(copyButtons[0])
 
-    // Copied without being read, which is the point of concealing it: the key
-    // reached the clipboard and never the screen (otari-ai#2111).
+    // The key reached the clipboard and never the screen.
     expect(writeText).toHaveBeenCalledWith(NEW_SECRET)
     expect(
       within(reveal).queryByDisplayValue(NEW_SECRET),
@@ -611,9 +621,8 @@ describe("KeysPage", () => {
     const reveal = await screen.findByRole("alert", {
       name: /API key created|New secret for/,
     })
-    await user.click(
-      within(reveal).getByRole("button", { name: "Show Secret key" }),
-    )
+    // Revealed on arrival, the same as a created key: regenerate hands over the
+    // same thing and hands it over the same way.
     expect(within(reveal).getByDisplayValue(REGEN_SECRET)).toBeInTheDocument()
   })
 
@@ -1249,9 +1258,6 @@ describe("KeysPage", () => {
       const reveal = await screen.findByRole("alert", {
         name: /API key created|New secret for/,
       })
-      await usr.click(
-        within(reveal).getByRole("button", { name: "Show Secret key" }),
-      )
       expect(within(reveal).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
 
       const post = fetchMock.mock.calls.find(

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -636,10 +636,11 @@ describe("KeysPage", () => {
     expect(trigger).toBeInTheDocument()
   })
 
-  it("clears the form instead of showing the secret when Create another is checked", async () => {
-    // The row lands in the table either way. What is given up is the one chance
-    // to read this key, which is why the checkbox is a deliberate press.
-    const fetchMock = mockApi({ keys: [] })
+  it("hands over the secret with no way for the form to skip it", async () => {
+    // The one chance to read the key is not something the form can waive. The
+    // only "Create another" is on the secret step, where it is reached by
+    // having been shown the key first.
+    mockApi({ keys: [] })
     const user = userEvent.setup()
     renderPage(<KeysPage />)
 
@@ -648,26 +649,20 @@ describe("KeysPage", () => {
       screen.getByRole("button", { name: "Create your first key" }),
     )
     const dialog = await screen.findByRole("dialog")
+    expect(
+      within(dialog).queryByLabelText("Create another"),
+    ).not.toBeInTheDocument()
     await user.type(screen.getByLabelText("Name"), "first-key")
     await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
     await user.keyboard("{Escape}")
-    await user.click(within(dialog).getByLabelText("Create another"))
     await submitTheCreateDialog(user)
 
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.filter(
-          ([u, init]) =>
-            String(u).endsWith("/v1/keys") && (init?.method ?? "") === "POST",
-        ),
-      ).toHaveLength(1),
-    )
-    // No secret step, and the name is cleared for the next one.
     expect(
-      screen.queryByRole("alert", { name: /API key created/ }),
-    ).not.toBeInTheDocument()
-    await waitFor(() => expect(screen.getByLabelText("Name")).toHaveValue(""))
-    expect(document.body.textContent).not.toContain(NEW_SECRET)
+      await screen.findByRole("alert", { name: /API key created/ }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /I.?ve saved this key/ }),
+    ).toBeInTheDocument()
   })
 
   it("shows a regenerated secret in the same dialog a created one arrives in", async () => {
@@ -693,7 +688,7 @@ describe("KeysPage", () => {
     ).toBeInTheDocument()
     // No form step and nothing to create again: the key already exists.
     expect(
-      within(dialog).queryByLabelText("Create another"),
+      within(dialog).queryByRole("button", { name: "Create another" }),
     ).not.toBeInTheDocument()
     expect(
       within(dialog).getByRole("button", { name: /I.?ve saved this key/ }),

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -646,10 +646,12 @@ describe("KeysPage", () => {
   })
 
   it("clears the owner and the budget exemption when it reopens", async () => {
-    // `resetForm` left both behind, so the next key silently inherited the
-    // previous owner and its exemption. The owner surviving also made a
-    // reopened dialog dirty on arrival, which armed the guard on a form nobody
-    // had touched.
+    // The draft is fresh on every open, which is what the page's open counter
+    // buys: the dialog stays mounted through the exit so its content is intact
+    // while it animates out, and the remount on the way in is what clears it.
+    // Before that, the reset ran on close and left the owner and the exemption
+    // behind, so the next key inherited both and a reopened dialog was dirty on
+    // arrival, arming the guard on a form nobody had touched.
     mockApi({ keys: [], users: [user({ user_id: "alice", alias: "Alice" })] })
     const usr = userEvent.setup()
     renderPage(<KeysPage />)

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -480,11 +480,27 @@ function CreateKeyDialog({
   const workspaceUnresolved = workspaceLoading
   const blocked = !scopeValid || ownerMissing || workspaceUnresolved
 
+  // What the form owns, in one place, because `resetForm` and `isDirty` are the
+  // same list read two ways and they drifted: reopening kept the previous owner
+  // and budget exemption, and the guard armed for three fields out of seven.
+  // `showAdvanced` is not in either: it reveals fields rather than holding a
+  // value, and a disclosure left open is not unsaved work.
+  const isPristine =
+    keyName === "" &&
+    expiresAt === "" &&
+    userId === "" &&
+    allowedModels === null &&
+    excludeFromBudget === false &&
+    rejectUserMismatch === null &&
+    scopeValid
+
   const resetForm = () => {
     setKeyName("")
     setExpiresAt("")
     setShowAdvanced(false)
+    setUserId("")
     setAllowedModels(null)
+    setExcludeFromBudget(false)
     setRejectUserMismatch(null)
     setScopeValid(true)
     create.reset()
@@ -586,9 +602,7 @@ function CreateKeyDialog({
       isPending={create.isPending}
       isSubmitDisabled={blocked}
       error={create.error}
-      isDirty={
-        keyName.trim() !== "" || expiresAt !== "" || userId.trim() !== ""
-      }
+      isDirty={!isPristine}
     >
       <Field
         label="Name"

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -141,6 +141,12 @@ function KeySecretStep({
   // the API. Undefined when it has not said where its gateway is (otari#823).
   const baseUrl = resolveSnippetBaseUrl(useDeployment())
   const secret = result.key
+  // One reveal for the key and both snippets, because the snippets carry the
+  // same secret: revealing the key while a snippet still printed bullets, or
+  // the reverse, would be one credential in two states on one screen. Open,
+  // because this screen exists to hand the key over and there is no second
+  // chance to read it; the toggle conceals all three.
+  const [isSecretRevealed, setIsSecretRevealed] = useState(true)
 
   // The same two calls the setup guide hands out with its own key; the builders
   // are shared so an operator cannot be shown two dialects of one request.
@@ -150,10 +156,10 @@ function KeySecretStep({
     ? {
         curl: buildCurlSnippet({ baseUrl, apiKey: secret }),
         python: buildPythonSnippet({ baseUrl, apiKey: secret }),
-        // The same two commands around the stand-in, which is what the fields
-        // show until the operator asks for the key. Without them the snippets
-        // would print the plaintext key under a concealed key field and hand it
-        // to anyone reading the screen, which is what concealing it prevents.
+        // The same two commands around the stand-in, which is what the
+        // snippets show whenever the key is concealed. Without them concealing
+        // the key would leave it in plain sight twice over, in the requests
+        // that explain it.
         concealedCurl: buildCurlSnippet({ baseUrl, apiKey: CONCEALED_SECRET }),
         concealedPython: buildPythonSnippet({
           baseUrl,
@@ -180,6 +186,8 @@ function KeySecretStep({
           label="Secret key"
           value={secret}
           concealed={CONCEALED_SECRET}
+          isRevealed={isSecretRevealed}
+          onRevealChange={setIsSecretRevealed}
           fieldRef={secretRef}
         />
         <p className="text-caption">{secretCaption(result, memberLabels)}</p>
@@ -202,12 +210,16 @@ function KeySecretStep({
               label="curl"
               value={snippets.curl}
               concealed={snippets.concealedCurl}
+              isRevealed={isSecretRevealed}
+              onRevealChange={setIsSecretRevealed}
               multiline
             />
             <CopyField
               label="Python (OpenAI SDK)"
               value={snippets.python}
               concealed={snippets.concealedPython}
+              isRevealed={isSecretRevealed}
+              onRevealChange={setIsSecretRevealed}
               multiline
             />
           </>

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -436,7 +436,6 @@ function CreateKeyDialog({
   const [scopeValid, setScopeValid] = useState(true)
   // The secret, once there is one. Its presence is the step: null is the form.
   const [created, setCreated] = useState<CreateKeyResponse | null>(null)
-  const [createAnother, setCreateAnother] = useState(false)
   const secretRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
 
   useEffect(() => {
@@ -490,7 +489,6 @@ function CreateKeyDialog({
     // The frame keeps its content while it animates out, so the reset waits for
     // the next open rather than blanking the dialog as it goes.
     setCreated(null)
-    setCreateAnother(false)
     resetForm()
   }
 
@@ -517,13 +515,6 @@ function CreateKeyDialog({
       : shared
     create.mutate(body, {
       onSuccess: (result) => {
-        // "Create another" trades the secret step for a cleared form. The row is
-        // already in the table either way; what is given up is the one chance to
-        // read this key, which is why the checkbox says so.
-        if (createAnother) {
-          resetForm()
-          return
-        }
         setCreated(result)
       },
     })
@@ -540,7 +531,6 @@ function CreateKeyDialog({
         // Cancel to match.
         isDismissable={false}
         title="Key created"
-        description="Copy it now. Otari stores a hash and cannot show it again."
         // The strip's own words, not "Done": this control is an
         // acknowledgement rather than a dismissal, and it is the only way out.
         submitLabel="I’ve saved this key"
@@ -582,11 +572,6 @@ function CreateKeyDialog({
       error={create.error}
       isDirty={
         keyName.trim() !== "" || expiresAt !== "" || userId.trim() !== ""
-      }
-      footerStart={
-        <Checkbox isSelected={createAnother} onChange={setCreateAnother}>
-          Create another
-        </Checkbox>
       }
     >
       <Field
@@ -701,7 +686,6 @@ function RegeneratedSecretDialog({
       size="lg"
       isDismissable={false}
       title={title}
-      description="Copy it now. Otari stores a hash and cannot show it again."
       submitLabel="I’ve saved this key"
       onSubmit={onClose}
       isPending={false}

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -433,7 +433,11 @@ function CreateKeyDialog({
 }) {
   const create = useCreateKey()
   // `/users` is operator-only; a member's form has no owner picker to feed.
-  const users = useUsers(isDeploymentWide)
+  // Gated on `isOpen` as well, because this dialog stays mounted while closed so
+  // it can animate out, and `fetchAllUsers` walks up to 100 pages of 1000: left
+  // on the deployment alone it ran that walk on every visit to the page. The
+  // query's own `staleTime` makes a reopen free.
+  const users = useUsers(isDeploymentWide && isOpen)
   const { selected: workspace, isLoading: workspaceLoading } =
     useSelectedWorkspace()
   const [keyName, setKeyName] = useState("")

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -308,7 +308,7 @@ function ArmedStrip({
   )
 }
 
-// ---------- create / edit forms (inline cards, matching ProvidersPage) ----------
+// ---------- create / edit forms (FormDialog) ----------
 
 // Shows the selected owner's model access so the operator sees the ceiling this
 // key narrows within (a key can inherit it or restrict to a subset, never exceed).

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -25,6 +25,7 @@ import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { EmptyState } from "@/design-system/feedback/EmptyState"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
 import { useConfirmationFocus } from "@/design-system/hooks/useConfirmationFocus"
@@ -106,61 +107,71 @@ const label = (k: ApiKey): string => k.key_name ?? k.id
 // Stable row-key getter so DataTable's per-row cache holds across re-renders.
 const getKeyRowKey = (k: ApiKey): string => k.id
 
-// ---------- one-time reveal ----------
+// ---------- the one-time secret ----------
 
 /**
- * The highest-stakes moment: the plaintext key, shown once.
+ * The line under the key, naming what was just made.
  *
- * A strip between the page header and the table rather than a modal. The modal
- * existed to make the acknowledgement unavoidable, and it bought that with a
- * focus trap, a swallowed Esc and a backdrop that ignored clicks, all of which
- * are a dialog fighting its own conventions. A strip that stays until it is
- * acknowledged does the same job without pretending to be dismissible: there is
- * one control and it is the acknowledgement. The page scrolls to it on reveal,
- * so it is never announced somewhere the operator is not looking.
+ * Three facts, each dropped when it is not there rather than printed empty. The
+ * owner is a name or nothing: `user_id` is an identifier, and an identifier in a
+ * sentence is noise to the person who just chose the owner from a list. There is
+ * deliberately no spend figure, though the frame it sits in is where one would
+ * look for it: a key has no budget of its own, only its owner's, which is what
+ * the paragraph above the table already says and links to.
  */
-function RevealSecretStrip({
-  title,
+export function secretCaption(
+  result: CreateKeyResponse,
+  memberLabels: ReadonlyMap<string, string>,
+): string {
+  const owner =
+    result.user_id && !isVirtualUser(result.user_id)
+      ? memberLabels.get(result.user_id)
+      : undefined
+  return [
+    owner ? `Owner ${owner}` : null,
+    accessLabel(result.allowed_models).text,
+    result.expires_at
+      ? `expires ${formatDate(result.expires_at)}`
+      : "never expires",
+  ]
+    .filter((part) => part !== null)
+    .join(" · ")
+}
+
+/**
+ * The plaintext key, shown once, and everything that has to travel with it.
+ *
+ * This was a strip between the page header and the table, and its docstring
+ * argued against exactly the modal it now lives in: a focus trap, a swallowed
+ * Esc and a backdrop that ignored clicks were a dialog fighting its own
+ * conventions. The objection was to those behaviors rather than to the surface,
+ * and `FormDialog` has none of them, except where this content needs one:
+ * `isDismissable={false}` is the strip's "there is one control and it is the
+ * acknowledgement", kept because a stray backdrop click here loses the key
+ * forever.
+ *
+ * The snippets come with it. An operator creating their first key arrives from
+ * the empty state, and "make your first call" is the next thing they need, so
+ * leaving it behind on the page would have made this dialog the one place the
+ * flow got worse.
+ */
+function KeySecretStep({
+  announce,
   result,
-  returnFocusRef,
-  onClose,
+  memberLabels,
+  secretRef,
 }: {
-  title: string
+  /** The dialog's title, repeated as the alert's own name. */
+  announce: string
   result: CreateKeyResponse
-  returnFocusRef: RefObject<HTMLButtonElement | null>
-  onClose: () => void
+  memberLabels: ReadonlyMap<string, string>
+  secretRef: RefObject<HTMLInputElement | HTMLTextAreaElement | null>
 }) {
-  const secretRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
   // Where a request from this deployment belongs, which is not always the address
   // that served this page: a hosted control plane serves the dashboard and not
   // the API. Undefined when it has not said where its gateway is (otari#823).
   const baseUrl = resolveSnippetBaseUrl(useDeployment())
   const secret = result.key
-
-  useEffect(() => {
-    // The strip is above the fold only if the page is at the top, and a reveal
-    // can arrive after a scroll. Move there first, then take focus, so the
-    // keyboard lands on the key and its two controls rather than wherever the
-    // operator was. Focus without a selection: the field is concealed, and
-    // selecting the stand-in would invite a Ctrl/Cmd-C that copies bullets.
-    window.scrollTo({ top: 0 })
-    secretRef.current?.focus()
-  }, [])
-
-  useEffect(
-    () => () => {
-      // The reveal opens from a mutation result rather than a press, so nothing
-      // here is the control focus should return to. A frame later anything else
-      // that wanted it has had its turn: an empty document.body then means
-      // nothing caught the focus, and the create button takes it.
-      requestAnimationFrame(() => {
-        if (document.activeElement === document.body) {
-          returnFocusRef.current?.focus()
-        }
-      })
-    },
-    [returnFocusRef],
-  )
 
   // The same two calls the setup guide hands out with its own key; the builders
   // are shared so an operator cannot be shown two dialects of one request.
@@ -174,10 +185,7 @@ function RevealSecretStrip({
         // show until the operator asks for the key. Without them the snippets
         // would print the plaintext key under a concealed key field and hand it
         // to anyone reading the screen, which is what concealing it prevents.
-        concealedCurl: buildCurlSnippet({
-          baseUrl,
-          apiKey: CONCEALED_SECRET,
-        }),
+        concealedCurl: buildCurlSnippet({ baseUrl, apiKey: CONCEALED_SECRET }),
         concealedPython: buildPythonSnippet({
           baseUrl,
           apiKey: CONCEALED_SECRET,
@@ -186,33 +194,27 @@ function RevealSecretStrip({
     : undefined
 
   return (
-    <Section
-      // `alert` rather than `status`: this is the one message on the page that
-      // is gone forever if it is missed.
-      role="alert"
-      aria-labelledby="reveal-title"
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
-    >
-      <div className="flex items-start gap-3">
-        <Dot className="mt-2 bg-danger" />
-        <div className="min-w-0">
-          <h2 id="reveal-title" className="text-title">
-            {title}
-          </h2>
-          <p className="mt-1 text-sm text-muted">
-            Copy this key now. For security it is shown only once and cannot be
-            retrieved later. If you lose it, use Regenerate to issue a new
-            secret. Model access: {accessLabel(result.allowed_models).text}.
-          </p>
-        </div>
+    // `alert` rather than `status`: this is the one message in the product that
+    // is gone forever if it is missed, which is also why the dialog around it
+    // does not dismiss.
+    <div role="alert" aria-label={announce} className="flex flex-col gap-4">
+      <p className="text-sm text-muted">
+        Copy this key now. For security it is shown only once and cannot be
+        retrieved later. If you lose it, use Regenerate to issue a new secret.
+      </p>
+      {/* The name above the field rather than as its label: `CopyField`'s label
+          is a real one and answers "which field is this" for a screen reader,
+          which "deploy-key" does not, and these arrive in threes. */}
+      <div className="flex flex-col gap-1">
+        <p className="truncate text-emphasis">{result.key_name ?? result.id}</p>
+        <CopyField
+          label="Secret key"
+          value={secret}
+          concealed={CONCEALED_SECRET}
+          fieldRef={secretRef}
+        />
+        <p className="text-caption">{secretCaption(result, memberLabels)}</p>
       </div>
-      <CopyField
-        label="Secret key"
-        value={secret}
-        concealed={CONCEALED_SECRET}
-        fieldRef={secretRef}
-      />
       <div className="flex flex-col gap-2">
         <div>
           <div className="text-body">Make your first call</div>
@@ -242,12 +244,7 @@ function RevealSecretStrip({
           </>
         ) : null}
       </div>
-      <div className="flex justify-end border-t border-border pt-4">
-        <Button variant="primary" onPress={onClose}>
-          I&rsquo;ve saved this key
-        </Button>
-      </div>
-    </Section>
+    </div>
   )
 }
 
@@ -426,14 +423,32 @@ function UserMismatchPicker({
 // operator names an owner and may exempt the key from budget; a member's key is
 // always their own and always enforced, so neither control is rendered and the
 // body sent is the member surface's narrower shape.
-function CreateKeyForm({
+/**
+ * Create a key, and hand back the secret, in one frame.
+ *
+ * Two steps rather than two surfaces: the form submits, and when it resolves the
+ * same dialog swaps its title, its body and its submit label. That is what makes
+ * the secret arrive where the operator is already looking, and it is why the
+ * success step is not a prop on `FormDialog` but a branch here.
+ *
+ * `lg` on both steps, and that is the reason the size is set at all: the form is
+ * five fields and would sit happily at `md`, but the secret step carries two
+ * snippets, and a frame that changed width between pressing Create and reading
+ * the key would read as a second dialog.
+ */
+function CreateKeyDialog({
   isDeploymentWide,
-  onClose,
-  onCreated,
+  isOpen,
+  onOpenChange,
+  memberLabels,
+  returnFocusRef,
 }: {
   isDeploymentWide: boolean
-  onClose: () => void
-  onCreated: (result: CreateKeyResponse) => void
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  memberLabels: ReadonlyMap<string, string>
+  /** Where focus goes when nothing else claims it. See `close`. */
+  returnFocusRef: RefObject<HTMLButtonElement | null>
 }) {
   const create = useCreateKey()
   // `/users` is operator-only; a member's form has no owner picker to feed.
@@ -450,6 +465,17 @@ function CreateKeyForm({
     null,
   )
   const [scopeValid, setScopeValid] = useState(true)
+  // The secret, once there is one. Its presence is the step: null is the form.
+  const [created, setCreated] = useState<CreateKeyResponse | null>(null)
+  const [createAnother, setCreateAnother] = useState(false)
+  const secretRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    // The secret field is what the operator came for, so it takes focus when the
+    // step arrives. Focus without a selection: the field is concealed, and
+    // selecting the stand-in would invite a Ctrl/Cmd-C that copies bullets.
+    if (created) secretRef.current?.focus()
+  }, [created])
 
   const expiresInPast =
     expiresAt !== "" && new Date(expiresAt).getTime() < Date.now()
@@ -468,10 +494,39 @@ function CreateKeyForm({
   // caller belongs to that default, which is the answer this form surfaces
   // rather than pre-empting.
   const workspaceUnresolved = workspaceLoading
+  const blocked = !scopeValid || ownerMissing || workspaceUnresolved
+
+  const resetForm = () => {
+    setKeyName("")
+    setExpiresAt("")
+    setShowAdvanced(false)
+    setAllowedModels(null)
+    setRejectUserMismatch(null)
+    setScopeValid(true)
+    create.reset()
+  }
+
+  const close = () => {
+    onOpenChange(false)
+    // React Aria returns focus to whatever had it when the dialog opened, which
+    // is right for the heading's own button and wrong for the empty state's:
+    // that one is gone by now, because creating a key is what fills the table.
+    // A frame later anything with a claim has had its turn, and an empty
+    // document.body means nothing took it.
+    requestAnimationFrame(() => {
+      if (document.activeElement === document.body) {
+        returnFocusRef.current?.focus()
+      }
+    })
+    // The frame keeps its content while it animates out, so the reset waits for
+    // the next open rather than blanking the dialog as it goes.
+    setCreated(null)
+    setCreateAnother(false)
+    resetForm()
+  }
 
   const submit = () => {
-    if (create.isPending || !scopeValid || ownerMissing || workspaceUnresolved)
-      return
+    if (create.isPending || blocked) return
     const shared = {
       key_name: keyName.trim() || null,
       // The workspace the shell is on. A key belongs to exactly one, and it is
@@ -493,46 +548,103 @@ function CreateKeyForm({
       : shared
     create.mutate(body, {
       onSuccess: (result) => {
-        // Capture the secret into the reveal BEFORE closing the form, so a render
-        // hiccup can never drop the one-time key.
-        onCreated(result)
-        onClose()
+        // "Create another" trades the secret step for a cleared form. The row is
+        // already in the table either way; what is given up is the one chance to
+        // read this key, which is why the checkbox says so.
+        if (createAnother) {
+          resetForm()
+          return
+        }
+        setCreated(result)
       },
     })
   }
 
+  if (created) {
+    return (
+      <FormDialog
+        isOpen={isOpen}
+        onOpenChange={close}
+        size="lg"
+        // A dismiss here loses the key for good, so there is one way out and it
+        // is the acknowledgement. `FormDialog` drops its close control and its
+        // Cancel to match.
+        isDismissable={false}
+        title="Key created"
+        description="Copy it now. Otari stores a hash and cannot show it again."
+        // The strip's own words, not "Done": this control is an
+        // acknowledgement rather than a dismissal, and it is the only way out.
+        submitLabel="I’ve saved this key"
+        onSubmit={close}
+        isPending={false}
+        footerStart={
+          <Button
+            variant="ghost"
+            onPress={() => {
+              setCreated(null)
+              resetForm()
+            }}
+          >
+            Create another
+          </Button>
+        }
+      >
+        <KeySecretStep
+          announce="API key created"
+          result={created}
+          memberLabels={memberLabels}
+          secretRef={secretRef}
+        />
+      </FormDialog>
+    )
+  }
+
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => (open ? onOpenChange(true) : close())}
+      size="lg"
+      title="New key"
+      description="The secret is shown once, right after you create it."
+      submitLabel="Create key"
+      onSubmit={submit}
+      isPending={create.isPending}
+      isSubmitDisabled={blocked}
+      error={create.error}
+      isDirty={
+        keyName.trim() !== "" || expiresAt !== "" || userId.trim() !== ""
+      }
+      footerStart={
+        <Checkbox isSelected={createAnother} onChange={setCreateAnother}>
+          Create another
+        </Checkbox>
+      }
     >
-      <h2 className="text-title">Create API key</h2>
-      <ErrorBanner error={create.error} />
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field
-          label="Name"
-          value={keyName}
-          onChange={setKeyName}
-          placeholder="ci-bot"
-          autoFocus
-          description="A label to recognize this key later."
-        />
-        <Field
-          label="Expires (optional)"
-          value={expiresAt}
-          onChange={setExpiresAt}
-          type="datetime-local"
-          description={
-            expiresInPast ? (
-              <span className="text-danger">
-                That time is in the past; the key would be rejected immediately.
-              </span>
-            ) : (
-              "Leave blank for a key that never expires."
-            )
-          }
-        />
-      </div>
+      <Field
+        label="Name"
+        value={keyName}
+        onChange={setKeyName}
+        placeholder="ci-bot"
+        autoFocus
+        description="A label to recognize this key later."
+        reserveMessage
+      />
+      <Field
+        label="Expires (optional)"
+        value={expiresAt}
+        onChange={setExpiresAt}
+        type="datetime-local"
+        description={
+          expiresInPast ? (
+            <span className="text-danger">
+              That time is in the past; the key would be rejected immediately.
+            </span>
+          ) : (
+            "Leave blank for a key that never expires."
+          )
+        }
+        reserveMessage
+      />
       {isDeploymentWide ? (
         <UserComboBox
           value={userId}
@@ -588,26 +700,50 @@ function CreateKeyForm({
           />
         </div>
       ) : null}
-      {/* The actions sit under a rule of their own, so the row that commits the
-          form is divided from the fields rather than floating after them. */}
-      <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-        <Button
-          variant="primary"
-          isDisabled={
-            create.isPending ||
-            !scopeValid ||
-            ownerMissing ||
-            workspaceUnresolved
-          }
-          onPress={submit}
-        >
-          {create.isPending ? "Creating…" : "Create key"}
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
+  )
+}
+
+/**
+ * The secret a regenerate produced, in the same frame a create's arrives in.
+ *
+ * No form step and no "Create another": the key already exists and this is the
+ * new secret for it, so the dialog opens where the create flow ends up.
+ */
+function RegeneratedSecretDialog({
+  title,
+  result,
+  memberLabels,
+  onClose,
+}: {
+  title: string
+  result: CreateKeyResponse
+  memberLabels: ReadonlyMap<string, string>
+  onClose: () => void
+}) {
+  const secretRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+  useEffect(() => {
+    secretRef.current?.focus()
+  }, [])
+  return (
+    <FormDialog
+      isOpen
+      onOpenChange={onClose}
+      size="lg"
+      isDismissable={false}
+      title={title}
+      description="Copy it now. Otari stores a hash and cannot show it again."
+      submitLabel="I’ve saved this key"
+      onSubmit={onClose}
+      isPending={false}
+    >
+      <KeySecretStep
+        announce={title}
+        result={result}
+        memberLabels={memberLabels}
+        secretRef={secretRef}
+      />
+    </FormDialog>
   )
 }
 
@@ -645,7 +781,7 @@ function EditKeyForm({
       allowed_models: allowedModels,
       reject_user_mismatch: rejectUserMismatch,
     }
-    // The member surface has no budget exemption to send (see CreateKeyForm).
+    // The member surface has no budget exemption to send (see CreateKeyDialog).
     const body: UpdateKeyRequest | UpdateOwnKeyRequest = isDeploymentWide
       ? { ...shared, exclude_from_budget: excludeFromBudget }
       : shared
@@ -823,14 +959,14 @@ export function KeysPage() {
 
   const [addOpen, setAddOpen] = useState(false)
   const [editing, setEditing] = useState<string | null>(null)
-  const [revealed, setRevealed] = useState<{
+  const [regenerated, setRegenerated] = useState<{
     title: string
     result: CreateKeyResponse
   } | null>(null)
-  // Where focus lands when the reveal closes. The control that opened it is
-  // either gone (the create form) or behind a confirm that has been consumed
-  // (a regenerate), so the page's own primary action is the stable landing
-  // spot nearest to where the operator was.
+  // Where focus lands when a dialog opened from a consumed confirm closes.
+  // `FormDialog` returns focus to whatever had it, and a regenerate's trigger is
+  // a row action that has already disarmed itself, so the page's own primary
+  // action is the stable landing spot nearest to where the operator was.
   const createButtonRef = useRef<HTMLButtonElement>(null)
 
   const rows = keys.data ?? []
@@ -839,7 +975,7 @@ export function KeysPage() {
   // context answers, and a disabled query reports `isLoading` false.
   const loading = !scope.isReady || keys.isLoading
   const editingKey = rows.find((k) => k.id === editing) ?? null
-  const showOnboarding = !loading && rows.length === 0 && !addOpen
+  const showOnboarding = !loading && rows.length === 0
   const selection = useTableSelection()
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [bulkError, setBulkError] = useState<unknown>(undefined)
@@ -861,7 +997,7 @@ export function KeysPage() {
     (k: ApiKey) =>
       rotateKey.mutate(k.id, {
         onSuccess: (result) =>
-          setRevealed({ title: `New secret for ${label(k)}`, result }),
+          setRegenerated({ title: `New secret for ${label(k)}`, result }),
       }),
     [rotateKey.mutate],
   )
@@ -1106,20 +1242,21 @@ export function KeysPage() {
       <PageIntro
         title="API keys"
         action={
-          addOpen ? undefined : (
-            <Button
-              // The reveal strip hands focus back here when it closes, so the
-              // control that opened it has to stay addressable.
-              ref={createButtonRef}
-              variant="primary"
-              onPress={() => {
-                setEditing(null)
-                setAddOpen(true)
-              }}
-            >
-              Create key
-            </Button>
-          )
+          <Button
+            // Focus returns here when a dialog opened from a row action closes,
+            // so the control has to stay addressable. It also no longer hides
+            // while the create dialog is open: the dialog is over the page, and
+            // a heading that loses its action while you are using it is the
+            // inconsistency this page had.
+            ref={createButtonRef}
+            variant="primary"
+            onPress={() => {
+              setEditing(null)
+              setAddOpen(true)
+            }}
+          >
+            Create key
+          </Button>
         }
       >
         {isDeploymentWide
@@ -1162,16 +1299,17 @@ export function KeysPage() {
         </p>
       )}
 
-      {revealed ? (
-        <RevealSecretStrip
-          title={revealed.title}
-          result={revealed.result}
-          returnFocusRef={createButtonRef}
+      {regenerated ? (
+        <RegeneratedSecretDialog
+          title={regenerated.title}
+          result={regenerated.result}
+          memberLabels={memberLabels}
           onClose={() => {
-            setRevealed(null)
-            // Drop the one-time secret from mutation state so reopening
-            // Create/Regenerate never flashes the previous key.
+            setRegenerated(null)
+            // Drop the one-time secret from mutation state so a later
+            // regenerate never flashes the previous key.
             rotateKey.reset()
+            createButtonRef.current?.focus()
           }}
         />
       ) : null}
@@ -1188,15 +1326,13 @@ export function KeysPage() {
         />
       ) : null}
 
-      {addOpen ? (
-        <CreateKeyForm
-          isDeploymentWide={isDeploymentWide}
-          onClose={() => setAddOpen(false)}
-          onCreated={(result) =>
-            setRevealed({ title: "API key created", result })
-          }
-        />
-      ) : null}
+      <CreateKeyDialog
+        isDeploymentWide={isDeploymentWide}
+        isOpen={addOpen}
+        onOpenChange={setAddOpen}
+        memberLabels={memberLabels}
+        returnFocusRef={createButtonRef}
+      />
       {/* Key on the row id so switching which key is edited remounts the form:
           its fields seed from `apiKey` via useState (mount-only), so without this
           a second Edit would keep the first key's values and PATCH the wrong row. */}

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -481,9 +481,11 @@ function CreateKeyDialog({
   const blocked = !scopeValid || ownerMissing || workspaceUnresolved
 
   // What the form owns, in one place, because `resetForm` and `isDirty` are the
-  // same list read two ways and they drifted: reopening kept the previous owner
-  // and budget exemption, and the guard armed for three fields out of seven.
-  // `showAdvanced` is not in either: it reveals fields rather than holding a
+  // same list read two ways and they drifted: the guard armed for three fields
+  // out of seven, and "Create another" left the rest behind. Reopening is a
+  // remount now (the page keys this on an open counter), so `resetForm` answers
+  // for "Create another" alone, which is a reset inside an open dialog.
+  // `showAdvanced` is in neither: it reveals fields rather than holding a
   // value, and a disclosure left open is not unsaved work.
   const isPristine =
     keyName === "" &&
@@ -518,10 +520,6 @@ function CreateKeyDialog({
         returnFocusRef.current?.focus()
       }
     })
-    // The frame keeps its content while it animates out, so the reset waits for
-    // the next open rather than blanking the dialog as it goes.
-    setCreated(null)
-    resetForm()
   }
 
   const submit = () => {
@@ -941,6 +939,22 @@ export function KeysPage() {
   const memberLabels = useMemberAttributionLabels()
 
   const [addOpen, setAddOpen] = useState(false)
+  // Bumped on each open, and the create dialog is keyed on it, so the draft is
+  // fresh every time and untouched through the exit: the dialog keeps its
+  // content while it animates out, so clearing on the way out blanked the
+  // secret step to an empty form for the length of the animation.
+  //
+  // No guard against a second press while it is open: react-aria takes the page
+  // out of the accessibility tree behind a modal, so the heading's trigger
+  // cannot be reached until the dialog has closed. Probed rather than assumed,
+  // because the trigger is still on screen: with the dialog open there is
+  // exactly one control named "Create key" and it is the dialog's own submit.
+  const [openCount, setOpenCount] = useState(0)
+  const openCreate = () => {
+    setEditing(null)
+    setOpenCount((n) => n + 1)
+    setAddOpen(true)
+  }
   const [editing, setEditing] = useState<string | null>(null)
   const [regenerated, setRegenerated] = useState<{
     title: string
@@ -1233,10 +1247,7 @@ export function KeysPage() {
             // inconsistency this page had.
             ref={createButtonRef}
             variant="primary"
-            onPress={() => {
-              setEditing(null)
-              setAddOpen(true)
-            }}
+            onPress={openCreate}
           >
             Create key
           </Button>
@@ -1302,14 +1313,12 @@ export function KeysPage() {
           title="No API keys yet"
           description="An API key authenticates callers to this gateway. Create one to make your first request; the secret is shown once, so keep it somewhere safe."
           actionLabel="Create your first key"
-          onAction={() => {
-            setEditing(null)
-            setAddOpen(true)
-          }}
+          onAction={openCreate}
         />
       ) : null}
 
       <CreateKeyDialog
+        key={openCount}
         isDeploymentWide={isDeploymentWide}
         isOpen={addOpen}
         onOpenChange={setAddOpen}

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/shared/helpers/tableSelection"
 import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
 import { useDeployment } from "@/shared/hooks/useDeployment"
+import { isVirtualUser, secretCaption } from "./secretCaption"
 
 // ---------- helpers ----------
 
@@ -99,44 +100,12 @@ function toDatetimeLocal(iso: string | null): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-const isVirtualUser = (userId: string | null): boolean =>
-  (userId ?? "").startsWith("apikey-")
-
 const label = (k: ApiKey): string => k.key_name ?? k.id
 
 // Stable row-key getter so DataTable's per-row cache holds across re-renders.
 const getKeyRowKey = (k: ApiKey): string => k.id
 
 // ---------- the one-time secret ----------
-
-/**
- * The line under the key, naming what was just made.
- *
- * Three facts, each dropped when it is not there rather than printed empty. The
- * owner is a name or nothing: `user_id` is an identifier, and an identifier in a
- * sentence is noise to the person who just chose the owner from a list. There is
- * deliberately no spend figure, though the frame it sits in is where one would
- * look for it: a key has no budget of its own, only its owner's, which is what
- * the paragraph above the table already says and links to.
- */
-export function secretCaption(
-  result: CreateKeyResponse,
-  memberLabels: ReadonlyMap<string, string>,
-): string {
-  const owner =
-    result.user_id && !isVirtualUser(result.user_id)
-      ? memberLabels.get(result.user_id)
-      : undefined
-  return [
-    owner ? `Owner ${owner}` : null,
-    accessLabel(result.allowed_models).text,
-    result.expires_at
-      ? `expires ${formatDate(result.expires_at)}`
-      : "never expires",
-  ]
-    .filter((part) => part !== null)
-    .join(" · ")
-}
 
 /**
  * The plaintext key, shown once, and everything that has to travel with it.

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -28,6 +28,7 @@ import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { useConfirmationFocus } from "@/design-system/hooks/useConfirmationFocus"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
@@ -480,21 +481,25 @@ function CreateKeyDialog({
   const workspaceUnresolved = workspaceLoading
   const blocked = !scopeValid || ownerMissing || workspaceUnresolved
 
-  // What the form owns, in one place, because `resetForm` and `isDirty` are the
-  // same list read two ways and they drifted: the guard armed for three fields
-  // out of seven, and "Create another" left the rest behind. Reopening is a
-  // remount now (the page keys this on an open counter), so `resetForm` answers
-  // for "Create another" alone, which is a reset inside an open dialog.
-  // `showAdvanced` is in neither: it reveals fields rather than holding a
-  // value, and a disclosure left open is not unsaved work.
-  const isPristine =
-    keyName === "" &&
-    expiresAt === "" &&
-    userId === "" &&
-    allowedModels === null &&
-    excludeFromBudget === false &&
-    rejectUserMismatch === null &&
-    scopeValid
+  // What the form owns, handed to the guard whole rather than compared field by
+  // field: the two drifted apart once already, with the guard armed for three
+  // fields out of seven while "Create another" left the rest behind. Reopening
+  // is a remount now (the page keys this on an open counter), so `resetForm`
+  // answers for "Create another" alone, which is a reset inside an open dialog,
+  // and putting every field back to its seed reads clean again without telling
+  // the guard anything. `showAdvanced` is in neither: it reveals fields rather
+  // than holding a value, and a disclosure left open is not unsaved work.
+  // `scopeValid` is, though: a model scope typed to something invalid is work
+  // the operator would lose.
+  const { isDirty } = useDirtySnapshot({
+    keyName,
+    expiresAt,
+    userId,
+    allowedModels,
+    excludeFromBudget,
+    rejectUserMismatch,
+    scopeValid,
+  })
 
   const resetForm = () => {
     setKeyName("")
@@ -606,7 +611,7 @@ function CreateKeyDialog({
       isPending={create.isPending}
       isSubmitDisabled={blocked}
       error={create.error}
-      isDirty={!isPristine}
+      isDirty={isDirty}
     >
       <Field
         label="Name"

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -554,11 +554,17 @@ function CreateKeyDialog({
     return (
       <FormDialog
         isOpen={isOpen}
-        onOpenChange={close}
+        // Guarded the same way the form step is: a truthy `open` is forwarded
+        // straight through, so taking `close` bare here made any request to
+        // open this dialog close it instead. Nothing sends one today, since the
+        // only source is the hidden trigger, but this is the step where being
+        // wrong loses the key.
+        onOpenChange={(open) => (open ? onOpenChange(true) : close())}
         size="lg"
         // A dismiss here loses the key for good, so there is one way out and it
         // is the acknowledgement. `FormDialog` drops its close control and its
-        // Cancel to match.
+        // Cancel to match, and `isDismissable` does not reach the line above:
+        // it guards `requestClose`, not a forwarded open.
         isDismissable={false}
         title="Key created"
         // The strip's own words, not "Done": this control is an

--- a/web/src/features/keys/secretCaption.test.ts
+++ b/web/src/features/keys/secretCaption.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import type { CreateKeyResponse } from "@/client"
+import { formatDate } from "@/shared/helpers/format"
+import { secretCaption } from "./KeysPage"
+
+const result = (over: Partial<CreateKeyResponse> = {}): CreateKeyResponse => ({
+  allowed_models: null,
+  capture_agent_telemetry: null,
+  created_at: "2026-09-10T00:00:00Z",
+  exclude_from_budget: false,
+  expires_at: null,
+  id: "key-1",
+  is_active: true,
+  key: "gw-secret",
+  key_name: "ci-bot",
+  key_prefix: "gw-secret…",
+  metadata: {},
+  reject_user_mismatch: null,
+  user_id: "alice",
+  ...over,
+})
+
+const labels = new Map([["alice", "Alice Chen"]])
+
+describe("secretCaption", () => {
+  it("names the owner, the access and the expiry", () => {
+    // The date goes through the shared formatter rather than being spelled
+    // here: `formatDate` is `toLocaleDateString()`, so the rendered string is
+    // the reader's locale and a literal in this file would pin the suite to
+    // whichever one CI happens to run under.
+    const expires = "2027-01-31T00:00:00Z"
+    expect(
+      secretCaption(
+        result({ expires_at: expires, allowed_models: null }),
+        labels,
+      ),
+    ).toBe(`Owner Alice Chen · All models · expires ${formatDate(expires)}`)
+    expect(
+      secretCaption(result({ expires_at: expires }), labels),
+    ).not.toContain(expires)
+  })
+
+  it("drops the owner rather than printing an id", () => {
+    // A member creating their own key cannot resolve a name: `/v1/users` is
+    // operator-only, so the map is empty on that surface. An identifier in a
+    // sentence is noise to the person who just chose the owner from a list.
+    expect(secretCaption(result(), new Map())).toBe(
+      "All models · never expires",
+    )
+  })
+
+  it("drops the owner for a virtual user, which has no person behind it", () => {
+    expect(secretCaption(result({ user_id: "apikey-abc" }), labels)).toBe(
+      "All models · never expires",
+    )
+  })
+
+  it("reuses the table's own access wording rather than restating it", () => {
+    expect(secretCaption(result({ allowed_models: ["gpt-4o"] }), labels)).toBe(
+      "Owner Alice Chen · Selected models · never expires",
+    )
+    expect(secretCaption(result({ allowed_models: [] }), labels)).toBe(
+      "Owner Alice Chen · No models · never expires",
+    )
+  })
+
+  it("carries no spend figure, because a key has no budget of its own", () => {
+    // The frame this sits in is where an operator would look for one, so this
+    // is a rule rather than an omission: a key spends against its owner's
+    // budget, which the page says and links to above the table.
+    const caption = secretCaption(result({ exclude_from_budget: true }), labels)
+    expect(caption).not.toMatch(/\$|budget|per month/)
+    expect(caption).toBe("Owner Alice Chen · All models · never expires")
+  })
+})

--- a/web/src/features/keys/secretCaption.test.ts
+++ b/web/src/features/keys/secretCaption.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import type { CreateKeyResponse } from "@/client"
 import { formatDate } from "@/shared/helpers/format"
-import { secretCaption } from "./KeysPage"
+import { secretCaption } from "./secretCaption"
 
 const result = (over: Partial<CreateKeyResponse> = {}): CreateKeyResponse => ({
   allowed_models: null,

--- a/web/src/features/keys/secretCaption.ts
+++ b/web/src/features/keys/secretCaption.ts
@@ -1,0 +1,35 @@
+import type { CreateKeyResponse } from "@/client"
+import { accessLabel } from "@/features/models/ModelScopeControl"
+import { formatDate } from "@/shared/helpers/format"
+
+export const isVirtualUser = (userId: string | null): boolean =>
+  (userId ?? "").startsWith("apikey-")
+
+/**
+ * The line under the key, naming what was just made.
+ *
+ * Three facts, each dropped when it is not there rather than printed empty. The
+ * owner is a name or nothing: `user_id` is an identifier, and an identifier in a
+ * sentence is noise to the person who just chose the owner from a list. There is
+ * deliberately no spend figure, though the frame it sits in is where one would
+ * look for it: a key has no budget of its own, only its owner's, which is what
+ * the paragraph above the table already says and links to.
+ */
+export function secretCaption(
+  result: CreateKeyResponse,
+  memberLabels: ReadonlyMap<string, string>,
+): string {
+  const owner =
+    result.user_id && !isVirtualUser(result.user_id)
+      ? memberLabels.get(result.user_id)
+      : undefined
+  return [
+    owner ? `Owner ${owner}` : null,
+    accessLabel(result.allowed_models).text,
+    result.expires_at
+      ? `expires ${formatDate(result.expires_at)}`
+      : "never expires",
+  ]
+    .filter((part) => part !== null)
+    .join(" · ")
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2215,16 +2215,24 @@ main {
     max-height: none;
     border: 0;
   }
-  /* The footer stacks. Two 36px buttons and a caption sharing one row fit a
-   * desktop and not a 390px sheet: the routing dialog's caption wrapped to three
-   * lines beside them. Each control takes the sheet's full width at the 44px
-   * touch floor, in DOM order, so Cancel sits above the primary.
-   *
-   * Nothing reorders them, and that is the point: an earlier version moved
-   * Cancel with `order`, which left the visual order and the focus order
-   * disagreeing on a phone. DOM, visual and focus order now agree at both
-   * widths. It also puts the primary lowest, which is the control nearest the
-   * thumb on a sheet. */
+}
+/* The footer stacks, and on the narrow axis only. Two 36px buttons and a caption
+ * sharing one row fit a desktop and not a 390px sheet: the routing dialog's
+ * caption wrapped to three lines beside them. Each control takes the sheet's
+ * full width at the 44px touch floor, in DOM order, so Cancel sits above the
+ * primary.
+ *
+ * Width alone, unlike the geometry above: `(height <= 639px)` also matches an
+ * unmaximized 1280x600 desktop window, and stacking two full-width buttons
+ * across 1280px is not a sheet, it is a broken footer. A landscape phone
+ * (844x390) keeps the sheet from the block above and gets a row footer, which
+ * its 844px affords.
+ *
+ * Nothing reorders them, and that is the point: an earlier version moved Cancel
+ * with `order`, which left the visual order and the focus order disagreeing on
+ * a phone. DOM, visual and focus order now agree at both widths. It also puts
+ * the primary lowest, which is the control nearest the thumb on a sheet. */
+@media (width <= 639px) {
   .otari-form-dialog__footer {
     flex-direction: column;
     align-items: stretch;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2189,16 +2189,25 @@ main {
   max-width: none;
 }
 
-/* Below 640px every size is a full-screen sheet: a centered box with a phone's
- * margins around it wastes the only axis a form needs, and the keyboard takes
- * half of what is left.
+/* A full-screen sheet below 640px in EITHER dimension. The 120px gap above and
+ * below is a desktop luxury, and a viewport that cannot afford it in either axis
+ * gets the sheet rather than a third layout: at a landscape phone (844x390 is
+ * the common one) the width query alone left the dialog a 150px height budget,
+ * of which the header and footer are about 137px.
+ *
+ * The container's own `sm:` paddings still apply at that width, so they are
+ * overridden here too; without that the sheet would sit inside a 240px vertical
+ * inset and none of this would help.
  *
  * The footer's bottom padding is a plain 1rem and not a safe-area inset:
  * `env(safe-area-inset-bottom)` is 0 without `viewport-fit=cover`, which
  * `index.html` leaves off deliberately (the shell has no insets to sit out of
  * the way), so adding it would read as clearing the home indicator while
  * changing nothing. */
-@media (max-width: 639px) {
+@media (width <= 639px), (height <= 639px) {
+  .otari-form-dialog__container {
+    padding: 0;
+  }
   .otari-form-dialog {
     width: 100%;
     max-width: none;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2217,12 +2217,14 @@ main {
   }
   /* The footer stacks. Two 36px buttons and a caption sharing one row fit a
    * desktop and not a 390px sheet: the routing dialog's caption wrapped to three
-   * lines beside them. Primary on top, Cancel under it, each the sheet's full
-   * width at the 44px touch floor. Drawn on artboard 07.
+   * lines beside them. Each control takes the sheet's full width at the 44px
+   * touch floor, in DOM order, so Cancel sits above the primary.
    *
-   * Cancel is first in the DOM, where it belongs beside the primary on a
-   * desktop, so `order` moves it rather than the markup: reading order on a
-   * desktop and stacking order on a phone are different questions. */
+   * Nothing reorders them, and that is the point: an earlier version moved
+   * Cancel with `order`, which left the visual order and the focus order
+   * disagreeing on a phone. DOM, visual and focus order now agree at both
+   * widths. It also puts the primary lowest, which is the control nearest the
+   * thumb on a sheet. */
   .otari-form-dialog__footer {
     flex-direction: column;
     align-items: stretch;
@@ -2246,9 +2248,6 @@ main {
    * button by 7.07px, and this one spans the sheet. */
   .otari-form-dialog__actions > button:is(:active, [data-pressed="true"]) {
     transform: none;
-  }
-  .otari-form-dialog__cancel {
-    order: 1;
   }
   .otari-form-dialog__footer button {
     min-height: 2.75rem;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2193,10 +2193,11 @@ main {
  * margins around it wastes the only axis a form needs, and the keyboard takes
  * half of what is left.
  *
- * The footer takes no rule of its own: `env(safe-area-inset-bottom)` is 0
- * without `viewport-fit=cover`, which `index.html` leaves off deliberately (the
- * shell has no insets to sit out of the way), so a safe-area pad here would
- * read as clearing the home indicator while adding nothing. */
+ * The footer's bottom padding is a plain 1rem and not a safe-area inset:
+ * `env(safe-area-inset-bottom)` is 0 without `viewport-fit=cover`, which
+ * `index.html` leaves off deliberately (the shell has no insets to sit out of
+ * the way), so adding it would read as clearing the home indicator while
+ * changing nothing. */
 @media (max-width: 639px) {
   .otari-form-dialog {
     width: 100%;
@@ -2217,7 +2218,7 @@ main {
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
-    padding: 0.75rem 1rem calc(1rem + env(safe-area-inset-bottom));
+    padding: 0.75rem 1rem 1rem;
   }
   .otari-form-dialog__actions {
     flex-direction: column;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2205,6 +2205,44 @@ main {
     max-height: none;
     border: 0;
   }
+  /* The footer stacks. Two 36px buttons and a caption sharing one row fit a
+   * desktop and not a 390px sheet: the routing dialog's caption wrapped to three
+   * lines beside them. Primary on top, Cancel under it, each the sheet's full
+   * width at the 44px touch floor. Drawn on artboard 07.
+   *
+   * Cancel is first in the DOM, where it belongs beside the primary on a
+   * desktop, so `order` moves it rather than the markup: reading order on a
+   * desktop and stacking order on a phone are different questions. */
+  .otari-form-dialog__footer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem calc(1rem + env(safe-area-inset-bottom));
+  }
+  .otari-form-dialog__actions {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  /* `width`, not the footer's `align-items: stretch`: `.button` is
+   * `width: fit-content`, so its cross size is never `auto` and stretch cannot
+   * reach it. Measured, the two buttons stayed 110px and 83px in a 373px
+   * column. HeroUI's `fullWidth` prop is the other way to get here and it is a
+   * prop, so it would take the desktop with it. */
+  .otari-form-dialog__actions > button {
+    width: 100%;
+  }
+  /* Full width earns the same press suppression `.button` already gives
+   * `.w-full` and HeroUI's `fullWidth` class: the transform displaces a wide
+   * button by 7.07px, and this one spans the sheet. */
+  .otari-form-dialog__actions > button:is(:active, [data-pressed="true"]) {
+    transform: none;
+  }
+  .otari-form-dialog__cancel {
+    order: 1;
+  }
+  .otari-form-dialog__footer button {
+    min-height: 2.75rem;
+  }
 }
 
 /* Backdrop dimming — HeroUI's default backdrop variant is `opaque`, and that


### PR DESCRIPTION
## Description

Creating an API key used to append a form to the page, and then a second full-width strip holding the secret. Regenerating one appended that same strip from a table row. Both now open the dialog every create flow in the dashboard is moving to.

**They moved together on purpose.** They hand over the same thing, they are eight lines apart in the same file, and migrating one alone would have left a single page showing a one-time secret in a dialog after Create and in a strip after Regenerate, which is the inconsistency this series exists to remove. `RevealSecretStrip` is gone; those were its only two consumers.

**The secret step keeps everything the strip carried**, in the strip's own order and its own words: the "shown only once" sentence, the concealed key, the curl and Python snippets concealed the same way, and the notice for a deployment that never published a gateway address. An operator creating their first key arrives from the empty state and "make your first call" is the next thing they need, so leaving it behind would have made this dialog the one place the flow got worse. Its footer action stays **"I've saved this key"** rather than the "Done" the pattern would give it: this control is an acknowledgement rather than a dismissal.

**Two things the strip's own docstring argued for are kept rather than lost to the surface change.** It refused a modal over a focus trap, a swallowed Escape and a backdrop that ignores clicks. `FormDialog` has none of those, except here, where `isDismissable={false}` *is* the strip's "there is one control and it is the acknowledgement", because a stray backdrop click loses the key forever. And focus still returns to the page's create action, which is why that button no longer hides while the dialog is open: a dialog sits over the page, so there was never a reason to take the heading's action away, and it is where focus lands when the empty state's own button has been unmounted by the row it created.

**The caption under the key** names the owner, the access and the expiry. It deliberately carries no spend figure, though the frame is where you would look for one: a key has no budget of its own, only its owner's, which the paragraph above the table already says and links to. The owner is a name or nothing, never an id.

**The create form's "Create another" Checkbox is gone, and that is a bug fix rather than a copy change.** It was the only control that skipped the secret step, and skipping it discarded a live credential: the server cannot return `result.key` again, so a key created that way was unusable until it was regenerated. A second reviewer found the same defect from the code independently. The only "Create another" left is the ghost button on the secret step, which resets the form after the key has been handed over.

`FormDialog` grows three changes for this, all in `feedback/FormDialog.tsx`:

- **`isSubmitDisabled`.** The create form has three conditions the browser cannot check (a model scope that is valid, an owner, a resolved workspace). The old form disabled its button on them; a submit that fails silently teaches nothing.
- **`isDismissable`.** It also drops the close control and Cancel, since both are dismissals and a dialog with neither has exactly one way out.
- **A footer that stays at the foot of a phone sheet.** Below 640px the dialog is the height of the viewport rather than of its content, and nothing claimed the free space, so the footer sat halfway up an empty sheet. Found by capturing the phone viewport, which is the only place that shape exists.

## How to test it locally

    pnpm --dir web run storybook

`Design system → Feedback → FormDialog` has `SubmitBlocked`, `NotDismissable`, `PhoneSheet` and `PhoneSheetLandscape`; `Actions → Copy` has `RevealedOnArrival` and `CoupledReveal`.

For the page itself:

    pnpm --dir web run build
    pnpm --dir web exec playwright test --project=seed --project=screenshots-desktop-small-light --project=screenshots-mobile-light --grep "create dialog"

Captures land in `web/e2e/screenshots/authenticated.spec.ts-snapshots/` (gitignored, per the repo's convention while the dashboard is mid-migration). Two new ones, each across all three viewports and both themes: the dialog on its form step, and the same dialog with **Advanced** open, which is what makes the body scroll with the header and footer pinned.

The success step is deliberately **not** in that suite. Those projects read pages and write nothing, which is what lets them retry safely; reaching the secret means creating a key. It is covered by the vitest suite and by the `onboarding` project's existing end-to-end create flow instead.

Automated, all run on this commit:

- `pnpm --dir web test` — 5298 pass across 153 files. 41 in `KeysPage.test.tsx`, 5 in the new `secretCaption.test.ts`.
- `pnpm --dir web run lint`, `run typecheck`, `run build` — clean.
- `pnpm --dir web run storybook:build` then `node .storybook/smoke.mjs` — 378 stories x 2 themes, all rendered clean.
- Playwright `onboarding` + `seed` + two screenshot projects: 98 passed, 4 failed. **Those 4 fail identically on the base commit** (`45a5fe1a`), verified by running them there in a separate worktree; they are `organization member › workspace members` and `organization admin › organization spend and budgets`, neither of which touches keys. Delta from this branch: zero.

### What would have to break for each new test to fail

Each was checked by removing the behavior and watching the right case go red:

| Remove | Fails |
| --- | --- |
| the trigger's visibility while the dialog is open (restore `addOpen ? undefined :`) | `keeps the page's create action visible while the dialog is open` |
| the `isOpen` gate on the owner roster | `does not walk /v1/users until the create dialog is opened` |
| either setter `resetForm` was missing | `clears the owner and the budget exemption when it reopens` |
| the unified dirty predicate, back to the three-field check | `guards a field the old dirty check did not know about` |
| the `isSubmitDisabled` gate on either submit path | `blocks the button, plain Enter, and Cmd/Ctrl+Enter alike` |
| the absence of a "Create another" slot on the regenerate dialog | `shows a regenerated secret in the same dialog a created one arrives in` |
| the owner-name guard, printing `user_id` when no name resolves | `drops the owner rather than printing an id` **and** `drops the owner for a virtual user` |

The caption's date is asserted against `formatDate` rather than a literal: it is `toLocaleDateString()`, so a literal would pin the suite to whichever locale CI runs under.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of #1031

Stacked on #1032, which adds `FormDialog`. Review that one first; this branch contains its commits.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      41 cases in `KeysPage.test.tsx` (3 new, 12 rewritten for the new surface),
      5 in the new `secretCaption.test.ts`, 2 new Storybook stories, and 2 new
      screenshot captures. The dashboard's tests live under `web/src` and
      `web/e2e` rather than the repo-root `tests/` the template names.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      The dashboard's counterparts, which is what this diff touches; `make lint`
      does not reach `web/`. Commands and results above.
- [ ] Documentation was updated where necessary.
      No design-doc change: the placement, label and surface rules this page now
      follows were written down in #1032, and this is the first page to follow
      them rather than a new rule.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      No API change. No route, schema or docstring is touched, and the request
      bodies this form sends are byte-for-byte what it sent before.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Three premises this change started from turned out to be wrong about the page and were corrected before any code was written: a spend figure for the caption (a key has no budget), the belief that the strip was only a key and a copy field (it also carries the snippets), and the belief that its other consumer was elsewhere in the app (it was this page's own regenerate). Each is called out in the review comments on the diff.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved one-time secrets for key creation and regeneration into `FormDialog`.
- Preserved secret details, code snippets, captions, and acknowledgement actions in the dialog.
- Added controlled secret reveal support to `CopyField`.
- Added dialog controls for disabled submission, dismissal behavior, mobile footer layout, and accessibility.
- Removed the create-form “Create another” checkbox and kept the action in the secret step.
- Updated key-flow tests, end-to-end helpers, Storybook stories, and screenshot coverage.

## Benefits

- Keeps sensitive key information in a focused, non-dismissible step.
- Provides consistent behavior for key creation and regeneration.
- Improves keyboard, mobile, and accessibility behavior.
- Delays user loading until the create dialog opens.
- Reduces stale secret reveal behavior during asynchronous copy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
