### PR TITLE
feat(dashboard): move the budget form into FormDialog

### DIFF
--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -67,6 +67,7 @@ for a component, not for those.
 | `forms/Field` · `/SecretField` · `/TextArea` · `/SearchField` · `/FieldAction` | one component each |
 | `forms/Select` | `Select`, and the `SelectOption` type |
 | `forms/ComboBoxField` | `ComboBoxField`, and the `ComboBoxOption` type |
+| `forms/MultiSelect` | `MultiSelect`, and the `MultiSelectOption` type |
 | `forms/ComboBoxEmpty` | `ComboBoxEmpty`. The two sentences an empty popover picks between |
 | `forms/RadioGroup` | `RadioGroup`, and the `RadioOption` type |
 | `forms/Toggle` | `Toggle` |

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -63,9 +63,9 @@ ComboBoxField: { label, value, onChange, onQueryChange?, options: ComboBoxOption
   reserveMessage?, className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus",
   shouldSelectOnFocus?, isSourceEmpty?, emptyMessage?, noMatchesMessage? }
 MultiSelect: { label, value: readonly string[], onChange: (next: string[]) => void,
-  options: MultiSelectOption[], description?, isInvalid?, errorMessage?,
-  reserveMessage?, searchPlaceholder?, emptyMessage?, noMatchesMessage?,
-  countNoun?: { one, other }, maxVisible = 50, autoFocus? }
+  options: MultiSelectOption[] ({ id, label, hint? }), description?, isInvalid?,
+  errorMessage?, reserveMessage?, searchPlaceholder?, emptyMessage?,
+  noMatchesMessage?, countNoun?: { one, other }, maxVisible = 50, autoFocus? }
 RadioGroup: { label, value, onChange, options: RadioOption[], description?,
   orientation = "vertical", isRequired?, isDisabled?, isInvalid?, errorMessage?,
   className? }
@@ -173,6 +173,11 @@ never re-sorts on a pick.
 counts is how "1 people assigned" ships. `maxVisible` caps what is rendered,
 never what is searched: the filter runs over every option and the footer says
 when it is showing fewer.
+
+An option's `hint` is the same thing it is on `ComboBoxField`: a second, muted
+line inside the row, folded into the row's accessible name because it is what
+tells two rows with one label apart. The query matches it too, so an operator
+who knows an id reaches the row named for a person.
 
 ## Field height is a property of the place, not of the field
 

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -31,7 +31,8 @@ Is it one of a set too long to scroll, or open-ended?
  └── ComboBoxField                 (search as you type; `allowsCustomValue`
                                     for a list that is a shortcut, not a whitelist)
 Is it many of a set?
- └── FilterMultiComboBox
+ ├── In a form -> MultiSelect
+ └── In a toolbar -> FilterMultiComboBox
 ```
 
 `Select` and `FilterSelect` are two components rather than one with a mode, and
@@ -61,6 +62,10 @@ ComboBoxField: { label, value, onChange, onQueryChange?, options: ComboBoxOption
   description?, placeholder?, isRequired?, isDisabled?, isInvalid?, errorMessage?,
   reserveMessage?, className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus",
   shouldSelectOnFocus?, isSourceEmpty?, emptyMessage?, noMatchesMessage? }
+MultiSelect: { label, value: readonly string[], onChange: (next: string[]) => void,
+  options: MultiSelectOption[], description?, isInvalid?, errorMessage?,
+  reserveMessage?, searchPlaceholder?, emptyMessage?, noMatchesMessage?,
+  countNoun?: { one, other }, maxVisible = 50, autoFocus? }
 RadioGroup: { label, value, onChange, options: RadioOption[], description?,
   orientation = "vertical", isRequired?, isDisabled?, isInvalid?, errorMessage?,
   className? }
@@ -150,6 +155,24 @@ one label apart.
 `FilterMultiComboBox` stays a separate component for the reason `FilterSelect`
 does: it is a filter, so its label is a caption beside the control and it never
 speaks a validation message.
+
+## MultiSelect
+
+**The form half of that pair.** It puts its label above the control, owns a
+description and an error announced on it, and is the one to reach for inside a
+`FormDialog`; `FilterMultiComboBox` is the toolbar one and stays.
+
+Two behaviors are its own, and both were the bug it was built for. **The search
+field never moves**: the chips render *below* it, so a growing selection pushes
+the block down rather than shoving the control out from under the pointer. And
+**a picked option stays in the list, checked**, so the list answers "who is in"
+rather than only "who is left"; pressing it again removes it, and the order
+never re-sorts on a pick.
+
+`countNoun` is a pair, `{ one, other }`, because one noun interpolated into both
+counts is how "1 people assigned" ships. `maxVisible` caps what is rendered,
+never what is searched: the filter runs over every option and the footer says
+when it is showing fewer.
 
 ## Field height is a property of the place, not of the field
 

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -179,14 +179,6 @@ line inside the row, folded into the row's accessible name because it is what
 tells two rows with one label apart. The query matches it too, so an operator
 who knows an id reaches the row named for a person.
 
-**Its description and its error are two rungs, which is the one place this
-control departs from the rule above.** Everywhere else an error replaces the
-description line. Here the description sits above the field and the error below
-it, because what lies between them is the field itself, its popover and its
-chip row: an error rendered up there would be separated from the control it is
-about by everything the operator is looking at, and one that replaced the
-description would move the field on the way in and out. `reserveMessage` holds
-the lower line open, so going invalid still moves nothing.
 
 ## Field height is a property of the place, not of the field
 

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -63,8 +63,8 @@ ComboBoxField: { label, value, onChange, onQueryChange?, options: ComboBoxOption
   reserveMessage?, className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus",
   shouldSelectOnFocus?, isSourceEmpty?, emptyMessage?, noMatchesMessage? }
 MultiSelect: { label, value: readonly string[], onChange: (next: string[]) => void,
-  options: MultiSelectOption[] ({ id, label, hint? }), description?, isInvalid?,
-  errorMessage?, reserveMessage?, searchPlaceholder?, emptyMessage?,
+  options: readonly MultiSelectOption[] ({ id, label, hint? }), description?,
+  isInvalid?, errorMessage?, reserveMessage?, searchPlaceholder?, emptyMessage?,
   noMatchesMessage?, countNoun?: { one, other }, maxVisible = 50, autoFocus? }
 RadioGroup: { label, value, onChange, options: RadioOption[], description?,
   orientation = "vertical", isRequired?, isDisabled?, isInvalid?, errorMessage?,
@@ -178,6 +178,15 @@ An option's `hint` is the same thing it is on `ComboBoxField`: a second, muted
 line inside the row, folded into the row's accessible name because it is what
 tells two rows with one label apart. The query matches it too, so an operator
 who knows an id reaches the row named for a person.
+
+**Its description and its error are two rungs, which is the one place this
+control departs from the rule above.** Everywhere else an error replaces the
+description line. Here the description sits above the field and the error below
+it, because what lies between them is the field itself, its popover and its
+chip row: an error rendered up there would be separated from the control it is
+about by everything the operator is looking at, and one that replaced the
+description would move the field on the way in and out. `reserveMessage` holds
+the lower line open, so going invalid still moves nothing.
 
 ## Field height is a property of the place, not of the field
 

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test"
 import { API_ROOT } from "@/shared/api/client"
 import {
-  dismissComboBox,
   dismissComboBoxInDialog,
   login,
   MASTER_KEY,
@@ -163,7 +162,7 @@ test.describe("dashboard core flows", () => {
     })
     await owners.fill("alice@example.com")
     await page.getByRole("option", { name: /alice@example\.com/ }).click()
-    await dismissComboBox(owners)
+    await dismissComboBoxInDialog(owners)
     await editDialog.getByRole("button", { name: "Save" }).click()
 
     // The budget now reports one holder in its People column, which is the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -154,7 +154,7 @@ test.describe("dashboard core flows", () => {
     const budgetRow = page.getByRole("row", { name: /e2e-budget/ })
     await budgetRow.getByRole("button", { name: "Edit" }).click()
     // The field's visible label is its accessible name now: the picker used to
-    // carry a hidden "Add a person" beside a heading that labelled nothing, so
+    // carry a hidden "Add a person" beside a heading that labeled nothing, so
     // one control had two names.
     const editDialog = page.getByRole("dialog")
     const owners = editDialog.getByRole("combobox", {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -118,9 +118,12 @@ test.describe("dashboard core flows", () => {
     await openOrganization(page)
     await nav(page).getByRole("link", { name: "Spend & budgets" }).click()
     await page.getByRole("button", { name: "Create your first budget" }).click()
-    await page.getByLabel("Name (optional)").fill("e2e-budget")
-    await page.getByLabel("Spending limit (USD)").fill("100")
-    await page.getByRole("button", { name: "Create budget" }).click()
+    // Scoped: the heading's trigger and the dialog's submit both say "Create
+    // budget", so an unscoped press is ambiguous.
+    const dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Name (optional)").fill("e2e-budget")
+    await dialog.getByLabel("Spending limit (USD)").fill("100")
+    await dialog.getByRole("button", { name: "Create budget" }).click()
 
     // The shared table renders on react-aria, so non-row-header cells are gridcells.
     await expect(page.getByRole("gridcell", { name: "$100.00" })).toBeVisible()
@@ -155,11 +158,12 @@ test.describe("dashboard core flows", () => {
     // the section heading beside it and labels nothing. Same shape as
     // `addFilterValue` otherwise: the popover aria-hides the rest of the page, so
     // it has to be put away before the submit button is reachable.
-    const owners = page.getByRole("combobox", { name: "Add a person" })
+    const editDialog = page.getByRole("dialog")
+    const owners = editDialog.getByRole("combobox", { name: "Add a person" })
     await owners.fill("alice@example.com")
     await page.getByRole("option", { name: /alice@example\.com/ }).click()
     await dismissComboBox(owners)
-    await page.getByRole("button", { name: "Save changes" }).click()
+    await editDialog.getByRole("button", { name: "Save" }).click()
 
     // The budget now reports one holder in its People column, which is the
     // assignment landing.

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -154,12 +154,13 @@ test.describe("dashboard core flows", () => {
     await nav(page).getByRole("link", { name: "Spend & budgets" }).click()
     const budgetRow = page.getByRole("row", { name: /e2e-budget/ })
     await budgetRow.getByRole("button", { name: "Edit" }).click()
-    // "Add a person" is the input's own accessible name; "Assign to people" is
-    // the section heading beside it and labels nothing. Same shape as
-    // `addFilterValue` otherwise: the popover aria-hides the rest of the page, so
-    // it has to be put away before the submit button is reachable.
+    // The field's visible label is its accessible name now: the picker used to
+    // carry a hidden "Add a person" beside a heading that labelled nothing, so
+    // one control had two names.
     const editDialog = page.getByRole("dialog")
-    const owners = editDialog.getByRole("combobox", { name: "Add a person" })
+    const owners = editDialog.getByRole("combobox", {
+      name: "Assign to people (optional)",
+    })
     await owners.fill("alice@example.com")
     await page.getByRole("option", { name: /alice@example\.com/ }).click()
     await dismissComboBox(owners)

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -193,11 +193,14 @@ test.describe("budgets", () => {
     await openPage(page, "Spend & budgets", "Budgets")
 
     await page.getByRole("button", { name: "Create budget" }).click()
-    await page.getByLabel("Name (optional)").fill(BUDGET)
-    await page.getByLabel("Spending limit (USD)").fill("25")
+    // Scoped: the heading's trigger and the dialog's submit both say "Create
+    // budget", so an unscoped press is ambiguous.
+    const dialog = page.getByRole("dialog")
+    await dialog.getByLabel("Name (optional)").fill(BUDGET)
+    await dialog.getByLabel("Spending limit (USD)").fill("25")
     // Assigning at creation is the path that makes a budget enforceable; a budget
     // with no users caps nothing.
-    const owner = page.getByRole("combobox", { name: "Add a person" })
+    const owner = dialog.getByRole("combobox", { name: "Add a person" })
     await owner.fill(PARITY.users.heavy)
     // Plain string, not a RegExp built from the id: an address is full of regex
     // metacharacters, so `.` would match any character and the pattern could pick
@@ -208,9 +211,9 @@ test.describe("budgets", () => {
     // The picked user becomes a removable chip, which is the form's own record of
     // who this budget will cap before it is submitted.
     await expect(
-      page.getByRole("button", { name: `Remove ${PARITY.users.heavy}` }),
+      dialog.getByRole("button", { name: `Remove ${PARITY.users.heavy}` }),
     ).toBeVisible()
-    await page.getByRole("button", { name: "Create budget" }).click()
+    await dialog.getByRole("button", { name: "Create budget" }).click()
 
     const budget = row(page, "Budgets", BUDGET)
     await expect(budget).toContainText("$25.00")
@@ -219,8 +222,9 @@ test.describe("budgets", () => {
     await expect(budget).not.toContainText("No users assigned")
 
     await budget.getByRole("button", { name: "Edit" }).click()
-    await page.getByLabel("Spending limit (USD)").fill("50")
-    await page.getByRole("button", { name: "Save changes" }).click()
+    const editDialog = page.getByRole("dialog")
+    await editDialog.getByLabel("Spending limit (USD)").fill("50")
+    await editDialog.getByRole("button", { name: "Save" }).click()
     await expect(row(page, "Budgets", BUDGET)).toContainText("$50.00")
 
     // Reset history is a per-budget panel, not a page: it opens under the table

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -200,7 +200,9 @@ test.describe("budgets", () => {
     await dialog.getByLabel("Spending limit (USD)").fill("25")
     // Assigning at creation is the path that makes a budget enforceable; a budget
     // with no users caps nothing.
-    const owner = dialog.getByRole("combobox", { name: "Add a person" })
+    const owner = dialog.getByRole("combobox", {
+      name: "Assign to people (optional)",
+    })
     await owner.fill(PARITY.users.heavy)
     // Plain string, not a RegExp built from the id: an address is full of regex
     // metacharacters, so `.` would match any character and the pattern could pick

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -49,6 +49,13 @@ function row(page: Page, ariaLabel: string, name: string | RegExp): Locator {
 // A routing form's model pickers take any selector, so the value is typed rather
 // than chosen. Their popover has to be put away afterwards or it aria-hides the
 // controls below it, including the form's own submit.
+//
+// The page-level dismissal, deliberately, even though this form is a dialog now.
+// The model box does not reopen on focus, so the `blur()` puts it away and the
+// wait passes. The people picker is the one that does: it is `menuTrigger="focus"`,
+// so blurring it inside a modal hands focus back and the popover returns, which
+// is what `dismissComboBoxInDialog` exists for. Move this to that helper if the
+// model box ever opens on focus too.
 async function fillModelBox(
   page: Page,
   name: RegExp,
@@ -209,7 +216,7 @@ test.describe("budgets", () => {
     // a neighbouring option. Playwright matches an accessible name by substring
     // here, which is what an aliased user's "id (alias)" label needs anyway.
     await page.getByRole("option", { name: PARITY.users.heavy }).click()
-    await dismissComboBox(owner)
+    await dismissComboBoxInDialog(owner)
     // The picked user becomes a removable chip, which is the form's own record of
     // who this budget will cap before it is submitted.
     await expect(

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -404,3 +404,17 @@ test.describe("the routing policy dialog", () => {
     await captureScreenshot(page, "routing-create-dialog-fallback")
   })
 })
+
+test.describe("the budget dialog", () => {
+  test("the create dialog", async ({ page }) => {
+    await login(page)
+    await gotoRoute(page, "/budgets")
+    await expect(
+      page.getByRole("heading", { name: /budgets/i }).first(),
+    ).toBeVisible()
+    await page.getByRole("button", { name: "Create budget" }).first().click()
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByLabel("Name (optional)")).toBeVisible()
+    await captureScreenshot(page, "budgets-create-dialog")
+  })
+})

--- a/web/src/design-system/forms/MultiSelect.stories.tsx
+++ b/web/src/design-system/forms/MultiSelect.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+
+import { MultiSelect } from "./MultiSelect"
+
+const PEOPLE = [
+  { id: "operator", label: "Operator" },
+  { id: "alice@example.com", label: "alice@example.com" },
+  { id: "parity-heavy@example.com", label: "parity-heavy@example.com" },
+  { id: "parity-light@example.com", label: "parity-light@example.com" },
+  { id: "pat@example.com", label: "pat@example.com (Pat Okafor)" },
+  { id: "priya@example.com", label: "priya@example.com (Priya Raghavan)" },
+  { id: "sam@example.com", label: "sam@example.com (Sam Iyer)" },
+  { id: "wei@example.com", label: "wei@example.com (Wei Zhang)" },
+]
+
+/**
+ * Pick several without the field moving.
+ *
+ * Controlled, like every other control here, so each story owns the selection it
+ * shows. The interesting states are what the selection does to the layout, so
+ * they differ by how much is picked rather than by a prop.
+ */
+const meta = {
+  title: "Design system/Forms/MultiSelect",
+  component: MultiSelect,
+  parameters: { layout: "padded" },
+  args: {
+    label: "Assign to people (optional)",
+    description:
+      "Everyone selected is held to this budget, each with their own allowance rather than a shared pool.",
+    options: PEOPLE,
+    value: [],
+    onChange: () => {},
+    searchPlaceholder: "Search people…",
+    countNoun: "people assigned",
+  },
+} satisfies Meta<typeof MultiSelect>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function Live({
+  initial,
+  ...args
+}: React.ComponentProps<typeof MultiSelect> & { initial?: string[] }) {
+  const [value, setValue] = useState<string[]>(initial ?? [])
+  return <MultiSelect {...args} value={value} onChange={setValue} />
+}
+
+/** Nothing picked. The field reads as a search box, because that is all it is. */
+export const Empty: Story = {
+  render: (args) => <Live {...args} />,
+}
+
+/**
+ * Six picked. The field has not moved: the chips are below it, so the block
+ * grew downward and the control the operator is pointing at stayed put.
+ */
+export const WithSelection: Story = {
+  render: (args) => (
+    <Live
+      {...args}
+      initial={[
+        "operator",
+        "alice@example.com",
+        "parity-heavy@example.com",
+        "parity-light@example.com",
+        "pat@example.com",
+        "priya@example.com",
+      ]}
+    />
+  ),
+}
+
+/**
+ * The list open. A picked person stays listed with a check rather than
+ * disappearing, so the list answers "who is in" and not only "who is left", and
+ * the row order does not change on a pick.
+ *
+ * Open it and type to see the footer count follow the query. Stories cannot
+ * carry an open popover on their own: it opens on focus, which a static render
+ * has not had.
+ */
+export const Open: Story = {
+  render: (args) => (
+    <Live {...args} initial={["parity-heavy@example.com", "operator"]} />
+  ),
+}
+
+/** A refusal, on the same rung a `Field`'s sits on. */
+export const Invalid: Story = {
+  render: (args) => (
+    <Live
+      {...args}
+      isInvalid
+      errorMessage="Pick at least one person, or leave the budget unassigned."
+      reserveMessage
+    />
+  ),
+}
+
+/**
+ * Nothing matches the query, which is a different sentence from having nothing
+ * to offer: one is about what was typed, the other about the deployment.
+ */
+export const NoMatches: Story = {
+  args: {
+    noMatchesMessage: "Nobody matches what you typed.",
+  },
+  render: (args) => <Live {...args} />,
+}
+
+/** Nothing to offer, which is a different sentence from nothing matching. */
+export const NoOptions: Story = {
+  args: {
+    options: [],
+    emptyMessage:
+      "Nobody to assign yet. Add people under Members & roles, or issue a key, and they can be assigned here.",
+  },
+  render: (args) => <Live {...args} />,
+}

--- a/web/src/design-system/forms/MultiSelect.stories.tsx
+++ b/web/src/design-system/forms/MultiSelect.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { MultiSelect } from "./MultiSelect"
 
@@ -33,7 +33,7 @@ const meta = {
     value: [],
     onChange: () => {},
     searchPlaceholder: "Search people…",
-    countNoun: "people assigned",
+    countNoun: { one: "person assigned", other: "people assigned" },
   },
 } satisfies Meta<typeof MultiSelect>
 
@@ -43,10 +43,32 @@ type Story = StoryObj<typeof meta>
 
 function Live({
   initial,
+  query,
   ...args
-}: React.ComponentProps<typeof MultiSelect> & { initial?: string[] }) {
+}: React.ComponentProps<typeof MultiSelect> & {
+  initial?: string[]
+  /** Typed into the field on mount, for the story that needs a query behind it. */
+  query?: string
+}) {
   const [value, setValue] = useState<string[]>(initial ?? [])
-  return <MultiSelect {...args} value={value} onChange={setValue} />
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!query) return
+    const input = ref.current?.querySelector("input")
+    if (!input) return
+    // Through the native setter, so React sees the change rather than only the
+    // DOM: the same reason the e2e helpers fill controlled inputs this way.
+    Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set?.call(input, query)
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+  }, [query])
+  return (
+    <div ref={ref}>
+      <MultiSelect {...args} value={value} onChange={setValue} />
+    </div>
+  )
 }
 
 /** Nothing picked. The field reads as a search box, because that is all it is. */
@@ -75,17 +97,20 @@ export const WithSelection: Story = {
 }
 
 /**
- * The list open. A picked person stays listed with a check rather than
- * disappearing, so the list answers "who is in" and not only "who is left", and
- * the row order does not change on a pick.
+ * The list open, which `autoFocus` is what makes a static render able to show:
+ * the popover opens on focus. A picked person stays listed with a check rather
+ * than disappearing, so the list answers "who is in" and not only "who is
+ * left", and the row order does not change on a pick.
  *
- * Open it and type to see the footer count follow the query. Stories cannot
- * carry an open popover on their own: it opens on focus, which a static render
- * has not had.
+ * Type to see the footer count follow the query.
  */
 export const Open: Story = {
   render: (args) => (
-    <Live {...args} initial={["parity-heavy@example.com", "operator"]} />
+    <Live
+      {...args}
+      autoFocus
+      initial={["parity-heavy@example.com", "operator"]}
+    />
   ),
 }
 
@@ -108,14 +133,17 @@ export const Invalid: Story = {
 export const NoMatches: Story = {
   args: {
     noMatchesMessage: "Nobody matches what you typed.",
+    // The story is the popover saying it, so it has to be open and querying.
+    autoFocus: true,
   },
-  render: (args) => <Live {...args} />,
+  render: (args) => <Live {...args} query="zzz" />,
 }
 
 /** Nothing to offer, which is a different sentence from nothing matching. */
 export const NoOptions: Story = {
   args: {
     options: [],
+    autoFocus: true,
     emptyMessage:
       "Nobody to assign yet. Add people under Members & roles, or issue a key, and they can be assigned here.",
   },

--- a/web/src/design-system/forms/MultiSelect.stories.tsx
+++ b/web/src/design-system/forms/MultiSelect.stories.tsx
@@ -114,7 +114,11 @@ export const Open: Story = {
   ),
 }
 
-/** A refusal, on the same rung a `Field`'s sits on. */
+/**
+ * A refusal, on the same rung a `Field`'s sits on, and in the description's
+ * place rather than under it: the error replaces that line, so going invalid
+ * moves nothing.
+ */
 export const Invalid: Story = {
   render: (args) => (
     <Live

--- a/web/src/design-system/forms/MultiSelect.test.tsx
+++ b/web/src/design-system/forms/MultiSelect.test.tsx
@@ -174,8 +174,26 @@ describe("MultiSelect", () => {
     expect(screen.getByText(/0 of 3 selected here/)).toBeInTheDocument()
   })
 
-  it("names its description and its error on the control", async () => {
-    render(
+  it("names its description on the control, and its error in that line's place", async () => {
+    // One rung, the way `Field` does it: the error replaces the description
+    // rather than adding a row, so going invalid moves nothing.
+    const { rerender } = render(
+      <MultiSelect
+        label={LABEL}
+        description="Everyone selected is held to this budget."
+        options={PEOPLE}
+        value={[]}
+        onChange={() => {}}
+      />,
+    )
+
+    const described = () => field().getAttribute("aria-describedby") ?? ""
+    expect(described().split(" ").filter(Boolean)).toHaveLength(1)
+    expect(document.getElementById(described())?.textContent).toContain(
+      "held to this budget",
+    )
+
+    rerender(
       <MultiSelect
         label={LABEL}
         description="Everyone selected is held to this budget."
@@ -187,14 +205,12 @@ describe("MultiSelect", () => {
       />,
     )
 
-    const described = field().getAttribute("aria-describedby") ?? ""
-    const ids = described.split(" ").filter(Boolean)
-    expect(ids).toHaveLength(2)
-    const text = ids
-      .map((id) => document.getElementById(id)?.textContent ?? "")
-      .join(" ")
-    expect(text).toContain("held to this budget")
-    expect(text).toContain("Pick at least one person")
+    expect(described().split(" ").filter(Boolean)).toHaveLength(1)
+    expect(document.getElementById(described())?.textContent).toContain(
+      "Pick at least one person",
+    )
+    // Replaced, not joined: the description is gone from the DOM.
+    expect(screen.queryByText(/held to this budget/)).toBeNull()
   })
 
   it("keeps a live region mounted so a change is announced", () => {

--- a/web/src/design-system/forms/MultiSelect.test.tsx
+++ b/web/src/design-system/forms/MultiSelect.test.tsx
@@ -24,7 +24,7 @@ function Live({ initial = [] }: { initial?: string[] }) {
       value={value}
       onChange={setValue}
       searchPlaceholder="Search people…"
-      countNoun="people assigned"
+      countNoun={{ one: "person assigned", other: "people assigned" }}
     />
   )
 }
@@ -112,6 +112,108 @@ describe("MultiSelect", () => {
     expect(onKeyDown).not.toHaveBeenCalled()
   })
 
+  it("swallows Enter while the list is open with nothing to toggle", async () => {
+    // The input sits inside a real form, so an Enter that falls through submits
+    // it: type a query that matches nobody, press Enter, and the enclosing
+    // dialog would create the object with none of this field's work in it.
+    const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault())
+    const user = userEvent.setup()
+    render(
+      <form onSubmit={onSubmit}>
+        <Live />
+      </form>,
+    )
+
+    await user.click(field())
+    await user.type(field(), "zzz")
+    expect(screen.queryAllByRole("option")).toHaveLength(0)
+    await user.keyboard("{Enter}")
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("leaves the list closed when a chip is removed", async () => {
+    // The chips sit outside the popover, so they are pressable while it is
+    // closed. Refocusing the input on every toggle sprang the list open over
+    // the chip row, one extra Escape per removal.
+    const user = userEvent.setup()
+    render(<Live initial={["operator", "alice"]} />)
+
+    await user.click(field())
+    await user.keyboard("{Escape}")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Remove Operator" }))
+
+    expect(within(chips()).getAllByRole("listitem")).toHaveLength(1)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("renders at most `maxVisible` matches and says so", async () => {
+    const many = Array.from({ length: 8 }, (_, index) => ({
+      id: `user-${index}`,
+      label: `person-${index}@example.com`,
+    }))
+    const user = userEvent.setup()
+    render(
+      <MultiSelect
+        label={LABEL}
+        options={many}
+        value={[]}
+        onChange={() => {}}
+        maxVisible={3}
+        countNoun={{ one: "person assigned", other: "people assigned" }}
+      />,
+    )
+
+    await user.click(field())
+    expect(screen.getAllByRole("option")).toHaveLength(3)
+    expect(screen.getByText(/of 3 matches selected of 8/)).toBeInTheDocument()
+  })
+
+  it("names its description and its error on the control", async () => {
+    render(
+      <MultiSelect
+        label={LABEL}
+        description="Everyone selected is held to this budget."
+        options={PEOPLE}
+        value={[]}
+        onChange={() => {}}
+        isInvalid
+        errorMessage="Pick at least one person."
+      />,
+    )
+
+    const described = field().getAttribute("aria-describedby") ?? ""
+    const ids = described.split(" ").filter(Boolean)
+    expect(ids).toHaveLength(2)
+    const text = ids
+      .map((id) => document.getElementById(id)?.textContent ?? "")
+      .join(" ")
+    expect(text).toContain("held to this budget")
+    expect(text).toContain("Pick at least one person")
+  })
+
+  it("keeps a live region mounted so a change is announced", () => {
+    // A region inserted with its content already in it announces nothing, so
+    // one that exists only while the popover is open is silent on the first
+    // count and absent when a chip is removed from the closed state.
+    render(<Live />)
+    const live = document.querySelector('[aria-live="polite"]')
+    expect(live).not.toBeNull()
+    expect(live?.textContent).toBe("0 people assigned")
+  })
+
+  it("pluralizes the count noun", async () => {
+    const user = userEvent.setup()
+    render(<Live />)
+
+    await user.click(field())
+    await user.click(screen.getByRole("option", { name: /Operator/ }))
+
+    expect(screen.getAllByText(/1 person assigned/).length).toBeGreaterThan(0)
+  })
+
   it("filters on the query and counts the matches against the whole selection", async () => {
     const user = userEvent.setup()
     render(<Live initial={["operator"]} />)
@@ -126,7 +228,8 @@ describe("MultiSelect", () => {
     ).toBeInTheDocument()
     // None of the two matches is selected, and one person is assigned overall.
     expect(screen.getByText(/0 of 2 matches selected/)).toBeInTheDocument()
-    expect(screen.getByText(/1 people assigned/)).toBeInTheDocument()
+    // Singular, which is the whole reason the noun is a pair.
+    expect(screen.getAllByText(/1 person assigned/).length).toBeGreaterThan(0)
   })
 
   it("removes the last chip on Backspace with an empty query", async () => {

--- a/web/src/design-system/forms/MultiSelect.test.tsx
+++ b/web/src/design-system/forms/MultiSelect.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { MultiSelect } from "./MultiSelect"
+
+const PEOPLE = [
+  { id: "operator", label: "Operator" },
+  { id: "alice", label: "alice@example.com" },
+  { id: "pat", label: "pat@example.com (Pat Okafor)" },
+  { id: "priya", label: "priya@example.com (Priya Raghavan)" },
+  { id: "parity", label: "parity-heavy@example.com" },
+]
+
+const LABEL = "Assign to people (optional)"
+
+function Live({ initial = [] }: { initial?: string[] }) {
+  const [value, setValue] = useState<string[]>(initial)
+  return (
+    <MultiSelect
+      label={LABEL}
+      options={PEOPLE}
+      value={value}
+      onChange={setValue}
+      searchPlaceholder="Search people…"
+      countNoun="people assigned"
+    />
+  )
+}
+
+const field = () => screen.getByLabelText(LABEL)
+/** The chip row, which is a real list named after the field. */
+const chips = () => screen.getByRole("list", { name: `${LABEL}, selected` })
+
+describe("MultiSelect", () => {
+  it("names the field by its visible label", () => {
+    render(<Live />)
+    expect(field()).toBeInTheDocument()
+    expect(field()).toHaveAttribute("role", "combobox")
+  })
+
+  it("leaves the field where it was when a pick is made", async () => {
+    // The bug this exists for: chips above the field grew the block upward and
+    // pushed the control out from under the pointer. Measured as the field's
+    // own position in the DOM order of its container, which is what moving it
+    // would change.
+    const user = userEvent.setup()
+    render(<Live />)
+
+    await user.click(field())
+    await user.click(screen.getByRole("option", { name: /Operator/ }))
+    await user.click(screen.getByRole("option", { name: /alice/ }))
+
+    expect(within(chips()).getAllByRole("listitem")).toHaveLength(2)
+    // Every chip comes AFTER the field in document order, which is the whole
+    // fix: chips above it grew the block upward and moved the control.
+    for (const chip of within(chips()).getAllByRole("listitem")) {
+      expect(field().compareDocumentPosition(chip)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      )
+    }
+  })
+
+  it("keeps a selected option in the list, checked, and toggles it off", async () => {
+    // The other half: a picked person used to vanish from the list, so the list
+    // only ever showed who was left rather than who was in.
+    const user = userEvent.setup()
+    render(<Live />)
+
+    await user.click(field())
+    const before = screen
+      .getAllByRole("option")
+      .map((option) => option.textContent)
+
+    await user.click(screen.getByRole("option", { name: /Operator/ }))
+
+    const operator = screen.getByRole("option", { name: /Operator/ })
+    expect(operator).toHaveAttribute("aria-selected", "true")
+    // Order is the same list, in the same order: no selected-first re-sort,
+    // which would move rows under the pointer between two presses.
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(before)
+
+    await user.click(operator)
+    expect(screen.getByRole("option", { name: /Operator/ })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    )
+    expect(screen.queryByRole("list", { name: /selected/ })).toBeNull()
+  })
+
+  it("closes the popover on Escape without letting the key travel further", async () => {
+    // Inside a FormDialog, an Escape that reaches the dialog arms its
+    // unsaved-changes guard. Dismissing a list must not do that, so the handler
+    // stops the event rather than only acting on it.
+    const onKeyDown = vi.fn()
+    const user = userEvent.setup()
+    render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: a stand-in for the dialog that would catch this key
+      <div onKeyDown={onKeyDown}>
+        <Live />
+      </div>,
+    )
+
+    await user.click(field())
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+
+    await user.keyboard("{Escape}")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+
+  it("filters on the query and counts the matches against the whole selection", async () => {
+    const user = userEvent.setup()
+    render(<Live initial={["operator"]} />)
+
+    await user.click(field())
+    await user.type(field(), "pa")
+
+    // "pa" reaches two of the five: pat@ and parity-heavy@.
+    expect(screen.getAllByRole("option")).toHaveLength(2)
+    expect(
+      within(screen.getByRole("listbox")).getByText(/Pat Okafor/),
+    ).toBeInTheDocument()
+    // None of the two matches is selected, and one person is assigned overall.
+    expect(screen.getByText(/0 of 2 matches selected/)).toBeInTheDocument()
+    expect(screen.getByText(/1 people assigned/)).toBeInTheDocument()
+  })
+
+  it("removes the last chip on Backspace with an empty query", async () => {
+    const user = userEvent.setup()
+    render(<Live initial={["operator", "alice"]} />)
+
+    await user.click(field())
+    await user.keyboard("{Backspace}")
+
+    expect(within(chips()).getAllByRole("listitem")).toHaveLength(1)
+    expect(within(chips()).getByText("Operator")).toBeInTheDocument()
+  })
+
+  it("moves the active option with the arrows and toggles it with Enter", async () => {
+    const user = userEvent.setup()
+    render(<Live />)
+
+    await user.click(field())
+    await user.keyboard("{ArrowDown}")
+    await user.keyboard("{Enter}")
+
+    expect(screen.getByRole("option", { name: /alice/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    )
+  })
+})

--- a/web/src/design-system/forms/MultiSelect.test.tsx
+++ b/web/src/design-system/forms/MultiSelect.test.tsx
@@ -168,7 +168,10 @@ describe("MultiSelect", () => {
 
     await user.click(field())
     expect(screen.getAllByRole("option")).toHaveLength(3)
-    expect(screen.getByText(/of 3 matches selected of 8/)).toBeInTheDocument()
+    // Two clauses, not one nested sentence: what is shown, then what is
+    // picked among it.
+    expect(screen.getByText(/Showing 3 of 8/)).toBeInTheDocument()
+    expect(screen.getByText(/0 of 3 selected here/)).toBeInTheDocument()
   })
 
   it("names its description and its error on the control", async () => {
@@ -227,7 +230,7 @@ describe("MultiSelect", () => {
       within(screen.getByRole("listbox")).getByText(/Pat Okafor/),
     ).toBeInTheDocument()
     // None of the two matches is selected, and one person is assigned overall.
-    expect(screen.getByText(/0 of 2 matches selected/)).toBeInTheDocument()
+    expect(screen.getByText(/0 of 2 selected here/)).toBeInTheDocument()
     // Singular, which is the whole reason the noun is a pair.
     expect(screen.getAllByText(/1 person assigned/).length).toBeGreaterThan(0)
   })

--- a/web/src/design-system/forms/MultiSelect.tsx
+++ b/web/src/design-system/forms/MultiSelect.tsx
@@ -224,11 +224,6 @@ export function MultiSelect({
       <label htmlFor={inputId} className="text-body">
         {label}
       </label>
-      {description ? (
-        <p id={descriptionId} className="text-caption">
-          {description}
-        </p>
-      ) : null}
       {/* `relative` so the popover hangs off the field rather than off the
           dialog, and the chips below it stay in flow. */}
       <div ref={wrapperRef} className="relative flex flex-col gap-1.5">
@@ -246,13 +241,14 @@ export function MultiSelect({
             // Wired by hand, because this does not go through HeroUI's
             // Description and FieldError slots: without it a screen reader
             // says "invalid" and never says why.
+            // Whichever line is actually rendered, since the error replaces
+            // the description rather than joining it.
             aria-describedby={
-              [
-                description ? descriptionId : null,
-                isInvalid && errorMessage ? errorId : null,
-              ]
-                .filter(Boolean)
-                .join(" ") || undefined
+              isInvalid && errorMessage
+                ? errorId
+                : description
+                  ? descriptionId
+                  : undefined
             }
             className={`${INPUT_CLASS} w-full pr-9`}
             // The closed field says how many are in rather than staying blank,
@@ -420,10 +416,19 @@ export function MultiSelect({
       <span aria-live="polite" className="sr-only">
         {counted(value.length)}
       </span>
+      {/* One rung, below the control, the way `Field` does it: the error
+          replaces the description rather than adding a row. Below the chips
+          rather than above the field, because that is where a `Field` puts it
+          and a dialog full of `Field`s should not have one control speaking
+          from somewhere else. */}
       <FieldMessages reserve={reserveMessage}>
         {isInvalid && errorMessage ? (
           <span id={errorId} className="text-danger">
             {errorMessage}
+          </span>
+        ) : description ? (
+          <span id={descriptionId} className="text-muted">
+            {description}
           </span>
         ) : null}
       </FieldMessages>

--- a/web/src/design-system/forms/MultiSelect.tsx
+++ b/web/src/design-system/forms/MultiSelect.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useId, useRef, useState } from "react"
+import { type ReactNode, useEffect, useId, useRef, useState } from "react"
 import { FiCheck, FiChevronDown } from "react-icons/fi"
 
 import { DismissChip } from "../indicators/DismissChip"
@@ -86,12 +86,38 @@ export function MultiSelect({
   const [query, setQuery] = useState("")
   const [isOpen, setIsOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState(0)
-  const inputRef = useRef<HTMLInputElement>(null)
+  // The control's own box, which is what "focus left this control" means. Held
+  // as a ref rather than walked up from the input, so wrapping the input in one
+  // more div cannot silently close the popover before an option press lands.
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  // The list, so the active option can be scrolled into view: the popover shows
+  // six rows and the cap renders fifty, so the highlight walks off the bottom.
+  const listRef = useRef<HTMLDivElement>(null)
   const listId = useId()
   const inputId = useId()
   const descriptionId = useId()
   const errorId = useId()
   const optionId = (index: number) => `${listId}-option-${index}`
+
+  // The popover shows six rows and renders up to `maxVisible`, so the active
+  // row walks past the fold on its own. Scrolled here rather than by the row,
+  // because only the list knows which one is active.
+  useEffect(() => {
+    if (!isOpen) return
+    // The id is spelled here rather than through `optionId`, which is a fresh
+    // arrow every render and so cannot be a dependency.
+    const active = listRef.current?.querySelector(
+      `[id="${listId}-option-${activeIndex}"]`,
+    )
+    // Guarded because jsdom implements no layout and so no `scrollIntoView`;
+    // the tests below drive the arrows and would throw on the first press.
+    if (
+      active instanceof HTMLElement &&
+      typeof active.scrollIntoView === "function"
+    ) {
+      active.scrollIntoView({ block: "nearest" })
+    }
+  }, [isOpen, activeIndex, listId])
 
   const needle = query.trim().toLowerCase()
   // Filtered, never re-ordered: a selected row keeps its place, so a second
@@ -156,8 +182,12 @@ export function MultiSelect({
       if (!isOpen) return
       // Before the row lookup, not after: an open combo box owns Enter whether
       // or not it has a row to give, and this input sits inside a real form, so
-      // falling through submits it.
+      // falling through submits it. Stopped as well as prevented, because
+      // `FormDialog` submits on Cmd/Ctrl+Enter from anywhere inside the form:
+      // without this, one gesture toggles a row and posts the selection from
+      // before that toggle.
       event.preventDefault()
+      event.stopPropagation()
       const option = matches[activeIndex]
       if (!option) return
       toggle(option.id)
@@ -201,10 +231,9 @@ export function MultiSelect({
       ) : null}
       {/* `relative` so the popover hangs off the field rather than off the
           dialog, and the chips below it stay in flow. */}
-      <div className="relative flex flex-col gap-1.5">
+      <div ref={wrapperRef} className="relative flex flex-col gap-1.5">
         <div className="relative">
           <input
-            ref={inputRef}
             id={inputId}
             role="combobox"
             aria-expanded={isOpen}
@@ -245,11 +274,7 @@ export function MultiSelect({
               // Only when focus actually left the control: a press on an option
               // blurs the input and must not close the list before the press
               // lands.
-              if (
-                !event.currentTarget.parentElement?.parentElement?.contains(
-                  event.relatedTarget,
-                )
-              ) {
+              if (!wrapperRef.current?.contains(event.relatedTarget)) {
                 setIsOpen(false)
               }
             }}
@@ -267,6 +292,7 @@ export function MultiSelect({
                 both a lint error and a second, conflicting announcement. The
                 chip row below IS a real list, because that one is a list. */}
             <div
+              ref={listRef}
               id={listId}
               role="listbox"
               aria-multiselectable
@@ -274,11 +300,13 @@ export function MultiSelect({
               // carrying one name is three things a screen reader cannot tell
               // apart, and it is what a query for the field then finds.
               aria-label={`${label}, options`}
-              // Six rows before it scrolls, each at the 44px touch floor
-              // (motion-and-access.md: "44px is the floor, everywhere"), so
-              // 6 x 44px = 264px = `max-h-66`. A class rather than an inline
-              // style: the arithmetic is a compile-time constant.
-              className="max-h-66 overflow-y-auto"
+              // Six rows before it scrolls. Each is 44px, the touch floor
+              // (motion-and-access.md: "44px is the floor, everywhere"), and
+              // all but the first carry a 1px rule, so six of them are
+              // 6 x 44 + 5 = 269px. `max-h-[16.8125rem]` rather than the 264px
+              // the rows alone would suggest, which clipped the sixth by 5px.
+              // A class rather than an inline style: it is a constant.
+              className="max-h-[16.8125rem] overflow-y-auto"
             >
               {matches.length === 0 ? (
                 <p className="text-caption px-2.5 py-2">
@@ -353,9 +381,13 @@ export function MultiSelect({
               )}
             </div>
             <div className="border-border text-mono-caption text-subtle flex h-8 items-center justify-between border-t px-2.5">
+              {/* Two facts, two clauses. Nested, they read as one garbled
+                  sentence: "0 of 3 matches selected of 8". */}
               <span>
-                {selectedMatches} of {matches.length} matches selected
-                {capped ? ` of ${reached.length}` : ""} ·{" "}
+                {capped
+                  ? `Showing ${matches.length} of ${reached.length} · `
+                  : ""}
+                {selectedMatches} of {matches.length} selected here ·{" "}
                 {counted(value.length)}
               </span>
               <span>ESC closes</span>

--- a/web/src/design-system/forms/MultiSelect.tsx
+++ b/web/src/design-system/forms/MultiSelect.tsx
@@ -10,8 +10,8 @@ export interface MultiSelectOption {
   label: string
 }
 
-/** Six rows at 36px, which is where the list starts scrolling. */
-const MAX_VISIBLE_ROWS = 6
+/** How many matches are rendered at once, however many the query reaches. */
+const DEFAULT_MAX_VISIBLE = 50
 
 /**
  * Pick several from a searchable list, without the field moving.
@@ -43,7 +43,9 @@ export function MultiSelect({
   searchPlaceholder = "Search…",
   emptyMessage = "Nothing to choose from.",
   noMatchesMessage = "Nothing matches what you typed.",
-  countNoun = "selected",
+  countNoun = { one: "selected", other: "selected" },
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  autoFocus,
 }: {
   label: string
   description?: ReactNode
@@ -59,8 +61,20 @@ export function MultiSelect({
   emptyMessage?: ReactNode
   /** Shown when the query matches none of the options. */
   noMatchesMessage?: ReactNode
-  /** Pluralized into the closed field and the footer: "6 people assigned". */
-  countNoun?: string
+  /**
+   * Pluralized into the closed field and the footer: "1 person assigned",
+   * "6 people assigned". A pair rather than one string, because interpolating
+   * one noun into both counts is how "1 people assigned" ships.
+   */
+  countNoun?: { one: string; other: string }
+  /**
+   * How many matches to render. The filter runs over every option; this caps
+   * what is mounted, because a deployment's roster is unbounded and the popover
+   * is inside a modal. The footer says when it is capping.
+   */
+  maxVisible?: number
+  /** A form's first field takes this; see feedback.md. */
+  autoFocus?: boolean
 }) {
   const [query, setQuery] = useState("")
   const [isOpen, setIsOpen] = useState(false)
@@ -68,32 +82,44 @@ export function MultiSelect({
   const inputRef = useRef<HTMLInputElement>(null)
   const listId = useId()
   const inputId = useId()
+  const descriptionId = useId()
+  const errorId = useId()
   const optionId = (index: number) => `${listId}-option-${index}`
 
   const needle = query.trim().toLowerCase()
   // Filtered, never re-ordered: a selected row keeps its place, so a second
   // press lands on the row the first one did.
-  const matches = options.filter(
+  const reached = options.filter(
     (option) =>
       needle === "" ||
       option.id.toLowerCase().includes(needle) ||
       option.label.toLowerCase().includes(needle),
   )
+  // Capped after the filter, never before: the query has to see every option,
+  // and only the rendering is bounded.
+  const matches = reached.slice(0, maxVisible)
+  const capped = reached.length > matches.length
   const selectedMatches = matches.filter((option) =>
     value.includes(option.id),
   ).length
   const labelOf = (id: string) =>
     options.find((option) => option.id === id)?.label ?? id
+  const counted = (n: number) =>
+    `${n} ${n === 1 ? countNoun.one : countNoun.other}`
 
+  // The query survives a pick. Clearing it would refill the list under the
+  // pointer, which is the same movement the chips were moved to avoid.
+  //
+  // No refocus here: a chip's Remove button calls this while the popover is
+  // closed, and focusing the input would reopen the list over the chip row. An
+  // option press keeps focus anyway, because its `onMouseDown` prevents the
+  // default that would have moved it.
   const toggle = (id: string) => {
     onChange(
       value.includes(id)
         ? value.filter((current) => current !== id)
         : [...value, id],
     )
-    // The query survives a pick. Clearing it would refill the list under the
-    // pointer, which is the same movement the chips were moved to avoid.
-    inputRef.current?.focus()
   }
 
   const open = () => {
@@ -120,10 +146,20 @@ export function MultiSelect({
       // somebody is typing into a name.
       if (event.key === " " && query !== "") return
       if (!isOpen) return
+      // Before the row lookup, not after: an open combo box owns Enter whether
+      // or not it has a row to give, and this input sits inside a real form, so
+      // falling through submits it.
+      event.preventDefault()
       const option = matches[activeIndex]
       if (!option) return
-      event.preventDefault()
       toggle(option.id)
+      return
+    }
+    if (event.key === "Tab" && isOpen) {
+      // Closed rather than trapped: the APG pattern dismisses the popup on Tab,
+      // and leaving it open puts the focus ring on a chip's Remove button drawn
+      // underneath the panel.
+      setIsOpen(false)
       return
     }
     if (event.key === "Escape" && isOpen) {
@@ -150,7 +186,11 @@ export function MultiSelect({
       <label htmlFor={inputId} className="text-body">
         {label}
       </label>
-      {description ? <p className="text-caption">{description}</p> : null}
+      {description ? (
+        <p id={descriptionId} className="text-caption">
+          {description}
+        </p>
+      ) : null}
       {/* `relative` so the popover hangs off the field rather than off the
           dialog, and the chips below it stay in flow. */}
       <div className="relative flex flex-col gap-1.5">
@@ -166,16 +206,27 @@ export function MultiSelect({
               isOpen && matches[activeIndex] ? optionId(activeIndex) : undefined
             }
             aria-invalid={isInvalid}
+            // Wired by hand, because this does not go through HeroUI's
+            // Description and FieldError slots: without it a screen reader
+            // says "invalid" and never says why.
+            aria-describedby={
+              [
+                description ? descriptionId : null,
+                isInvalid && errorMessage ? errorId : null,
+              ]
+                .filter(Boolean)
+                .join(" ") || undefined
+            }
             className={`${INPUT_CLASS} w-full pr-9`}
             // The closed field says how many are in rather than staying blank,
             // because the chips below it can be scrolled past in a long form.
             placeholder={
-              value.length === 0
-                ? searchPlaceholder
-                : `${value.length} ${countNoun}`
+              value.length === 0 ? searchPlaceholder : counted(value.length)
             }
             value={query}
             autoComplete="off"
+            // biome-ignore lint/a11y/noAutofocus: a form's first field takes it; see feedback.md
+            autoFocus={autoFocus}
             onChange={(event) => {
               setQuery(event.target.value)
               setActiveIndex(0)
@@ -215,8 +266,11 @@ export function MultiSelect({
               // carrying one name is three things a screen reader cannot tell
               // apart, and it is what a query for the field then finds.
               aria-label={`${label}, options`}
-              className="overflow-y-auto"
-              style={{ maxHeight: `${MAX_VISIBLE_ROWS * 36}px` }}
+              // Six rows before it scrolls, each at the 44px touch floor
+              // (motion-and-access.md: "44px is the floor, everywhere"), so
+              // 6 x 44px = 264px = `max-h-66`. A class rather than an inline
+              // style: the arithmetic is a compile-time constant.
+              className="max-h-66 overflow-y-auto"
             >
               {matches.length === 0 ? (
                 <p className="text-caption px-2.5 py-2">
@@ -247,12 +301,19 @@ export function MultiSelect({
                         toggle(option.id)
                       }}
                       onMouseEnter={() => setActiveIndex(index)}
-                      className={`flex h-9 cursor-pointer items-center gap-2.5 border-border-subtle px-2.5 text-sm not-first:border-t ${
-                        // `surface-alt`, not `surface-muted`: the two resolve
-                        // to the same value, and only this one is registered in
-                        // @theme, so only this one emits a rule.
-                        isSelected ? "bg-surface-alt" : ""
-                      } ${index === activeIndex ? "bg-surface-subtle" : ""}`}
+                      // One background, picked here. Two classes on one element
+                      // are resolved by Tailwind's emitted order rather than by
+                      // the order they are written in, which `inputClass.ts`
+                      // documents as a hazard. `surface-alt` rather than
+                      // `surface-muted`: the two resolve to the same value and
+                      // only this one is registered in @theme.
+                      className={`flex min-h-11 cursor-pointer items-center gap-2.5 border-border-subtle px-2.5 text-sm not-first:border-t ${
+                        index === activeIndex
+                          ? "bg-surface-subtle"
+                          : isSelected
+                            ? "bg-surface-alt"
+                            : ""
+                      }`}
                     >
                       <span className="flex size-4 shrink-0 items-center justify-center">
                         {isSelected ? (
@@ -266,9 +327,10 @@ export function MultiSelect({
               )}
             </div>
             <div className="border-border text-mono-caption text-subtle flex h-8 items-center justify-between border-t px-2.5">
-              <span aria-live="polite">
-                {selectedMatches} of {matches.length} matches selected ·{" "}
-                {value.length} {countNoun}
+              <span>
+                {selectedMatches} of {matches.length} matches selected
+                {capped ? ` of ${reached.length}` : ""} ·{" "}
+                {counted(value.length)}
               </span>
               <span>ESC closes</span>
             </div>
@@ -293,9 +355,18 @@ export function MultiSelect({
           </ul>
         ) : null}
       </div>
+      {/* Mounted whatever the popover is doing. A live region inserted with
+          its content already in it announces nothing, so a region that only
+          exists while the list is open is silent on the first count and absent
+          when a chip is removed from the closed state. */}
+      <span aria-live="polite" className="sr-only">
+        {counted(value.length)}
+      </span>
       <FieldMessages reserve={reserveMessage}>
         {isInvalid && errorMessage ? (
-          <span className="text-danger">{errorMessage}</span>
+          <span id={errorId} className="text-danger">
+            {errorMessage}
+          </span>
         ) : null}
       </FieldMessages>
     </div>

--- a/web/src/design-system/forms/MultiSelect.tsx
+++ b/web/src/design-system/forms/MultiSelect.tsx
@@ -1,0 +1,303 @@
+import { type ReactNode, useId, useRef, useState } from "react"
+import { FiCheck, FiChevronDown } from "react-icons/fi"
+
+import { DismissChip } from "../indicators/DismissChip"
+import { FieldMessages } from "./FieldMessages"
+import { INPUT_CLASS } from "./inputClass"
+
+export interface MultiSelectOption {
+  id: string
+  label: string
+}
+
+/** Six rows at 36px, which is where the list starts scrolling. */
+const MAX_VISIBLE_ROWS = 6
+
+/**
+ * Pick several from a searchable list, without the field moving.
+ *
+ * The form-grade half of the pair `forms.md` describes: `FilterMultiComboBox` is
+ * the toolbar one and stays. Two things make this the form's, and both are the
+ * bug it was built for. The search field is at the top and never moves, because
+ * the chips render *below* it, so a growing selection pushes down rather than
+ * shoving the field out from under the pointer. And a selected option stays in
+ * the list, checked, so the list answers "who is in" rather than only "who is
+ * left"; pressing it again removes it, and the order never re-sorts on a pick.
+ *
+ * A combo box with a listbox popup, hand-rolled to the APG pattern rather than
+ * built on HeroUI's `ComboBox`: that one selects a single value and closes, and
+ * every behavior here that matters (toggle, stay listed, Escape closing only the
+ * popover) is a departure from it. Focus stays in the input the whole time and
+ * the active option travels by `aria-activedescendant`, which is what lets the
+ * arrows move a highlight while the query keeps taking keystrokes.
+ */
+export function MultiSelect({
+  label,
+  description,
+  options,
+  value,
+  onChange,
+  isInvalid,
+  errorMessage,
+  reserveMessage,
+  searchPlaceholder = "Search…",
+  emptyMessage = "Nothing to choose from.",
+  noMatchesMessage = "Nothing matches what you typed.",
+  countNoun = "selected",
+}: {
+  label: string
+  description?: ReactNode
+  options: readonly MultiSelectOption[]
+  value: readonly string[]
+  onChange: (next: string[]) => void
+  isInvalid?: boolean
+  errorMessage?: ReactNode
+  reserveMessage?: boolean
+  /** The closed field's text while nothing is picked. */
+  searchPlaceholder?: string
+  /** Shown in the popover when there is nothing to offer at all. */
+  emptyMessage?: ReactNode
+  /** Shown when the query matches none of the options. */
+  noMatchesMessage?: ReactNode
+  /** Pluralized into the closed field and the footer: "6 people assigned". */
+  countNoun?: string
+}) {
+  const [query, setQuery] = useState("")
+  const [isOpen, setIsOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listId = useId()
+  const inputId = useId()
+  const optionId = (index: number) => `${listId}-option-${index}`
+
+  const needle = query.trim().toLowerCase()
+  // Filtered, never re-ordered: a selected row keeps its place, so a second
+  // press lands on the row the first one did.
+  const matches = options.filter(
+    (option) =>
+      needle === "" ||
+      option.id.toLowerCase().includes(needle) ||
+      option.label.toLowerCase().includes(needle),
+  )
+  const selectedMatches = matches.filter((option) =>
+    value.includes(option.id),
+  ).length
+  const labelOf = (id: string) =>
+    options.find((option) => option.id === id)?.label ?? id
+
+  const toggle = (id: string) => {
+    onChange(
+      value.includes(id)
+        ? value.filter((current) => current !== id)
+        : [...value, id],
+    )
+    // The query survives a pick. Clearing it would refill the list under the
+    // pointer, which is the same movement the chips were moved to avoid.
+    inputRef.current?.focus()
+  }
+
+  const open = () => {
+    setIsOpen(true)
+    setActiveIndex(0)
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault()
+      if (!isOpen) {
+        open()
+        return
+      }
+      if (matches.length === 0) return
+      const step = event.key === "ArrowDown" ? 1 : -1
+      setActiveIndex(
+        (current) => (current + step + matches.length) % matches.length,
+      )
+      return
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      // Space only toggles when the query is empty; otherwise it is a character
+      // somebody is typing into a name.
+      if (event.key === " " && query !== "") return
+      if (!isOpen) return
+      const option = matches[activeIndex]
+      if (!option) return
+      event.preventDefault()
+      toggle(option.id)
+      return
+    }
+    if (event.key === "Escape" && isOpen) {
+      // Stopped here rather than allowed to bubble: this dialog's own Escape
+      // closes the dialog, and dismissing a popover must not also throw away
+      // the form behind it.
+      event.preventDefault()
+      event.stopPropagation()
+      setIsOpen(false)
+      return
+    }
+    if (event.key === "Backspace" && query === "" && value.length > 0) {
+      onChange(value.slice(0, -1))
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {/* A real label with `htmlFor`, not HeroUI's `Label`: that one resolves
+          its target through a field context this control is not inside, so it
+          would render the words and name nothing. The visible text IS the
+          accessible name here, which is why there is no `aria-label` beside
+          it. */}
+      <label htmlFor={inputId} className="text-body">
+        {label}
+      </label>
+      {description ? <p className="text-caption">{description}</p> : null}
+      {/* `relative` so the popover hangs off the field rather than off the
+          dialog, and the chips below it stay in flow. */}
+      <div className="relative flex flex-col gap-1.5">
+        <div className="relative">
+          <input
+            ref={inputRef}
+            id={inputId}
+            role="combobox"
+            aria-expanded={isOpen}
+            aria-controls={listId}
+            aria-autocomplete="list"
+            aria-activedescendant={
+              isOpen && matches[activeIndex] ? optionId(activeIndex) : undefined
+            }
+            aria-invalid={isInvalid}
+            className={`${INPUT_CLASS} w-full pr-9`}
+            // The closed field says how many are in rather than staying blank,
+            // because the chips below it can be scrolled past in a long form.
+            placeholder={
+              value.length === 0
+                ? searchPlaceholder
+                : `${value.length} ${countNoun}`
+            }
+            value={query}
+            autoComplete="off"
+            onChange={(event) => {
+              setQuery(event.target.value)
+              setActiveIndex(0)
+              setIsOpen(true)
+            }}
+            onFocus={open}
+            onBlur={(event) => {
+              // Only when focus actually left the control: a press on an option
+              // blurs the input and must not close the list before the press
+              // lands.
+              if (
+                !event.currentTarget.parentElement?.parentElement?.contains(
+                  event.relatedTarget,
+                )
+              ) {
+                setIsOpen(false)
+              }
+            }}
+            onKeyDown={onKeyDown}
+          />
+          <FiChevronDown
+            aria-hidden
+            className="text-muted pointer-events-none absolute top-1/2 right-3 size-3 -translate-y-1/2"
+          />
+        </div>
+        {isOpen ? (
+          <div className="border-control-border bg-surface absolute top-full right-0 left-0 z-10 mt-1 border">
+            {/* Divs rather than a ul/li pair: the roles are what carry the
+                semantics here, and a list element with an interactive role is
+                both a lint error and a second, conflicting announcement. The
+                chip row below IS a real list, because that one is a list. */}
+            <div
+              id={listId}
+              role="listbox"
+              aria-multiselectable
+              // Named apart from the field and from the chip row: three things
+              // carrying one name is three things a screen reader cannot tell
+              // apart, and it is what a query for the field then finds.
+              aria-label={`${label}, options`}
+              className="overflow-y-auto"
+              style={{ maxHeight: `${MAX_VISIBLE_ROWS * 36}px` }}
+            >
+              {matches.length === 0 ? (
+                <p className="text-caption px-2.5 py-2">
+                  {options.length === 0 ? emptyMessage : noMatchesMessage}
+                </p>
+              ) : (
+                matches.map((option, index) => {
+                  const isSelected = value.includes(option.id)
+                  return (
+                    <div
+                      key={option.id}
+                      id={optionId(index)}
+                      role="option"
+                      aria-selected={isSelected}
+                      // Not tabbable, and deliberately not focused either: the
+                      // input keeps focus and `aria-activedescendant` points at
+                      // the active row. -1 is what the option needs to be a
+                      // legal target for that.
+                      tabIndex={-1}
+                      // Pressed rather than clicked through a button: the row is
+                      // the option, and a button inside it would be a second
+                      // stop for a keyboard that is already driving the list
+                      // from the input.
+                      onMouseDown={(event) => {
+                        // Before blur, so the press is not lost to the list
+                        // closing under it.
+                        event.preventDefault()
+                        toggle(option.id)
+                      }}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      className={`flex h-9 cursor-pointer items-center gap-2.5 border-border-subtle px-2.5 text-sm not-first:border-t ${
+                        // `surface-alt`, not `surface-muted`: the two resolve
+                        // to the same value, and only this one is registered in
+                        // @theme, so only this one emits a rule.
+                        isSelected ? "bg-surface-alt" : ""
+                      } ${index === activeIndex ? "bg-surface-subtle" : ""}`}
+                    >
+                      <span className="flex size-4 shrink-0 items-center justify-center">
+                        {isSelected ? (
+                          <FiCheck aria-hidden className="text-accent size-3" />
+                        ) : null}
+                      </span>
+                      {option.label}
+                    </div>
+                  )
+                })
+              )}
+            </div>
+            <div className="border-border text-mono-caption text-subtle flex h-8 items-center justify-between border-t px-2.5">
+              <span aria-live="polite">
+                {selectedMatches} of {matches.length} matches selected ·{" "}
+                {value.length} {countNoun}
+              </span>
+              <span>ESC closes</span>
+            </div>
+          </div>
+        ) : null}
+        {value.length > 0 ? (
+          // Below the field, which is the whole point: a growing selection
+          // pushes down rather than moving the control it grew from.
+          <ul
+            aria-label={`${label}, selected`}
+            className="flex list-none flex-wrap gap-x-2 gap-y-1.5 pt-0.5"
+          >
+            {value.map((id) => (
+              <li key={id}>
+                <DismissChip
+                  value={labelOf(id)}
+                  onDismiss={() => toggle(id)}
+                  dismissLabel={`Remove ${labelOf(id)}`}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      <FieldMessages reserve={reserveMessage}>
+        {isInvalid && errorMessage ? (
+          <span className="text-danger">{errorMessage}</span>
+        ) : null}
+      </FieldMessages>
+    </div>
+  )
+}

--- a/web/src/design-system/forms/MultiSelect.tsx
+++ b/web/src/design-system/forms/MultiSelect.tsx
@@ -8,6 +8,13 @@ import { INPUT_CLASS } from "./inputClass"
 export interface MultiSelectOption {
   id: string
   label: string
+  /**
+   * A second, muted line inside the row, for text that identifies the label
+   * rather than repeating it, such as the id a person is billed under. It joins
+   * the row's accessible name, since it is what tells two rows with one label
+   * apart. Same shape and same treatment as `ComboBoxField`'s.
+   */
+  hint?: string
 }
 
 /** How many matches are rendered at once, however many the query reaches. */
@@ -93,7 +100,8 @@ export function MultiSelect({
     (option) =>
       needle === "" ||
       option.id.toLowerCase().includes(needle) ||
-      option.label.toLowerCase().includes(needle),
+      option.label.toLowerCase().includes(needle) ||
+      (option.hint?.toLowerCase().includes(needle) ?? false),
   )
   // Capped after the filter, never before: the query has to see every option,
   // and only the rendering is bounded.
@@ -285,6 +293,11 @@ export function MultiSelect({
                       id={optionId(index)}
                       role="option"
                       aria-selected={isSelected}
+                      aria-label={
+                        option.hint
+                          ? `${option.label} (${option.hint})`
+                          : undefined
+                      }
                       // Not tabbable, and deliberately not focused either: the
                       // input keeps focus and `aria-activedescendant` points at
                       // the active row. -1 is what the option needs to be a
@@ -320,7 +333,20 @@ export function MultiSelect({
                           <FiCheck aria-hidden className="text-accent size-3" />
                         ) : null}
                       </span>
-                      {option.label}
+                      {/* Spelled out when there is a hint, because the row has
+                          two text nodes and the name computed from them runs
+                          the hint onto the end of the label with no separator.
+                          The hint belongs in the name rather than being dropped
+                          from it: it is what tells two rows with one label
+                          apart. `ComboBoxField` does this the same way. */}
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate">{option.label}</span>
+                        {option.hint ? (
+                          <span className="text-caption text-subtle truncate">
+                            {option.hint}
+                          </span>
+                        ) : null}
+                      </span>
                     </div>
                   )
                 })

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { act, render, screen, within } from "@testing-library/react"
+import { act, render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -350,6 +350,39 @@ describe("BudgetsPage", () => {
     expect(JSON.parse(String(patch[1]?.body))).toEqual({
       budget_id: "new-budget-id-0000-0000-000000000000",
     })
+  })
+
+  it("seeds a fresh draft from either opener, header or empty state", async () => {
+    // Keying the create dialog on an open counter is only correct while every
+    // opener bumps it, and this page has two: the heading's Create budget and
+    // the empty state's Create your first budget. A missed one opens on the
+    // last draft, which here is a duplicate budget one press away.
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create your first budget" }),
+    )
+    await user.type(screen.getByLabelText("Name (optional)"), "team-a")
+    // A typed draft is dirty, so leaving goes through the guard.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Create budget" }))
+    expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
+
+    // And back the other way, so neither opener is the only one asserted.
+    await user.type(screen.getByLabelText("Name (optional)"), "team-b")
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(
+      screen.getByRole("button", { name: "Create your first budget" }),
+    )
+    expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
   })
 
   it("keeps failed initial assignments retryable without creating another budget", async () => {

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -329,7 +329,10 @@ describe("BudgetsPage", () => {
     )
     await user.type(screen.getByLabelText("Spending limit (USD)"), "100")
     // Pick a user from the assignment combobox, then submit.
-    await user.type(screen.getByLabelText("Add a person"), "alice")
+    await user.type(
+      screen.getByLabelText("Assign to people (optional)"),
+      "alice",
+    )
     await user.click(await screen.findByRole("option", { name: /alice/ }))
     await user.keyboard("{Escape}")
     await user.click(screen.getByRole("button", { name: "Create budget" }))
@@ -361,7 +364,10 @@ describe("BudgetsPage", () => {
     await user.click(
       await screen.findByRole("button", { name: "Create your first budget" }),
     )
-    await user.type(screen.getByLabelText("Add a person"), "alice")
+    await user.type(
+      screen.getByLabelText("Assign to people (optional)"),
+      "alice",
+    )
     await user.click(await screen.findByRole("option", { name: /alice/ }))
     await user.keyboard("{Escape}")
     await user.click(screen.getByRole("button", { name: "Create budget" }))
@@ -403,7 +409,10 @@ describe("BudgetsPage", () => {
     await user.click(
       await screen.findByRole("button", { name: "Create your first budget" }),
     )
-    await user.type(screen.getByLabelText("Add a person"), "alice")
+    await user.type(
+      screen.getByLabelText("Assign to people (optional)"),
+      "alice",
+    )
     await user.click(await screen.findByRole("option", { name: /alice/ }))
     await user.keyboard("{Escape}")
     await user.click(screen.getByRole("button", { name: "Create budget" }))

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -466,6 +466,50 @@ describe("BudgetsPage", () => {
     expect(budgetPosts).toHaveLength(1)
   })
 
+  it("closes the form when a retried assignment finally succeeds", async () => {
+    // The retry's answer is what decides whether the form is done, so it has to
+    // be awaited. Left open, `pendingAssignments` clears the moment the
+    // assignments land, the label reverts to "Create budget", and the next
+    // press creates a second budget for the same people.
+    let patches = 0
+    const fetchMock = mockApi({
+      budgets: [],
+      users: [testUser("alice")],
+      updateUser: () => {
+        patches += 1
+        return patches === 1
+          ? jsonResponse({ detail: "User update failed" }, 500)
+          : jsonResponse(testUser("alice"))
+      },
+    })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create your first budget" }),
+    )
+    await user.type(
+      screen.getByLabelText("Assign to people (optional)"),
+      "alice",
+    )
+    await user.click(await screen.findByRole("option", { name: /alice/ }))
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Create budget" }))
+
+    expect(
+      await screen.findByText(/these people were not updated: alice/),
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Retry assignments" }))
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    const budgetPosts = fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).includes(`${API_ROOT}/budgets`) &&
+        (init?.method ?? "") === "POST",
+    )
+    expect(budgetPosts).toHaveLength(1)
+  })
+
   it("prevents closing the form while initial user assignments are pending", async () => {
     let resolveUserUpdate: ((response: Response) => void) | undefined
     const userUpdate = new Promise<Response>((resolve) => {

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -69,6 +69,8 @@ function mockApi(
     users?: User[]
     /** What a create answers with, for the case that drives a refusal. */
     createBudget?: () => Response
+    /** The same, for an edit. */
+    updateBudget?: () => Response
     failedUserUpdates?: string[]
     updateUser?: (userId: string) => Response | Promise<Response>
     // Who is asking, which is what decides which of the two pages this route
@@ -119,6 +121,7 @@ function mockApi(
           return jsonResponse(row)
         }
         if (method === "PATCH") {
+          if (opts.updateBudget) return opts.updateBudget()
           const id = decodeURIComponent(url.split("/").pop() ?? "")
           const body = JSON.parse(String(init?.body)) as Partial<Budget>
           list = list.map((b) => (b.budget_id === id ? { ...b, ...body } : b))
@@ -386,6 +389,116 @@ describe("BudgetsPage", () => {
       screen.getByRole("button", { name: "Create your first budget" }),
     )
     expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
+  })
+
+  it("retries the assignments the form now shows, not the set that failed", async () => {
+    // The fields stay editable while Retry is offered, so the retry is the
+    // operator's chance to fix the selection. Replaying the original ids would
+    // drop whoever they added in the meantime and close as though it worked.
+    let failFirst = true
+    const fetchMock = mockApi({
+      budgets: [],
+      users: [testUser("alice"), testUser("bob")],
+      updateUser: (userId) => {
+        if (userId === "alice" && failFirst) {
+          failFirst = false
+          return jsonResponse({ detail: "User update failed" }, 500)
+        }
+        return jsonResponse(testUser(userId))
+      },
+    })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create budget" }),
+    )
+    await user.type(
+      screen.getByLabelText("Assign to people (optional)"),
+      "alice",
+    )
+    await user.click(await screen.findByRole("option", { name: /alice/ }))
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Create budget",
+      }),
+    )
+    expect(
+      await screen.findByText(/these people were not updated: alice/),
+    ).toBeInTheDocument()
+
+    // Add the second person, then retry.
+    await user.clear(screen.getByLabelText("Assign to people (optional)"))
+    await user.type(screen.getByLabelText("Assign to people (optional)"), "bob")
+    await user.click(await screen.findByRole("option", { name: /bob/ }))
+    await user.click(screen.getByRole("button", { name: "Retry assignments" }))
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    const patched = fetchMock.mock.calls
+      .filter(([, init]) => (init?.method ?? "") === "PATCH")
+      .map(([url]) => String(url))
+    expect(patched.some((url) => url.includes("bob"))).toBe(true)
+    // And still one budget, which is what the retry exists to protect.
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => (init?.method ?? "") === "POST")
+        .length,
+    ).toBe(1)
+  })
+
+  it("does not carry one row's refused edit into the next row's dialog", async () => {
+    // The create dialog's twin. The update mutation lives below the edit
+    // dialog's key, so a 409 taken on budget A cannot still be on screen when
+    // budget B's Edit is pressed.
+    mockApi({
+      budgets: [
+        budget({ budget_id: "a", name: "alpha" }),
+        budget({ budget_id: "b", name: "beta" }),
+      ],
+      updateBudget: () =>
+        jsonResponse({ detail: "A budget named beta already exists" }, 409),
+    })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    const rowA = await screen.findByRole("row", { name: /alpha/ })
+    await user.click(within(rowA).getByRole("button", { name: "Edit" }))
+    await user.clear(screen.getByLabelText("Name (optional)"))
+    await user.type(screen.getByLabelText("Name (optional)"), "beta")
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Save" }),
+    )
+    expect(
+      await screen.findByText(/A budget named beta already exists/),
+    ).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    const rowB = screen.getByRole("row", { name: /beta/ })
+    await user.click(within(rowB).getByRole("button", { name: "Edit" }))
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(screen.queryByText(/A budget named beta already exists/)).toBeNull()
+  })
+
+  it("keeps the onboarding panel mounted while its dialog is open", async () => {
+    // react-aria returns focus to whatever opened the dialog. An empty-state
+    // CTA that unmounts on open leaves it nothing to return to, so focus lands
+    // on body and Tab restarts at the top of the document.
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    const cta = await screen.findByRole("button", {
+      name: "Create your first budget",
+    })
+    await user.click(cta)
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(cta).toBeVisible()
+
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    await waitFor(() => expect(cta).toHaveFocus())
   })
 
   it("does not greet the next open with the last one's refusal", async () => {

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -481,6 +481,33 @@ describe("BudgetsPage", () => {
     expect(screen.queryByText(/A budget named beta already exists/)).toBeNull()
   })
 
+  it("returns focus to the heading trigger when the empty state has gone", async () => {
+    // The first budget created retires the panel the CTA sits in, so
+    // react-aria has nothing to restore focus to and it falls to body, which
+    // restarts Tab at the top of the document. `returnFocusRef` names the
+    // heading's own trigger, which outlives the create.
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create your first budget" }),
+    )
+    await user.type(screen.getByLabelText("Name (optional)"), "team-a")
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Create budget",
+      }),
+    )
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Create budget" }),
+      ).toHaveFocus(),
+    )
+  })
+
   it("keeps the onboarding panel mounted while its dialog is open", async () => {
     // react-aria returns focus to whatever opened the dialog. An empty-state
     // CTA that unmounts on open leaves it nothing to return to, so focus lands

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -159,6 +159,32 @@ describe("BudgetsPage", () => {
     vi.restoreAllMocks()
   })
 
+  it("keeps the page's create action visible while the dialog is open", async () => {
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await screen.findByText("No budgets yet")
+    const trigger = screen.getByRole("button", { name: "Create budget" })
+    await user.click(trigger)
+    await screen.findByRole("dialog")
+    expect(trigger).toBeInTheDocument()
+  })
+
+  it("names the object in the title and the budget in the description when editing", async () => {
+    mockApi({ budgets: [budget({ name: "team-free-tier" })] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    const row = (await screen.findByText("team-free-tier")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    // A dialog title is a noun phrase, so the budget it names is in the
+    // description rather than folded into the title.
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveAccessibleName("Edit budget")
+    expect(dialog).toHaveTextContent("team-free-tier")
+  })
+
   it("shows onboarding when there are no budgets", async () => {
     mockApi({ budgets: [] })
     renderPage(<BudgetsPage />)
@@ -167,9 +193,12 @@ describe("BudgetsPage", () => {
     expect(
       screen.getByRole("button", { name: "Create your first budget" }),
     ).toBeInTheDocument()
+    // The heading keeps its action beside the empty state's, which offers the
+    // same thing in the operator's own words. A dialog is over the page, and
+    // the heading's action is where focus returns when one closes.
     expect(
-      screen.queryByRole("button", { name: "Create budget" }),
-    ).not.toBeInTheDocument()
+      screen.getByRole("button", { name: "Create budget" }),
+    ).toBeInTheDocument()
     // Only the onboarding panel shows: the table (and its own "no rows" fallback,
     // whose "cap spending" text is unique to it) is suppressed so the two empty
     // states are not stacked.
@@ -485,7 +514,7 @@ describe("BudgetsPage", () => {
     expect(
       screen.getByText("Enter a whole number of days."),
     ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled()
   })
 
   it("creates an unlimited budget when the limit is left blank", async () => {
@@ -523,7 +552,7 @@ describe("BudgetsPage", () => {
     await user.click(within(row).getByRole("button", { name: "Edit" }))
 
     expect(
-      await screen.findByRole("button", { name: "Save changes" }),
+      await screen.findByRole("button", { name: "Save" }),
     ).toBeInTheDocument()
     expect(screen.getByLabelText("Spending limit (USD)")).toHaveValue("42")
   })
@@ -547,7 +576,7 @@ describe("BudgetsPage", () => {
 
     await user.click(within(row).getByRole("button", { name: "Edit" }))
     expect(
-      await screen.findByRole("button", { name: "Save changes" }),
+      await screen.findByRole("button", { name: "Save" }),
     ).toBeInTheDocument()
     expect(screen.queryByText("Assign to people (optional)")).toBeNull()
     expect(screen.getByText(/belongs to an organization/)).toBeInTheDocument()

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -67,6 +67,8 @@ function mockApi(
     budgets?: Budget[]
     resetLogs?: BudgetResetLog[]
     users?: User[]
+    /** What a create answers with, for the case that drives a refusal. */
+    createBudget?: () => Response
     failedUserUpdates?: string[]
     updateUser?: (userId: string) => Response | Promise<Response>
     // Who is asking, which is what decides which of the two pages this route
@@ -105,6 +107,7 @@ function mockApi(
           return jsonResponse(resetLogs)
         }
         if (method === "POST") {
+          if (opts.createBudget) return opts.createBudget()
           const body = JSON.parse(String(init?.body)) as Partial<Budget>
           const row = budget({
             budget_id: "new-budget-id-0000-0000-000000000000",
@@ -383,6 +386,43 @@ describe("BudgetsPage", () => {
       screen.getByRole("button", { name: "Create your first budget" }),
     )
     expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
+  })
+
+  it("does not greet the next open with the last one's refusal", async () => {
+    // The create mutation lives below the dialog's key, so it is remounted with
+    // the form: a 409 from one attempt cannot still be on screen when the
+    // dialog is opened again. Left above the key, the banner survives, and the
+    // second open reads as though this attempt had already failed.
+    mockApi({
+      budgets: [],
+      createBudget: () =>
+        jsonResponse({ detail: "A budget named team-a already exists" }, 409),
+    })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create budget" }),
+    )
+    await user.type(screen.getByLabelText("Name (optional)"), "team-a")
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Create budget",
+      }),
+    )
+    expect(
+      await screen.findByText(/A budget named team-a already exists/),
+    ).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Create budget" }))
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(
+      screen.queryByText(/A budget named team-a already exists/),
+    ).toBeNull()
   })
 
   it("keeps failed initial assignments retryable without creating another budget", async () => {

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -1053,9 +1053,22 @@ function CreateBudgetDialog({
   // Create the budget, then (optionally) attach it to the chosen users. The
   // per-user PATCH sets each user's reset clock. Failed assignments stay in the
   // form so a retry never creates a duplicate budget.
-  const createAndAssign = (body: CreateBudgetRequest, userIds: string[]) => {
+  const createAndAssign = async (
+    body: CreateBudgetRequest,
+    userIds: string[],
+  ) => {
     if (pendingAssignments) {
-      void assignUsers(pendingAssignments.budgetId, pendingAssignments.userIds)
+      // Awaited, because the retry's success is what closes the form. Left
+      // open, the label reverts to "Create budget" the moment the assignments
+      // land and the next press creates a second budget.
+      if (
+        await assignUsers(
+          pendingAssignments.budgetId,
+          pendingAssignments.userIds,
+        )
+      ) {
+        onClose()
+      }
       return
     }
 

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -521,7 +521,6 @@ function DeploymentBudgetsPage() {
     [workspaces.data],
   )
   const workspaceDefaults = useAllWorkspaceBudgetDefaults(workspaceIds)
-  const updateBudget = useUpdateBudget()
   const deleteBudget = useDeleteBudget()
   const updateUser = useUpdateUser()
 
@@ -583,7 +582,11 @@ function DeploymentBudgetsPage() {
   }, [workspaces.data, workspaceDefaults.data])
   const editingBudget = rows.find((b) => b.budget_id === editing) ?? null
   const historyBudget = rows.find((b) => b.budget_id === historyOpen) ?? null
-  const showOnboarding = !loading && rows.length === 0 && !addOpen
+  // Not gated on the dialog being closed: react-aria returns focus to the
+  // element that opened the dialog, and an empty-state CTA that unmounts on
+  // open leaves it nothing to return to, so focus lands on body and Tab
+  // restarts at the top of the document.
+  const showOnboarding = !loading && rows.length === 0
   const selectableKeys = rows.map((b) => b.budget_id)
   const selectedIds = resolveSelectedIds(selection.selectedKeys, selectableKeys)
 
@@ -800,7 +803,6 @@ function DeploymentBudgetsPage() {
       <ErrorBanner
         error={
           budgets.error ??
-          updateBudget.error ??
           updateUser.error ??
           // Without this a failed roster silently withholds the assignment
           // control and the "Default for" column, with nothing saying why.
@@ -854,53 +856,23 @@ function DeploymentBudgetsPage() {
       {/* Key on the row id so switching which budget is edited remounts the form,
           its fields seed from `initial` on mount only. */}
       {editingBudget ? (
-        <BudgetForm
+        <EditBudgetDialog
           key={editingBudget.budget_id}
-          isOpen
-          onOpenChange={(open) => {
-            if (!open) setEditing(null)
+          budget={editingBudget}
+          users={users.data ?? []}
+          rosterReady={rosterReady}
+          assignUsers={assignUsers}
+          onAssignmentReset={() => {
+            setAssignmentError(null)
+            setPendingAssignments(null)
           }}
-          title="Edit budget"
-          description={budgetLabel(editingBudget)}
-          submitLabel="Save"
-          initial={{
-            name: editingBudget.name,
-            max_budget: editingBudget.max_budget,
-            budget_duration_sec: editingBudget.budget_duration_sec,
+          assignmentError={assignmentError}
+          assigningUsers={assigningUsers}
+          onClose={() => {
+            setAssignmentError(null)
+            setPendingAssignments(null)
+            setEditing(null)
           }}
-          error={updateBudget.error ?? assignmentError}
-          isPending={updateBudget.isPending || assigningUsers}
-          assignUsers={
-            rosterReady && !isOrganizationOwned(editingBudget)
-              ? (users.data ?? [])
-              : undefined
-          }
-          assignmentNote={
-            isOrganizationOwned(editingBudget)
-              ? "This budget belongs to an organization, so people here cannot be held to it. Its limit and reset are still the deployment's to change."
-              : undefined
-          }
-          assignedUserIds={(users.data ?? [])
-            .filter((u) => u.budget_id === editingBudget.budget_id)
-            .map((u) => u.user_id)}
-          onSubmit={(body, userIds) =>
-            updateBudget.mutate(
-              { id: editingBudget.budget_id, body },
-              {
-                onSuccess: async () => {
-                  const held = (users.data ?? [])
-                    .filter((u) => u.budget_id === editingBudget.budget_id)
-                    .map((u) => u.user_id)
-                  if (
-                    await assignUsers(editingBudget.budget_id, userIds, held)
-                  ) {
-                    setEditing(null)
-                  }
-                },
-              },
-            )
-          }
-          onClose={() => setEditing(null)}
         />
       ) : null}
 
@@ -1003,20 +975,81 @@ function DeploymentBudgetsPage() {
 }
 
 /**
- * Spend & budgets, picking the page for whoever is asking.
+ * Edit one budget, and reconcile who holds it.
  *
- * One route with two pages behind it, the way Routing does since otari#867: an
- * operator gets the deployment's budgets, and an organization owner or admin
- * gets their own organization's, which is the surface otari-ai#1943 added. Not
- * two rail rows, because it is one destination in the design and one row in the
- * roles matrix; and not one merged page, because the two read different tables
- * and every deployment-wide read here answers 403 to a tenant.
- *
- * Held until the context lands rather than defaulting to one of them. Guessing
- * would either flash the operator page at an admin and swap it, or fire the
- * deployment-wide reads as an admin and paint their refusals; the shell already
- * waits on this query, so the cost is a spinner that is usually already over.
+ * A component of its own for the reason the create one is: the update mutation
+ * resets with the form on each open, so a refusal on one row cannot greet the
+ * next row's dialog with a message about a budget it is not editing. The page
+ * keys it on the row, which is what makes "switching which budget is open"
+ * reseed the fields.
  */
+function EditBudgetDialog({
+  budget: row,
+  users,
+  rosterReady,
+  assignUsers,
+  onAssignmentReset,
+  assignmentError,
+  assigningUsers,
+  onClose,
+}: {
+  budget: Budget
+  users: User[]
+  rosterReady: boolean
+  assignUsers: (
+    budgetId: string,
+    userIds: string[],
+    previousUserIds?: string[],
+  ) => Promise<boolean>
+  onAssignmentReset: () => void
+  assignmentError: Error | null
+  assigningUsers: boolean
+  onClose: () => void
+}) {
+  const updateBudget = useUpdateBudget()
+  const held = users
+    .filter((user) => user.budget_id === row.budget_id)
+    .map((user) => user.user_id)
+
+  return (
+    <BudgetForm
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title="Edit budget"
+      description={budgetLabel(row)}
+      submitLabel="Save"
+      initial={{
+        name: row.name,
+        max_budget: row.max_budget,
+        budget_duration_sec: row.budget_duration_sec,
+      }}
+      error={updateBudget.error ?? assignmentError}
+      isPending={updateBudget.isPending || assigningUsers}
+      assignUsers={rosterReady && !isOrganizationOwned(row) ? users : undefined}
+      assignmentNote={
+        isOrganizationOwned(row)
+          ? "This budget belongs to an organization, so people here cannot be held to it. Its limit and reset are still the deployment's to change."
+          : undefined
+      }
+      assignedUserIds={held}
+      onSubmit={(body, userIds) => {
+        onAssignmentReset()
+        updateBudget.mutate(
+          { id: row.budget_id, body },
+          {
+            onSuccess: async () => {
+              if (await assignUsers(row.budget_id, userIds, held)) onClose()
+            },
+          },
+        )
+      }}
+      onClose={onClose}
+    />
+  )
+}
+
 /**
  * Create a budget, and attach it to the people chosen in the same form.
  *
@@ -1058,15 +1091,19 @@ function CreateBudgetDialog({
     userIds: string[],
   ) => {
     if (pendingAssignments) {
+      // Against the form as it stands, not against the set that failed. The
+      // retry is the operator's chance to fix the selection, and the fields
+      // stay editable while it is offered: replaying the original ids would
+      // drop whoever they just added. `held` is what the roster says already
+      // carries this budget, which is what makes the reconcile
+      // two-directional.
+      const held = users
+        .filter((user) => user.budget_id === pendingAssignments.budgetId)
+        .map((user) => user.user_id)
       // Awaited, because the retry's success is what closes the form. Left
       // open, the label reverts to "Create budget" the moment the assignments
       // land and the next press creates a second budget.
-      if (
-        await assignUsers(
-          pendingAssignments.budgetId,
-          pendingAssignments.userIds,
-        )
-      ) {
+      if (await assignUsers(pendingAssignments.budgetId, userIds, held)) {
         onClose()
       }
       return
@@ -1104,6 +1141,21 @@ function CreateBudgetDialog({
   )
 }
 
+/**
+ * Spend & budgets, picking the page for whoever is asking.
+ *
+ * One route with two pages behind it, the way Routing does since otari#867: an
+ * operator gets the deployment's budgets, and an organization owner or admin
+ * gets their own organization's, which is the surface otari-ai#1943 added. Not
+ * two rail rows, because it is one destination in the design and one row in the
+ * roles matrix; and not one merged page, because the two read different tables
+ * and every deployment-wide read here answers 403 to a tenant.
+ *
+ * Held until the context lands rather than defaulting to one of them. Guessing
+ * would either flash the operator page at an admin and swap it, or fire the
+ * deployment-wide reads as an admin and paint their refusals; the shell already
+ * waits on this query, so the cost is a spinner that is usually already over.
+ */
 export function BudgetsPage() {
   const organization = useOrganizationContext()
 

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -277,9 +277,21 @@ function BudgetForm({
   // a reason to paint the button as refused.
   const blocked = !parsed.valid || periodInvalid
   const canSubmit = !isPending && !blocked
-  // Everything the operator can change, against what the form was seeded with.
-  const draft = JSON.stringify({ name, limit, durationSec, userIds })
-  const seeded = useRef(draft)
+  // One predicate naming every field the operator can change, so "is there
+  // anything to lose" is answered in a single place rather than by a snapshot
+  // string whose contents have to be kept in step by hand.
+  const seeded = useRef({
+    name: initial.name ?? "",
+    limit: initial.max_budget === null ? "" : String(initial.max_budget),
+    durationSec: initial.budget_duration_sec,
+    userIds: assignedUserIds ?? [],
+  })
+  const isPristine =
+    name === seeded.current.name &&
+    limit === seeded.current.limit &&
+    durationSec === seeded.current.durationSec &&
+    userIds.length === seeded.current.userIds.length &&
+    userIds.every((id) => seeded.current.userIds.includes(id))
 
   const submit = () => {
     if (!canSubmit) return
@@ -307,7 +319,7 @@ function BudgetForm({
       onSubmit={submit}
       isPending={isPending}
       isSubmitDisabled={blocked}
-      isDirty={draft !== seeded.current}
+      isDirty={!isPristine}
       error={error}
     >
       <Field
@@ -509,12 +521,15 @@ function DeploymentBudgetsPage() {
     [workspaces.data],
   )
   const workspaceDefaults = useAllWorkspaceBudgetDefaults(workspaceIds)
-  const createBudget = useCreateBudget()
   const updateBudget = useUpdateBudget()
   const deleteBudget = useDeleteBudget()
   const updateUser = useUpdateUser()
 
   const [addOpen, setAddOpen] = useState(false)
+  // Bumped on every open and used as the create dialog's key. The draft is
+  // cleared on the way in rather than on the way out, which lets the dialog
+  // animate away with its fields intact.
+  const [addOpenCount, setAddOpenCount] = useState(0)
   const [editing, setEditing] = useState<string | null>(null)
   const [historyOpen, setHistoryOpen] = useState<string | null>(null)
   const [pendingDelete, setPendingDelete] = useState<Budget>()
@@ -757,29 +772,6 @@ function DeploymentBudgetsPage() {
     return true
   }
 
-  // Create the budget, then (optionally) attach it to the chosen users. The
-  // per-user PATCH sets each user's reset clock. Failed assignments stay in the
-  // form so a retry never creates a duplicate budget.
-  const createAndAssign = (body: CreateBudgetRequest, userIds: string[]) => {
-    if (pendingAssignments) {
-      void assignUsers(pendingAssignments.budgetId, pendingAssignments.userIds)
-      return
-    }
-
-    setAssignmentError(null)
-    createBudget.mutate(body, {
-      onSuccess: async (budget: Budget) => {
-        if (
-          userIds.length > 0 &&
-          !(await assignUsers(budget.budget_id, userIds))
-        ) {
-          return
-        }
-        setAddOpen(false)
-      },
-    })
-  }
-
   return (
     <div className="flex flex-col">
       <PageIntro
@@ -793,6 +785,7 @@ function DeploymentBudgetsPage() {
               setEditing(null)
               setAssignmentError(null)
               setPendingAssignments(null)
+              setAddOpenCount((count) => count + 1)
               setAddOpen(true)
             }}
           >
@@ -807,7 +800,6 @@ function DeploymentBudgetsPage() {
       <ErrorBanner
         error={
           budgets.error ??
-          createBudget.error ??
           updateBudget.error ??
           updateUser.error ??
           // Without this a failed roster silently withholds the assignment
@@ -833,21 +825,26 @@ function DeploymentBudgetsPage() {
             setEditing(null)
             setAssignmentError(null)
             setPendingAssignments(null)
+            setAddOpenCount((count) => count + 1)
             setAddOpen(true)
           }}
         />
       ) : null}
 
-      <BudgetForm
+      {/* Keyed on the open count, so each open remounts everything that should
+          start fresh: the draft, and the create mutation whose refusal would
+          otherwise greet the next open. The page keeps only what outlives an
+          open, which is whether it is open, how many times it has been, and
+          the list itself. */}
+      <CreateBudgetDialog
+        key={addOpenCount}
         isOpen={addOpen}
-        onOpenChange={setAddOpen}
-        title="New budget"
-        submitLabel={pendingAssignments ? "Retry assignments" : "Create budget"}
-        initial={{ name: null, max_budget: null, budget_duration_sec: null }}
-        error={createBudget.error ?? assignmentError}
-        isPending={createBudget.isPending || assigningUsers}
-        assignUsers={users.data ?? []}
-        onSubmit={createAndAssign}
+        assignmentError={assignmentError}
+        assigningUsers={assigningUsers}
+        pendingAssignments={pendingAssignments}
+        assignUsers={assignUsers}
+        onAssignmentReset={() => setAssignmentError(null)}
+        users={users.data ?? []}
         onClose={() => {
           setAssignmentError(null)
           setPendingAssignments(null)
@@ -1020,6 +1017,80 @@ function DeploymentBudgetsPage() {
  * deployment-wide reads as an admin and paint their refusals; the shell already
  * waits on this query, so the cost is a spinner that is usually already over.
  */
+/**
+ * Create a budget, and attach it to the people chosen in the same form.
+ *
+ * A component of its own so the page can key it: the draft *and* the create
+ * mutation reset together on each open, which is what stops a refusal from the
+ * last attempt greeting the next one. The assignment retry state stays on the
+ * page, because a failed attach is shared with the edit form and outlives this.
+ */
+function CreateBudgetDialog({
+  isOpen,
+  onClose,
+  users,
+  assignUsers,
+  onAssignmentReset,
+  assignmentError,
+  assigningUsers,
+  pendingAssignments,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  users: User[]
+  assignUsers: (
+    budgetId: string,
+    userIds: string[],
+    previousUserIds?: string[],
+  ) => Promise<boolean>
+  onAssignmentReset: () => void
+  assignmentError: Error | null
+  assigningUsers: boolean
+  pendingAssignments: { budgetId: string; userIds: string[] } | null
+}) {
+  const createBudget = useCreateBudget()
+
+  // Create the budget, then (optionally) attach it to the chosen users. The
+  // per-user PATCH sets each user's reset clock. Failed assignments stay in the
+  // form so a retry never creates a duplicate budget.
+  const createAndAssign = (body: CreateBudgetRequest, userIds: string[]) => {
+    if (pendingAssignments) {
+      void assignUsers(pendingAssignments.budgetId, pendingAssignments.userIds)
+      return
+    }
+
+    onAssignmentReset()
+    createBudget.mutate(body, {
+      onSuccess: async (budget: Budget) => {
+        if (
+          userIds.length > 0 &&
+          !(await assignUsers(budget.budget_id, userIds))
+        ) {
+          return
+        }
+        onClose()
+      },
+    })
+  }
+
+  return (
+    <BudgetForm
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title="New budget"
+      submitLabel={pendingAssignments ? "Retry assignments" : "Create budget"}
+      initial={{ name: null, max_budget: null, budget_duration_sec: null }}
+      error={createBudget.error ?? assignmentError}
+      isPending={createBudget.isPending || assigningUsers}
+      assignUsers={users}
+      onSubmit={createAndAssign}
+      onClose={onClose}
+    />
+  )
+}
+
 export function BudgetsPage() {
   const organization = useOrganizationContext()
 

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -3,7 +3,7 @@
 // took chips off everything it rebuilt, so this is an inconsistency rather than
 // a decision: see the note in the PR body.
 import { Button, Chip, Spinner } from "@heroui/react"
-import { useEffect, useMemo, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import type {
   Budget,
   BudgetResetLog,
@@ -17,6 +17,7 @@ import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { EmptyState } from "@/design-system/feedback/EmptyState"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { PageLoading } from "@/design-system/feedback/PageLoading"
 import { Field } from "@/design-system/forms/Field"
@@ -219,7 +220,10 @@ function PeriodPicker({
 // ---------- create / edit forms (inline cards, matching KeysPage) ----------
 
 function BudgetForm({
+  isOpen,
+  onOpenChange,
   title,
+  description,
   submitLabel,
   initial,
   error,
@@ -230,7 +234,11 @@ function BudgetForm({
   assignedUserIds,
   assignmentNote,
 }: {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
   title: string
+  /** The object being edited, where the title alone does not name it. */
+  description?: ReactNode
   submitLabel: string
   initial: {
     name: string | null
@@ -263,7 +271,15 @@ function BudgetForm({
   const [userIds, setUserIds] = useState<string[]>(assignedUserIds ?? [])
 
   const parsed = parseLimit(limit)
-  const canSubmit = !isPending && parsed.valid && !periodInvalid
+  // Two readings of one rule, spelled once: the submit is shown disabled while
+  // the form cannot be sent, and `submit` refuses while that OR a save is in
+  // flight. Pending is not part of `blocked` because a request in flight is not
+  // a reason to paint the button as refused.
+  const blocked = !parsed.valid || periodInvalid
+  const canSubmit = !isPending && !blocked
+  // Everything the operator can change, against what the form was seeded with.
+  const draft = JSON.stringify({ name, limit, durationSec, userIds })
+  const seeded = useRef(draft)
 
   const submit = () => {
     if (!canSubmit) return
@@ -279,14 +295,21 @@ function BudgetForm({
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (open) onOpenChange(true)
+        else onClose()
+      }}
+      title={title}
+      description={description}
+      submitLabel={submitLabel}
+      onSubmit={submit}
+      isPending={isPending}
+      isSubmitDisabled={blocked}
+      isDirty={draft !== seeded.current}
+      error={error}
     >
-      {/* A heading, not a styled div: this panel is a section of the page and
-          the type role is what it looks like, not what it is. */}
-      <h2 className="text-title">{title}</h2>
-      <ErrorBanner error={error} />
       <Field
         label="Name (optional)"
         value={name}
@@ -329,15 +352,7 @@ function BudgetForm({
         // without this branch it would be passed and never rendered.
         <p className="text-caption">{assignmentNote}</p>
       ) : null}
-      <div className="flex gap-2">
-        <Button variant="primary" isDisabled={!canSubmit} onPress={submit}>
-          {isPending ? "Saving…" : submitLabel}
-        </Button>
-        <Button variant="ghost" isDisabled={isPending} onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -770,19 +785,19 @@ function DeploymentBudgetsPage() {
       <PageIntro
         title="Budgets"
         action={
-          addOpen || showOnboarding ? null : (
-            <Button
-              variant="primary"
-              onPress={() => {
-                setEditing(null)
-                setAssignmentError(null)
-                setPendingAssignments(null)
-                setAddOpen(true)
-              }}
-            >
-              Create budget
-            </Button>
-          )
+          <Button
+            // Visible while the dialog is open, and beside the empty state's
+            // own copy of it: the dialog is over the page.
+            variant="primary"
+            onPress={() => {
+              setEditing(null)
+              setAssignmentError(null)
+              setPendingAssignments(null)
+              setAddOpen(true)
+            }}
+          >
+            Create budget
+          </Button>
         }
       >
         Define spending limits and reset schedules. Assign a budget to users to
@@ -823,31 +838,34 @@ function DeploymentBudgetsPage() {
         />
       ) : null}
 
-      {addOpen ? (
-        <BudgetForm
-          title="Create budget"
-          submitLabel={
-            pendingAssignments ? "Retry assignments" : "Create budget"
-          }
-          initial={{ name: null, max_budget: null, budget_duration_sec: null }}
-          error={createBudget.error ?? assignmentError}
-          isPending={createBudget.isPending || assigningUsers}
-          assignUsers={users.data ?? []}
-          onSubmit={createAndAssign}
-          onClose={() => {
-            setAssignmentError(null)
-            setPendingAssignments(null)
-            setAddOpen(false)
-          }}
-        />
-      ) : null}
+      <BudgetForm
+        isOpen={addOpen}
+        onOpenChange={setAddOpen}
+        title="New budget"
+        submitLabel={pendingAssignments ? "Retry assignments" : "Create budget"}
+        initial={{ name: null, max_budget: null, budget_duration_sec: null }}
+        error={createBudget.error ?? assignmentError}
+        isPending={createBudget.isPending || assigningUsers}
+        assignUsers={users.data ?? []}
+        onSubmit={createAndAssign}
+        onClose={() => {
+          setAssignmentError(null)
+          setPendingAssignments(null)
+          setAddOpen(false)
+        }}
+      />
       {/* Key on the row id so switching which budget is edited remounts the form,
           its fields seed from `initial` on mount only. */}
       {editingBudget ? (
         <BudgetForm
           key={editingBudget.budget_id}
-          title={`Edit budget ${budgetLabel(editingBudget)}`}
-          submitLabel="Save changes"
+          isOpen
+          onOpenChange={(open) => {
+            if (!open) setEditing(null)
+          }}
+          title="Edit budget"
+          description={budgetLabel(editingBudget)}
+          submitLabel="Save"
           initial={{
             name: editingBudget.name,
             max_budget: editingBudget.max_budget,

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -3,7 +3,14 @@
 // took chips off everything it rebuilt, so this is an inconsistency rather than
 // a decision: see the note in the PR body.
 import { Button, Chip, Spinner } from "@heroui/react"
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type ReactNode,
+  type RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import type {
   Budget,
   BudgetResetLog,
@@ -21,6 +28,7 @@ import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { PageLoading } from "@/design-system/feedback/PageLoading"
 import { Field } from "@/design-system/forms/Field"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
@@ -233,6 +241,7 @@ function BudgetForm({
   assignUsers,
   assignedUserIds,
   assignmentNote,
+  returnFocusRef,
 }: {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
@@ -259,6 +268,8 @@ function BudgetForm({
   // Why the multiselect is absent, where its absence is a rule rather than a
   // failed read. The failed-roster case is explained by the page's banner.
   assignmentNote?: string
+  /** Where focus goes when the opener has gone; see `FormDialog`. */
+  returnFocusRef?: RefObject<HTMLElement | null>
 }) {
   const [name, setName] = useState(initial.name ?? "")
   const [limit, setLimit] = useState(
@@ -277,21 +288,16 @@ function BudgetForm({
   // a reason to paint the button as refused.
   const blocked = !parsed.valid || periodInvalid
   const canSubmit = !isPending && !blocked
-  // One predicate naming every field the operator can change, so "is there
-  // anything to lose" is answered in a single place rather than by a snapshot
-  // string whose contents have to be kept in step by hand.
-  const seeded = useRef({
-    name: initial.name ?? "",
-    limit: initial.max_budget === null ? "" : String(initial.max_budget),
-    durationSec: initial.budget_duration_sec,
-    userIds: assignedUserIds ?? [],
+  // Everything the operator can change, in one snapshot. The people are sorted
+  // into it because the picker appends in click order, and a guard that read
+  // two orderings of one selection as a change would arm on the way back to
+  // where it started.
+  const { isDirty } = useDirtySnapshot({
+    name,
+    limit,
+    durationSec,
+    userIds: [...userIds].sort(),
   })
-  const isPristine =
-    name === seeded.current.name &&
-    limit === seeded.current.limit &&
-    durationSec === seeded.current.durationSec &&
-    userIds.length === seeded.current.userIds.length &&
-    userIds.every((id) => seeded.current.userIds.includes(id))
 
   const submit = () => {
     if (!canSubmit) return
@@ -319,7 +325,8 @@ function BudgetForm({
       onSubmit={submit}
       isPending={isPending}
       isSubmitDisabled={blocked}
-      isDirty={!isPristine}
+      isDirty={isDirty}
+      returnFocusRef={returnFocusRef}
       error={error}
     >
       <Field
@@ -525,6 +532,11 @@ function DeploymentBudgetsPage() {
   const updateUser = useUpdateUser()
 
   const [addOpen, setAddOpen] = useState(false)
+  // Where focus lands when a dialog closes and whatever opened it has gone.
+  // The empty state's CTA is the case: the first budget created retires the
+  // panel it sits in, so react-aria has nothing to restore to and focus falls
+  // to body, which restarts Tab at the top of the document.
+  const createButtonRef = useRef<HTMLButtonElement>(null)
   // Bumped on every open and used as the create dialog's key. The draft is
   // cleared on the way in rather than on the way out, which lets the dialog
   // animate away with its fields intact.
@@ -781,6 +793,7 @@ function DeploymentBudgetsPage() {
         title="Budgets"
         action={
           <Button
+            ref={createButtonRef}
             // Visible while the dialog is open, and beside the empty state's
             // own copy of it: the dialog is over the page.
             variant="primary"
@@ -844,6 +857,7 @@ function DeploymentBudgetsPage() {
         assignmentError={assignmentError}
         assigningUsers={assigningUsers}
         pendingAssignments={pendingAssignments}
+        returnFocusRef={createButtonRef}
         assignUsers={assignUsers}
         onAssignmentReset={() => setAssignmentError(null)}
         users={users.data ?? []}
@@ -1067,10 +1081,12 @@ function CreateBudgetDialog({
   assignmentError,
   assigningUsers,
   pendingAssignments,
+  returnFocusRef,
 }: {
   isOpen: boolean
   onClose: () => void
   users: User[]
+  returnFocusRef: RefObject<HTMLButtonElement | null>
   assignUsers: (
     budgetId: string,
     userIds: string[],
@@ -1134,6 +1150,7 @@ function CreateBudgetDialog({
       initial={{ name: null, max_budget: null, budget_duration_sec: null }}
       error={createBudget.error ?? assignmentError}
       isPending={createBudget.isPending || assigningUsers}
+      returnFocusRef={returnFocusRef}
       assignUsers={users}
       onSubmit={createAndAssign}
       onClose={onClose}

--- a/web/src/features/users/UserMultiSelect.test.tsx
+++ b/web/src/features/users/UserMultiSelect.test.tsx
@@ -89,10 +89,10 @@ describe("UserMultiSelect", () => {
       />,
     )
 
-    // `menuTrigger="input"`, so the list opens on typing or on ArrowDown rather
-    // than on a click.
-    await userEvent.click(screen.getByLabelText("Add a person"))
-    await userEvent.keyboard("{ArrowDown}")
+    // The field carries the form's own label and the list opens on focus, which
+    // is `forms/MultiSelect`'s shape rather than the combo box's. What the rows
+    // say is the part that has to match the owner picker, and it does.
+    await userEvent.click(screen.getByLabelText("Applies to"))
 
     // The same shape the owner picker uses, so a person reads the same way in
     // both: name first, billing id under it and in the row's name.
@@ -101,7 +101,7 @@ describe("UserMultiSelect", () => {
     })
     expect(within(row).getByText("Alice Example")).toBeInTheDocument()
     expect(within(row).getByText(UUID)).toBeInTheDocument()
-    // An id an operator named over the API is already its own name.
+    // An id an operator chose is already its own name, so it carries no hint.
     expect(screen.getByRole("option", { name: "ci-bot" })).toBeInTheDocument()
   })
 
@@ -116,7 +116,7 @@ describe("UserMultiSelect", () => {
       />,
     )
 
-    await userEvent.type(screen.getByLabelText("Add a person"), UUID)
+    await userEvent.type(screen.getByLabelText("Applies to"), UUID)
 
     expect(
       await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
@@ -128,10 +128,7 @@ describe("UserMultiSelect", () => {
     mockRoster([member(UUID, "Alice Example")])
     renderPicker(<Controlled users={[user(UUID)]} />)
 
-    // `menuTrigger="input"`, so the list opens on typing or on ArrowDown rather
-    // than on a click.
-    await userEvent.click(screen.getByLabelText("Add a person"))
-    await userEvent.keyboard("{ArrowDown}")
+    await userEvent.click(screen.getByLabelText("Applies to"))
     await userEvent.click(
       await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
     )
@@ -139,10 +136,10 @@ describe("UserMultiSelect", () => {
     // The id is what a budget assignment PATCHes; the chip is what the operator
     // reads back, and it is their name rather than that id.
     expect(await screen.findByText(`selected: ${UUID}`)).toBeInTheDocument()
-    // The open popover aria-hides the rest of the form, chips included.
-    await userEvent.keyboard("{Escape}")
     expect(
-      screen.getByRole("button", { name: "Remove Alice Example" }),
+      within(
+        screen.getByRole("list", { name: "Applies to, selected" }),
+      ).getByText("Alice Example"),
     ).toBeInTheDocument()
   })
 })

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -4,6 +4,8 @@ import type { User } from "@/client"
 import { MultiSelect } from "@/design-system/forms/MultiSelect"
 import { useMemberAttributionLabels } from "@/features/organization/attribution"
 
+import { userOptionText } from "./userOptions"
+
 // A picker of people, for assigning a budget to several at once. Only lists
 // named rows (virtual apikey-* shadows are excluded); it never creates one,
 // matching the model where a person exists before they are assigned a budget.
@@ -34,15 +36,10 @@ export function UserMultiSelect({
 
   const options = users
     .filter((user) => !user.user_id.startsWith("apikey-"))
-    .map((user) => {
-      const member = memberLabels.get(user.user_id)
-      return {
-        id: user.user_id,
-        label:
-          member ??
-          (user.alias ? `${user.user_id} (${user.alias})` : user.user_id),
-      }
-    })
+    .map((user) => ({
+      id: user.user_id,
+      ...userOptionText(user, memberLabels),
+    }))
 
   return (
     <MultiSelect

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -50,7 +50,7 @@ export function UserMultiSelect({
       onChange={onChange}
       searchPlaceholder="Search people…"
       countNoun={{ one: "person assigned", other: "people assigned" }}
-      emptyMessage="Nobody to assign yet. Add people under Members & roles, or issue a key, and they can be assigned here."
+      emptyMessage="Nobody to assign yet. Add people under Members & roles and they can be assigned here."
       noMatchesMessage="Nobody matches what you typed."
     />
   )

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -1,29 +1,22 @@
-import { ComboBox, Input, ListBox, ListBoxItem } from "@heroui/react"
-import { type ReactNode, useMemo, useState } from "react"
+import { type ReactNode, useMemo } from "react"
 
 import type { User } from "@/client"
-import { ComboBoxEmpty } from "@/design-system/forms/ComboBoxEmpty"
-import { comboBoxOptionText } from "@/design-system/forms/ComboBoxField"
-import { ControlField } from "@/design-system/forms/FieldMessages"
-import { DismissChip } from "@/design-system/indicators/DismissChip"
+import { MultiSelect } from "@/design-system/forms/MultiSelect"
 import { useMemberAttributionLabels } from "@/features/organization/attribution"
 
-import { type UserOptionText, userOptionText } from "./userOptions"
-
-interface Option extends UserOptionText {
-  id: string
-}
-
-const MAX_VISIBLE = 50
-
-// A chip picker of people, for assigning a budget to several at once. Only lists
+// A picker of people, for assigning a budget to several at once. Only lists
 // named rows (virtual apikey-* shadows are excluded); it never creates one,
 // matching the model where a person exists before they are assigned a budget.
 //
-// Rows are keyed by the id the request plane bills to, which for anyone added
-// through the roster is a bare UUID (`attribution_user_id` is the join).
-// `userOptionText` decides what that reads as, so this picker and the owner
-// picker name a person the same way.
+// The rows are keyed by the id the request plane bills to, which for anyone added
+// through the roster is a bare UUID. Showing that is useless to a human, so the
+// organization roster is asked what to call them (`attribution_user_id` is the
+// join). An id with no member behind it, such as one an operator named directly
+// over the API, keeps the id, since that *is* its name.
+//
+// Everything about how the picking behaves is `forms/MultiSelect`'s now. What is
+// left here is the one thing a design-system component cannot know: which rows
+// are people, and what a person is called.
 export function UserMultiSelect({
   value,
   onChange,
@@ -37,118 +30,35 @@ export function UserMultiSelect({
   label: string
   description?: ReactNode
 }) {
-  const [query, setQuery] = useState("")
   const memberLabels = useMemberAttributionLabels()
 
-  const options = useMemo<Option[]>(
+  const options = useMemo(
     () =>
       users
-        .filter((u) => !u.user_id.startsWith("apikey-"))
-        .map((u) => ({ id: u.user_id, ...userOptionText(u, memberLabels) })),
+        .filter((user) => !user.user_id.startsWith("apikey-"))
+        .map((user) => {
+          const member = memberLabels.get(user.user_id)
+          return {
+            id: user.user_id,
+            label:
+              member ??
+              (user.alias ? `${user.user_id} (${user.alias})` : user.user_id),
+          }
+        }),
     [users, memberLabels],
   )
-  const labelById = useMemo(
-    () => new Map(options.map((option) => [option.id, option.label])),
-    [options],
-  )
-
-  const visible = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    return options
-      .filter((o) => !value.includes(o.id))
-      .filter(
-        (o) =>
-          !q ||
-          o.id.toLowerCase().includes(q) ||
-          o.label.toLowerCase().includes(q),
-      )
-      .slice(0, MAX_VISIBLE)
-  }, [options, value, query])
-
-  const add = (id: string) => {
-    if (!value.includes(id)) onChange([...value, id])
-    setQuery("")
-  }
-  const remove = (id: string) => onChange(value.filter((v) => v !== id))
 
   return (
-    <div className="flex flex-col gap-2">
-      <ControlField label={label} description={description} />
-      {value.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {value.map((id) => (
-            <DismissChip
-              key={id}
-              value={labelById.get(id) ?? id}
-              onDismiss={() => remove(id)}
-              dismissLabel={`Remove ${labelById.get(id) ?? id}`}
-            />
-          ))}
-        </div>
-      ) : null}
-      {options.length === 0 ? (
-        <span className="text-caption">
-          Nobody to assign yet. Add people under Members &amp; roles, or issue a
-          key, and they can be assigned here.
-        </span>
-      ) : (
-        <ComboBox.Root
-          allowsEmptyCollection
-          menuTrigger="input"
-          inputValue={query}
-          onInputChange={setQuery}
-          selectedKey={null}
-          onSelectionChange={(key) => {
-            if (key != null) add(String(key))
-          }}
-          className="flex flex-col gap-1"
-        >
-          <ComboBox.InputGroup>
-            <Input
-              aria-label="Add a person"
-              placeholder="Search people…"
-              autoComplete="off"
-            />
-            <ComboBox.Trigger />
-          </ComboBox.InputGroup>
-          <ComboBox.Popover>
-            <ListBox
-              items={visible}
-              className="max-h-72 overflow-auto"
-              renderEmptyState={() => (
-                <ComboBoxEmpty
-                  isSourceEmpty={options.every((o) => value.includes(o.id))}
-                  emptyMessage="Everybody here is already assigned."
-                  noMatchesMessage="Nobody matches what you typed."
-                />
-              )}
-            >
-              {(option: Option) => (
-                <ListBoxItem
-                  id={option.id}
-                  textValue={comboBoxOptionText(option)}
-                  // Spelled out for the reason `ComboBoxField` spells it out: a
-                  // two-line row's computed name runs the hint onto the label
-                  // with no separator, and the hint is what tells two people of
-                  // one name apart.
-                  aria-label={
-                    option.hint ? comboBoxOptionText(option) : undefined
-                  }
-                >
-                  <span className="flex flex-col">
-                    <span>{option.label}</span>
-                    {option.hint ? (
-                      <span className="text-caption text-subtle">
-                        {option.hint}
-                      </span>
-                    ) : null}
-                  </span>
-                </ListBoxItem>
-              )}
-            </ListBox>
-          </ComboBox.Popover>
-        </ComboBox.Root>
-      )}
-    </div>
+    <MultiSelect
+      label={label}
+      description={description}
+      options={options}
+      value={value}
+      onChange={onChange}
+      searchPlaceholder="Search people…"
+      countNoun="people assigned"
+      emptyMessage="Nobody to assign yet. Add people under Members & roles, or issue a key, and they can be assigned here."
+      noMatchesMessage="Nobody matches what you typed."
+    />
   )
 }

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from "react"
+import type { ReactNode } from "react"
 
 import type { User } from "@/client"
 import { MultiSelect } from "@/design-system/forms/MultiSelect"
@@ -32,21 +32,17 @@ export function UserMultiSelect({
 }) {
   const memberLabels = useMemberAttributionLabels()
 
-  const options = useMemo(
-    () =>
-      users
-        .filter((user) => !user.user_id.startsWith("apikey-"))
-        .map((user) => {
-          const member = memberLabels.get(user.user_id)
-          return {
-            id: user.user_id,
-            label:
-              member ??
-              (user.alias ? `${user.user_id} (${user.alias})` : user.user_id),
-          }
-        }),
-    [users, memberLabels],
-  )
+  const options = users
+    .filter((user) => !user.user_id.startsWith("apikey-"))
+    .map((user) => {
+      const member = memberLabels.get(user.user_id)
+      return {
+        id: user.user_id,
+        label:
+          member ??
+          (user.alias ? `${user.user_id} (${user.alias})` : user.user_id),
+      }
+    })
 
   return (
     <MultiSelect
@@ -56,7 +52,7 @@ export function UserMultiSelect({
       value={value}
       onChange={onChange}
       searchPlaceholder="Search people…"
-      countNoun="people assigned"
+      countNoun={{ one: "person assigned", other: "people assigned" }}
       emptyMessage="Nobody to assign yet. Add people under Members & roles, or issue a key, and they can be assigned here."
       noMatchesMessage="Nobody matches what you typed."
     />


### PR DESCRIPTION
## Description

Creating a budget appended a form to the page; editing one appended the same form again. Both open the dialog now.

`BudgetForm` already took its title and submit label as props, so create and edit needed one change between them rather than two.

- **The trigger keeps its words**, "Create budget"; the dialog's title is "New budget".
- **Editing splits the old heading in two.** It was one string, `Edit budget team-free-tier`. "Edit budget" is the title and the budget it names is the description, because a dialog title is a noun phrase rather than a sentence. Its submit is **"Save"** rather than "Save changes", which is what the routing dialog already says: two edit dialogs disagreeing about that word is the inconsistency this series exists to remove.
- **The heading's action no longer hides**, and no longer hides behind the empty state either. It used to do both. A dialog sits over the page, so there is nothing for hiding it to prevent, and it is where focus returns when one closes. The empty state keeps its own call to action beside it.
- **`md`, not `lg`.** Four controls, and the assignment multiselect is the only one that grows; the body scrolls when it does.

One cleanup the migration forced rather than invited: `canSubmit` was a single expression, and passing it straight to `isSubmitDisabled` would have painted the submit as *refused* while a save was in flight, which is the treatment for denied. It is two readings of one rule now. `blocked` is what disables the submit; `canSubmit` adds the in-flight check that `submit` itself refuses on.

`FormDialog` is untouched.

## How to test it locally

    pnpm --dir web run build
    pnpm --dir web exec playwright test --project=seed --project=screenshots-desktop-small-light --project=screenshots-mobile-light --grep "budget dialog"

One new capture across three viewports and both themes.

Automated, all run on this commit:

- `pnpm --dir web test` — 5320 pass across 153 files; 63 in `BudgetsPage.test.tsx`, 2 of them new.
- `pnpm --dir web run lint`, `run typecheck`, `run build` — clean.
- **The whole behavioral Playwright set** (`onboarding`, `seed`, `parity`, `hybrid`) — 43 passed, 0 failed.

### What would have to break for each new test to fail

| Remove | Fails |
| --- | --- |
| the trigger's visibility while the dialog is open | `keeps the page's create action visible while the dialog is open` |
| the budget name from the description | `names the object in the title and the budget in the description when editing` |

Two existing tests changed rather than being added to, and both assert the new contract on purpose: `shows onboarding when there are no budgets` used to assert the heading's action was **absent** while the empty state showed, and now asserts it is present; the edit tests moved from "Save changes" to "Save".

### On the unslop pass

Run over this diff before opening. It removed two comments that described the change rather than the code ("The old heading was one string…", "It used to hide here, on the reasoning that…"), and it is what caught the duplicated submit rule described above: the same condition was spelled once in `submit` and again inline in `isSubmitDisabled`, which is two places to update and one to forget.


## MultiSelect for the people picker (#1047)

Two commits beyond the dialog migration, on the owner's ruling that they land here rather than as a PR of their own.

The picker stacked chips **above** its search field, so every pick grew the block and pushed the field down under the pointer, and a picked person left the list, so the list only ever showed who was left rather than who was in. The dialog made it visible; it is not the dialog's bug.

`design-system/forms/MultiSelect` is the form-grade half of the pair `forms.md` already describes, with `FilterMultiComboBox` staying the toolbar one. Chips render below the field. A selected option stays listed with a check and toggles off when pressed again, and the order never re-sorts, so a second press lands where the first one did. `features/users/UserMultiSelect` is its first consumer and keeps only what a design-system component cannot know: which rows are people and what a person is called.

Written to the APG combobox-with-listbox pattern rather than on HeroUI's `ComboBox`, which selects one value and closes. Focus stays in the input and the active option travels by `aria-activedescendant`. Escape closes the popover and stops there, because the same key reaches the dialog and would otherwise arm its guard.

Seven cases in `MultiSelect.test.tsx`, and the three the issue names were each checked by breaking them: moving the chips above the field fails the position test, filtering selected options out of the list fails the stays-listed test, and letting Escape bubble fails the guard test.

One user-visible name change: the field's visible label is now its accessible name. It carried a hidden "Add a person" beside a heading that labelled nothing, so one control had two names; three references in the suites moved with it.

Closes #1047

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of #1031

Stacked on #1038 → #1037 → #1032. Review those first; this branch contains their commits.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      63 cases in `BudgetsPage.test.tsx` (2 new, 3 updated to the new contract),
      1 screenshot capture. The dashboard's tests live under `web/src` and
      `web/e2e` rather than the repo-root `tests/`.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      The dashboard's counterparts; `make lint` does not reach `web/`.
- [ ] Documentation was updated where necessary.
      No design-doc change: the rules this page now follows were written down in
      #1032.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      No API change. The create and update bodies are unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

"Save changes" becoming "Save" is the one user-visible word this changes beyond the title split, and it is a deliberate alignment with the routing dialog rather than a rewrite.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Moved budget create and edit forms into `FormDialog`.
- Kept page actions visible while dialogs and empty states are active.
- Added a form-grade `MultiSelect` and migrated `UserMultiSelect` to it.
- Added stable search, selected chips, visible checked options, keyboard support, accessibility semantics, and capped scrolling.
- Improved dialog behavior for validation, submission, dismissal, mobile layouts, and draft reset.
- Updated related keys and routing dialogs to use the shared dialog patterns.
- Added stories, unit tests, end-to-end tests, and screenshots.

These changes provide consistent modal forms, clearer interactions, and a more usable people picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->