### PR TITLE
feat(dashboard): move both workspace creates and the organization one into FormDialog

### DIFF
--- a/web/e2e/parity.tenancy.spec.ts
+++ b/web/e2e/parity.tenancy.spec.ts
@@ -167,11 +167,14 @@ test.describe("standalone tenancy", () => {
     await openPage(page, "Workspaces", "Workspaces")
 
     await page.getByRole("button", { name: "Create workspace" }).click()
-    await page.getByLabel("Name").fill(WORKSPACE)
-    await page
+    // Scoped: the heading's trigger and the dialog's submit both say "Create
+    // workspace", so an unscoped press is ambiguous.
+    const dialog = page.getByRole("dialog", { name: "New workspace" })
+    await dialog.getByLabel("Name").fill(WORKSPACE)
+    await dialog
       .getByLabel("Description (optional)")
       .fill("Created by the parity suite")
-    await page.getByRole("button", { name: "Create workspace" }).click()
+    await dialog.getByRole("button", { name: "Create workspace" }).click()
 
     const created = workspaceRow(page, WORKSPACE)
     await expect(created).toBeVisible()

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -418,3 +418,17 @@ test.describe("the budget dialog", () => {
     await captureScreenshot(page, "budgets-create-dialog")
   })
 })
+
+test.describe("the workspace dialogs", () => {
+  test("the create dialog, from the page", async ({ page }) => {
+    await login(page)
+    await gotoRoute(page, "/workspaces")
+    await expect(
+      page.getByRole("heading", { name: /workspaces/i }).first(),
+    ).toBeVisible()
+    await page.getByRole("button", { name: "Create workspace" }).first().click()
+    const dialog = page.getByRole("dialog", { name: "New workspace" })
+    await expect(dialog.getByLabel("Name")).toBeVisible()
+    await captureScreenshot(page, "workspaces-create-dialog")
+  })
+})

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -204,6 +204,32 @@ describe("the organization half of the scope switcher", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument()
   })
 
+  it("offers a fresh draft on each open of the organization form", async () => {
+    // Reset on the way in, not on the way out: the dialog keeps its content
+    // while it animates out, so clearing on close blanks the body in front of
+    // the operator. The switcher keys the form on an open counter instead.
+    mockApi()
+    await renderSwitcher()
+
+    const { user, menu } = await openMenu()
+    await user.click(
+      within(menu).getByRole("button", { name: /Create organization/ }),
+    )
+    await user.type(await screen.findByLabelText(/Name/), "half-typed")
+
+    // Out through the guard, which is the only way out of a dirty form.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+
+    const reopened = await openMenu()
+    await reopened.user.click(
+      within(reopened.menu).getByRole("button", {
+        name: /Create organization/,
+      }),
+    )
+    expect(await screen.findByLabelText(/Name/)).toHaveValue("")
+  })
+
   it("creates an organization and moves into it", async () => {
     const requests = mockApi()
     await renderSwitcher()

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -295,7 +295,9 @@ async function fillCreateForm(user: ReturnType<typeof userEvent.setup>) {
       name: "Create workspace",
     }),
   )
-  const form = await screen.findByRole("dialog", { name: "Create workspace" })
+  // The dialog's title names the object and its submit names the action, so
+  // this is "New workspace" and the button below is "Create workspace".
+  const form = await screen.findByRole("dialog", { name: "New workspace" })
   await user.type(within(form).getByLabelText(/^Name/), "Staging")
   return form
 }
@@ -348,13 +350,18 @@ describe("the workspace half of the scope switcher", () => {
   // `<main>`, so a band that travelled here measured a viewport wide and the
   // dialog's `overflow-clip` cropped it to an empty modal (otari-ai#2107). jsdom
   // computes no layout, so what is pinned is the class that causes it.
-  it("frames the create form without the page's bleeding band", async () => {
+  it("opens the same dialog the workspaces page opens", async () => {
+    // The same form once had two frames, a bleeding band on the page and a
+    // Modal here, and this asserted it was not the band. There is one frame and
+    // neither entry point owns it, so the fact worth holding is that this is
+    // the shared dialog.
     mockApi({ context: startedInAWorkspace })
     const user = userEvent.setup()
     await renderSwitcherOnAPage({})
 
     const form = await fillCreateForm(user)
 
+    expect(form).toHaveClass("otari-form-dialog")
     expect(form.querySelector(".otari-bleed")).toBeNull()
     expect(within(form).getByLabelText(/^Name/)).toBeInTheDocument()
   })
@@ -374,7 +381,13 @@ describe("the workspace half of the scope switcher", () => {
     // The press is acknowledged before the page moves, rather than the create
     // landing them somewhere else with nothing in between. The button keeps its
     // name through the beat, so it is still the control it was.
-    expect(submit).toHaveAttribute("data-pending", "true")
+    //
+    // On the form, not the button: `FormDialog` withholds `isPending` from the
+    // submit because the prop paints it at the disabled 0.4, and a submit in
+    // flight is working rather than refused. React-aria filters `aria-busy` off
+    // a Button anyway.
+    expect(submit.closest("form")).toHaveAttribute("aria-busy", "true")
+    expect(submit).toHaveAccessibleName(/Create and open/)
     expect(screen.queryByText("OVERVIEW PAGE")).toBeNull()
 
     beat.release()
@@ -389,7 +402,7 @@ describe("the workspace half of the scope switcher", () => {
     ).toBeInTheDocument()
   })
 
-  it("does not enter a workspace the operator dismissed the form over", async () => {
+  it("cannot be dismissed mid-create, so the entry it promised happens", async () => {
     // The beat is a gate this test opens, so the window the guard exists for is
     // entered and left on purpose rather than by sleeping long enough to have
     // been inside it. Nothing here waits on a duration.
@@ -402,9 +415,13 @@ describe("the workspace half of the scope switcher", () => {
     await user.click(
       within(form).getByRole("button", { name: /Create and open/ }),
     )
-    // Escape rather than Cancel: Cancel is disabled while the create is in
-    // flight, so dismissal is what is left, and it is the path that bypasses
-    // every button.
+    // This asserted the opposite until the form moved into `FormDialog`, and the
+    // change is deliberate rather than incidental. Escape used to dismiss the
+    // form mid-flight and suppress the navigation, which was the one path that
+    // bypassed a Cancel the form had already disabled for the same window.
+    // `FormDialog` closes that path: while a submit is in flight neither
+    // Escape, the backdrop nor the close control dismisses it, so there is one
+    // answer to "can I abandon this" rather than two that disagree.
     await user.keyboard("{Escape}")
     beat.release()
 
@@ -418,16 +435,10 @@ describe("the workspace half of the scope switcher", () => {
     const staging = await within(menu).findByRole("button", { name: /Staging/ })
     expect(staging).toBeVisible()
 
-    // The workspace was created and the switcher offers it; what must not
-    // happen is being taken there after saying not to.
-    expect(screen.queryByText("OVERVIEW PAGE")).toBeNull()
-    expect(screen.getByText("USAGE PAGE")).toBeInTheDocument()
-    // Read from the menu rather than the trigger, which the open menu hides
-    // from the accessibility tree: the scope never moved.
-    expect(
-      within(menu).getByRole("button", { name: /Default Workspace/ }),
-    ).toHaveTextContent("Selected")
-    expect(staging).not.toHaveTextContent("Selected")
+    // The workspace was created and the operator is in it, because the create
+    // they started was never abandoned.
+    expect(staging).toHaveTextContent("Selected")
+    expect(screen.getByText("OVERVIEW PAGE")).toBeInTheDocument()
   })
 
   it("still completes after StrictMode's development remount", async () => {

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -257,6 +257,43 @@ describe("the organization half of the scope switcher", () => {
     })
   })
 
+  it("retries only the switch when the switch after a create was refused", async () => {
+    // The create succeeded, so pressing the button again has to send the second
+    // call and not the first: a retry that repeats the pair leaves a second
+    // organization behind, and nothing in this menu removes one.
+    const requests = mockApi({ switchFails: true })
+    await renderSwitcher()
+
+    const { user, menu } = await openMenu()
+    await user.click(
+      within(menu).getByRole("button", { name: /Create organization/ }),
+    )
+    await user.type(await screen.findByLabelText(/Name/), "Research")
+    const form = await screen.findByRole("dialog")
+    await user.click(
+      within(form).getByRole("button", { name: "Create organization" }),
+    )
+    expect(await within(form).findByRole("alert")).toHaveTextContent(
+      "Organization not found",
+    )
+
+    // The label is the retry: it names the one call that is left.
+    const retry = within(form).getByRole("button", {
+      name: "Switch to organization",
+    })
+    await user.click(retry)
+
+    const posts = requests.filter((request) => request.method === "POST")
+    expect(posts.map((request) => request.url)).toEqual([
+      "/organizations",
+      "/organizations/me/switch",
+      "/organizations/me/switch",
+    ])
+    expect(posts[2]?.body).toEqual({
+      organization_id: SECOND_ORGANIZATION_ID,
+    })
+  })
+
   it("offers Create organization whatever the caller's role in the one they are in", async () => {
     // No role in an organization gates creating one: it is not an action inside
     // a tenant, which is also why the server checks only the credential. Create
@@ -390,6 +427,34 @@ describe("the workspace half of the scope switcher", () => {
     expect(form).toHaveClass("otari-form-dialog")
     expect(form.querySelector(".otari-bleed")).toBeNull()
     expect(within(form).getByLabelText(/^Name/)).toBeInTheDocument()
+  })
+
+  it("offers a fresh draft on each open of the workspace form", async () => {
+    // Nothing here unmounts the form, so the remount on the way in is the only
+    // thing that clears it. Reset on the way out would blank the body while the
+    // dialog is still animating away.
+    mockApi({ context: startedInAWorkspace })
+    const user = userEvent.setup()
+    await renderSwitcherOnAPage({})
+
+    await fillCreateForm(user)
+
+    // Out through the guard, which is the only way out of a dirty form.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+
+    await user.click(
+      await screen.findByRole("button", { name: /^Switch workspace/ }),
+    )
+    await user.click(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Create workspace",
+      }),
+    )
+    const reopened = await screen.findByRole("dialog", {
+      name: "New workspace",
+    })
+    expect(within(reopened).getByLabelText(/^Name/)).toHaveValue("")
   })
 
   it("enters the workspace it just created", async () => {

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -53,6 +53,9 @@ function mockApi(
     memberships?: CallerOrganizationMembership[]
     context?: Parameters<typeof organizationContext>[0]
     switchFails?: boolean
+    // Holds the switch in flight, so the created step's pending line can be
+    // read before the refusal lands.
+    switchGate?: Promise<unknown>
     pendingInvitations?: PendingOrganizationInvitation[]
     pendingInvitationsFail?: boolean
   } = {},
@@ -104,13 +107,23 @@ function mockApi(
       return { data: memberships, count: memberships.length } as never
     }
     if (url === "/organizations/me/switch") {
+      if (options.switchGate) await options.switchGate
       if (options.switchFails) {
         throw new apiClient.ApiError(404, "Organization not found")
       }
       return organizationContext() as never
     }
     if (url === "/organizations") {
-      return organization({ id: SECOND_ORGANIZATION_ID }) as never
+      // Echoes the posted name, as the server does: the created step names the
+      // organization back to the operator, so a fixture name would let that
+      // copy pass while showing the wrong one.
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as { name?: string })
+        : {}
+      return organization({
+        id: SECOND_ORGANIZATION_ID,
+        ...(body.name ? { name: body.name } : {}),
+      }) as never
     }
     return organizationContext(options.context) as never
   })
@@ -255,6 +268,49 @@ describe("the organization half of the scope switcher", () => {
     expect(posts[1]?.body).toEqual({
       organization_id: SECOND_ORGANIZATION_ID,
     })
+  })
+
+  it("says the switch is running before it says the switch failed", async () => {
+    // Two states, one step: the organization exists the moment the create
+    // lands, so the body has to say what is happening rather than announcing a
+    // failure that has not happened yet.
+    let release = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    mockApi({ switchFails: true, switchGate: gate })
+    await renderSwitcher()
+
+    const { user, menu } = await openMenu()
+    await user.click(
+      within(menu).getByRole("button", { name: /Create organization/ }),
+    )
+    await user.type(await screen.findByLabelText(/Name/), "Research")
+    const form = await screen.findByRole("dialog")
+    await user.click(
+      within(form).getByRole("button", { name: "Create organization" }),
+    )
+
+    // In flight: the create is done and the switch is not.
+    expect(
+      await within(form).findByText("Research was created. Switching into it…"),
+    ).toBeVisible()
+    expect(
+      await within(form).findByRole("heading", {
+        name: "Organization created",
+      }),
+    ).toBeVisible()
+
+    release()
+
+    expect(
+      await within(form).findByText(
+        "Research was created. Switching into it failed.",
+      ),
+    ).toBeVisible()
+    expect(await within(form).findByRole("alert")).toHaveTextContent(
+      "Organization not found",
+    )
   })
 
   it("retries only the switch when the switch after a create was refused", async () => {

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -491,6 +491,29 @@ describe("the workspace half of the scope switcher", () => {
         name: /^Switch workspace, currently Staging/,
       }),
     ).toBeInTheDocument()
+
+    // And the next open is usable. This is the path that leaves `holding` set:
+    // the create navigated, so nothing unmounted the form and nothing cleared
+    // the flag, and an unkeyed mount reopens spinning with its Cancel and Close
+    // disabled and no way out. The remount on the way in is what clears it.
+    await user.click(
+      await screen.findByRole("button", { name: /^Switch workspace/ }),
+    )
+    await user.click(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Create workspace",
+      }),
+    )
+    const reopened = await screen.findByRole("dialog", {
+      name: "New workspace",
+    })
+    expect(reopened.querySelector("form")).not.toHaveAttribute(
+      "aria-busy",
+      "true",
+    )
+    expect(
+      within(reopened).getByRole("button", { name: "Cancel" }),
+    ).toBeEnabled()
   })
 
   it("cannot be dismissed mid-create, so the entry it promised happens", async () => {

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -88,6 +88,16 @@ export function WorkspaceSwitcher({
   const [open, setOpen] = useState(false)
   const [creating, setCreating] = useState(false)
   const [creatingOrganization, setCreatingOrganization] = useState(false)
+  // Bumped on each open, and the create form is keyed on it, so the draft is
+  // fresh every time and untouched through the exit: the dialog keeps its
+  // content while it animates out, so clearing on the way out would blank the
+  // body in front of the operator. See feedback.md, "A draft is fresh on every
+  // open and untouched through the exit".
+  const [creatingOrganizationCount, setCreatingOrganizationCount] = useState(0)
+  const openCreateOrganization = () => {
+    setCreatingOrganizationCount((n) => n + 1)
+    setCreatingOrganization(true)
+  }
   // Owners and admins only, which is what the server says of
   // `POST /v1/workspaces` and what the Workspaces page gates its own create
   // control on. Without it a member or a viewer is handed the whole form from
@@ -337,7 +347,7 @@ export function WorkspaceSwitcher({
               className={`${MENU_ROW} text-muted hover:bg-surface-alt hover:text-foreground`}
               onClick={() => {
                 setOpen(false)
-                setCreatingOrganization(true)
+                openCreateOrganization()
               }}
             >
               <PlusMark />
@@ -370,6 +380,7 @@ export function WorkspaceSwitcher({
         hold={createHold}
       />
       <CreateOrganizationForm
+        key={creatingOrganizationCount}
         isOpen={creatingOrganization}
         onClose={() => setCreatingOrganization(false)}
       />

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -93,6 +93,12 @@ export function WorkspaceSwitcher({
   // content while it animates out, so clearing on the way out would blank the
   // body in front of the operator. See feedback.md, "A draft is fresh on every
   // open and untouched through the exit".
+  const [creatingCount, setCreatingCount] = useState(0)
+  const openCreateWorkspace = () => {
+    setOpen(false)
+    setCreatingCount((n) => n + 1)
+    setCreating(true)
+  }
   const [creatingOrganizationCount, setCreatingOrganizationCount] = useState(0)
   const openCreateOrganization = () => {
     setCreatingOrganizationCount((n) => n + 1)
@@ -327,10 +333,7 @@ export function WorkspaceSwitcher({
               <button
                 type="button"
                 className={`${MENU_ROW} font-semibold text-muted hover:bg-surface-alt hover:text-foreground`}
-                onClick={() => {
-                  setOpen(false)
-                  setCreating(true)
-                }}
+                onClick={openCreateWorkspace}
               >
                 <PlusMark />
                 <span className="min-w-0 flex-1 truncate">
@@ -361,7 +364,13 @@ export function WorkspaceSwitcher({
       {/* Both entry points from this menu open the dialog every create in the
           dashboard opens in, rather than a Modal wrapped by hand here: the two
           forms were already the page's, and what was local was the frame. */}
+      {/* Keyed on an open counter like its sibling below: nothing here unmounts
+          either form, so the remount on the way in is what clears the draft,
+          and with it the `holding` flag a create that navigates leaves set. An
+          unkeyed mount leaves the next open spinning, its Cancel and Close
+          disabled. */}
       <CreateWorkspaceForm
+        key={creatingCount}
         isOpen={creating}
         onClose={() => setCreating(false)}
         // Creating from the scope switcher is a request to work in the new

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Popover } from "@heroui/react"
+import { Button, Popover } from "@heroui/react"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 import { FiCheck, FiChevronDown, FiMail, FiPlus } from "react-icons/fi"
@@ -348,77 +348,31 @@ export function WorkspaceSwitcher({
           </Popover.Dialog>
         </Popover.Content>
       </Popover>
-      {/* Reuses the Workspaces page's own form rather than restating its fields:
-          the popover has no room for a form, and it dismisses on the first click
-          outside itself, which a name field cannot survive. */}
-      <Modal isOpen={creating} onOpenChange={setCreating}>
-        {/* The menu row is the trigger, and it lives inside a popover that has
-            already dismissed by the time this opens, so the modal is driven from
-            state instead. HeroUI still renders a press responder for the trigger
-            slot and warns when nothing fills it, which is why this is hidden
-            rather than absent; `SettingsPage` does the same for its own dialog. */}
-        <Modal.Trigger className="hidden">Create workspace</Modal.Trigger>
-        {/* An explicit dim: HeroUI maps `--backdrop` to opaque black, which the
-            AlertDialog softens itself and the Modal does not, so without this the
-            page behind the form goes fully black. */}
-        <Modal.Backdrop className="bg-backdrop/50">
-          {/* A fixed width, not the content's own. The container is the
-              `sm:w-fit` element and `size="md"` only caps the dialog at
-              `max-w-md`, so the modal was as wide as whatever was in it: a
-              message longer than the fields made it jump out to the cap the
-              moment one appeared. 28rem is that cap, so this pins the width it
-              was already growing to, and the dialog's own `w-full` fills it.
-              Below `sm` the container is `w-full` and this does not apply. */}
-          <Modal.Container
-            placement="center"
-            size="md"
-            className="sm:w-[28rem]"
-          >
-            {/* The dialog's own padding, because the form inside it is
-                fields only: the page that also renders it supplies a band, and
-                a band cannot come in here (`.otari-bleed` measures `<main>`,
-                which a portalled modal is outside of). */}
-            <Modal.Dialog aria-label="Create workspace" className="p-5">
-              <CreateWorkspaceForm
-                onClose={() => setCreating(false)}
-                // Creating from the scope switcher is a request to work in the
-                // new workspace, so the flow ends inside it rather than back on
-                // the page it was started from: the shell's scope moves, and the
-                // overview is where that scope reads. Selecting by id is enough
-                // even though the switcher's list comes from the organization
-                // context: the mutation invalidates that context, and the
-                // selection resolves against the membership as soon as it
-                // arrives. Navigating also leaves whatever organization-scoped
-                // page the operator was on, which the new scope does not apply
-                // to.
-                onCreated={(workspace) => {
-                  select(workspace.id)
-                  void navigate({ to: "/" })
-                }}
-                hold={createHold}
-              />
-            </Modal.Dialog>
-          </Modal.Container>
-        </Modal.Backdrop>
-      </Modal>
-      {/* Its own modal rather than one dialog switching on which row opened it:
-          the two forms share no field, and a single state would have to encode
-          "which" as well as "open". */}
-      <Modal
+      {/* Both entry points from this menu open the dialog every create in the
+          dashboard opens in, rather than a Modal wrapped by hand here: the two
+          forms were already the page's, and what was local was the frame. */}
+      <CreateWorkspaceForm
+        isOpen={creating}
+        onClose={() => setCreating(false)}
+        // Creating from the scope switcher is a request to work in the new
+        // workspace, so the flow ends inside it rather than back on the page it
+        // was started from: the shell's scope moves, and the overview is where
+        // that scope reads. Selecting by id is enough even though the switcher's
+        // list comes from the organization context: the mutation invalidates
+        // that context, and the selection resolves against the membership as
+        // soon as it arrives. Navigating also leaves whatever
+        // organization-scoped page the operator was on, which the new scope does
+        // not apply to.
+        onCreated={(workspace) => {
+          select(workspace.id)
+          void navigate({ to: "/" })
+        }}
+        hold={createHold}
+      />
+      <CreateOrganizationForm
         isOpen={creatingOrganization}
-        onOpenChange={setCreatingOrganization}
-      >
-        <Modal.Trigger className="hidden">Create organization</Modal.Trigger>
-        <Modal.Backdrop className="bg-backdrop/50">
-          <Modal.Container placement="center" size="md">
-            <Modal.Dialog aria-label="Create organization" className="p-0">
-              <CreateOrganizationForm
-                onClose={() => setCreatingOrganization(false)}
-              />
-            </Modal.Dialog>
-          </Modal.Container>
-        </Modal.Backdrop>
-      </Modal>
+        onClose={() => setCreatingOrganization(false)}
+      />
     </>
   )
 }

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -370,7 +370,10 @@ export function WorkspaceSwitcher({
           unkeyed mount leaves the next open spinning, its Cancel and Close
           disabled. */}
       <CreateWorkspaceForm
-        key={creatingCount}
+        // Namespaced, not the bare counter: the two forms are siblings and both
+        // counters start at 0, so bare numbers collide on every open where they
+        // match and React resolves its sibling key map last-write-wins.
+        key={`workspace-${creatingCount}`}
         isOpen={creating}
         onClose={() => setCreating(false)}
         // Creating from the scope switcher is a request to work in the new
@@ -389,7 +392,7 @@ export function WorkspaceSwitcher({
         hold={createHold}
       />
       <CreateOrganizationForm
-        key={creatingOrganizationCount}
+        key={`organization-${creatingOrganizationCount}`}
         isOpen={creatingOrganization}
         onClose={() => setCreatingOrganization(false)}
       />

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -165,6 +165,27 @@ describe("BudgetsPage", () => {
     vi.restoreAllMocks()
   })
 
+  it("offers a fresh draft on each open of the create dialog", async () => {
+    // Reset on the way in, not on the way out: the dialog keeps its content
+    // while it animates out, so clearing on close blanks the body in front of
+    // the operator. The page keys the form on an open counter instead.
+    mockApi({})
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create budget" }),
+    )
+    await user.type(screen.getByLabelText("Name (optional)"), "half-typed")
+
+    // Out through the guard, which is the only way out of a dirty form.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+
+    await user.click(screen.getByRole("button", { name: "Create budget" }))
+    expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
+  })
+
   it("keeps the page's create action visible while the dialog is open", async () => {
     mockApi({ budgets: [] })
     const user = userEvent.setup()

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -165,27 +165,6 @@ describe("BudgetsPage", () => {
     vi.restoreAllMocks()
   })
 
-  it("offers a fresh draft on each open of the create dialog", async () => {
-    // Reset on the way in, not on the way out: the dialog keeps its content
-    // while it animates out, so clearing on close blanks the body in front of
-    // the operator. The page keys the form on an open counter instead.
-    mockApi({})
-    const user = userEvent.setup()
-    renderPage(<BudgetsPage />)
-
-    await user.click(
-      await screen.findByRole("button", { name: "Create budget" }),
-    )
-    await user.type(screen.getByLabelText("Name (optional)"), "half-typed")
-
-    // Out through the guard, which is the only way out of a dirty form.
-    await user.keyboard("{Escape}")
-    await user.click(screen.getByRole("button", { name: "Discard" }))
-
-    await user.click(screen.getByRole("button", { name: "Create budget" }))
-    expect(screen.getByLabelText("Name (optional)")).toHaveValue("")
-  })
-
   it("keeps the page's create action visible while the dialog is open", async () => {
     mockApi({ budgets: [] })
     const user = userEvent.setup()

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -537,10 +537,20 @@ function DeploymentBudgetsPage() {
   // panel it sits in, so react-aria has nothing to restore to and focus falls
   // to body, which restarts Tab at the top of the document.
   const createButtonRef = useRef<HTMLButtonElement>(null)
-  // Bumped on every open and used as the create dialog's key. The draft is
-  // cleared on the way in rather than on the way out, which lets the dialog
-  // animate away with its fields intact.
+  // Bumped on each open, and the create dialog is keyed on it, so the draft is
+  // fresh every time and untouched through the exit: the dialog keeps its
+  // content while it animates out, so clearing on the way out would blank the
+  // body in front of the operator. See feedback.md, "A draft is fresh on every
+  // open and untouched through the exit".
+  //
+  // One function rather than the two statements at each opener: this page has
+  // two openers, and a counter is only a remount while every one of them bumps
+  // it.
   const [addOpenCount, setAddOpenCount] = useState(0)
+  const openCreate = () => {
+    setAddOpenCount((n) => n + 1)
+    setAddOpen(true)
+  }
   const [editing, setEditing] = useState<string | null>(null)
   const [historyOpen, setHistoryOpen] = useState<string | null>(null)
   const [pendingDelete, setPendingDelete] = useState<Budget>()
@@ -801,8 +811,7 @@ function DeploymentBudgetsPage() {
               setEditing(null)
               setAssignmentError(null)
               setPendingAssignments(null)
-              setAddOpenCount((count) => count + 1)
-              setAddOpen(true)
+              openCreate()
             }}
           >
             Create budget
@@ -840,8 +849,7 @@ function DeploymentBudgetsPage() {
             setEditing(null)
             setAssignmentError(null)
             setPendingAssignments(null)
-            setAddOpenCount((count) => count + 1)
-            setAddOpen(true)
+            openCreate()
           }}
         />
       ) : null}

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -1,6 +1,5 @@
-import { Button, Card } from "@heroui/react"
 import { useState } from "react"
-import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import {
   useCreateOrganization,
@@ -13,47 +12,51 @@ import {
 // somebody else should not be moved out of their own. From the scope switcher
 // the two belong together, so this chains them, and a switch that fails leaves
 // the organization created and reachable from the same menu rather than lost.
-export function CreateOrganizationForm({ onClose }: { onClose: () => void }) {
+export function CreateOrganizationForm({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
   const create = useCreateOrganization()
   const switchTo = useSwitchOrganization()
   const [name, setName] = useState("")
   const trimmed = name.trim()
   return (
-    <Card>
-      <Card.Content className="flex flex-col gap-4 p-5">
-        <h2 className="text-title">Create organization</h2>
-        <ErrorBanner error={create.error ?? switchTo.error} />
-        <Field
-          label="Name"
-          value={name}
-          onChange={setName}
-          placeholder="Research"
-          isRequired
-          autoFocus
-          description="You become its owner, and it starts with a default workspace. Names do not have to be unique."
-        />
-        <div className="flex gap-2">
-          <Button
-            variant="primary"
-            isDisabled={trimmed === ""}
-            isPending={create.isPending || switchTo.isPending}
-            onPress={() =>
-              create.mutate(
-                { name: trimmed },
-                {
-                  onSuccess: (organization) =>
-                    switchTo.mutate(organization.id, { onSuccess: onClose }),
-                },
-              )
-            }
-          >
-            Create organization
-          </Button>
-          <Button variant="ghost" onPress={onClose}>
-            Cancel
-          </Button>
-        </div>
-      </Card.Content>
-    </Card>
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // One field, which is what `sm` is for.
+      size="sm"
+      title="New organization"
+      submitLabel="Create organization"
+      onSubmit={() =>
+        create.mutate(
+          { name: trimmed },
+          {
+            onSuccess: (organization) =>
+              switchTo.mutate(organization.id, { onSuccess: onClose }),
+          },
+        )
+      }
+      isPending={create.isPending || switchTo.isPending}
+      isSubmitDisabled={trimmed === ""}
+      isDirty={trimmed !== ""}
+      error={create.error ?? switchTo.error}
+    >
+      <Field
+        label="Name"
+        value={name}
+        onChange={setName}
+        placeholder="Research"
+        isRequired
+        autoFocus
+        description="You become its owner, and it starts with a default workspace. Names do not have to be unique."
+        reserveMessage
+      />
+    </FormDialog>
   )
 }

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -37,7 +37,10 @@ export function CreateOrganizationForm({
       }}
       // One field, which is what `sm` is for.
       size="sm"
-      title="New organization"
+      // The state, once there is one: nothing is left to create, and the frame
+      // saying "New organization" over a created one is the last thing still
+      // claiming nothing happened. Same shape as the keys page's secret step.
+      title={created ? "Organization created" : "New organization"}
       submitLabel={created ? "Switch to organization" : "Create organization"}
       onSubmit={() => {
         if (created) {
@@ -61,18 +64,27 @@ export function CreateOrganizationForm({
       isDirty={created === null && trimmed !== ""}
       error={create.error ?? switchTo.error}
     >
-      <Field
-        label="Name"
-        value={name}
-        onChange={setName}
-        placeholder="Research"
-        isRequired
-        autoFocus
-        // Editing it after the create would change nothing the retry sends.
-        isDisabled={created !== null}
-        description="You become its owner, and it starts with a default workspace. Names do not have to be unique."
-        reserveMessage
-      />
+      {created ? (
+        // The success step swaps the children as well as the label: a form that
+        // still looks unsubmitted reads as "nothing happened", and the operator
+        // closes it and creates the organization a second time. The field is
+        // gone rather than disabled, and so is its description, which describes
+        // a create that has already happened.
+        <p className="text-body">
+          {created.name} was created. Switching into it failed.
+        </p>
+      ) : (
+        <Field
+          label="Name"
+          value={name}
+          onChange={setName}
+          placeholder="Research"
+          isRequired
+          autoFocus
+          description="You become its owner, and it starts with a default workspace. Names do not have to be unique."
+          reserveMessage
+        />
+      )}
     </FormDialog>
   )
 }

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import type { Organization } from "@/client"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import {
@@ -22,6 +23,11 @@ export function CreateOrganizationForm({
   const create = useCreateOrganization()
   const switchTo = useSwitchOrganization()
   const [name, setName] = useState("")
+  // Only the second call is left to retry once the first has succeeded, so the
+  // organization it returned is held here and the submit becomes that call.
+  // Pressing the button again otherwise creates a second organization, which
+  // is the one failure of this pair an operator cannot undo from the menu.
+  const [created, setCreated] = useState<Organization | null>(null)
   const trimmed = name.trim()
   return (
     <FormDialog
@@ -32,19 +38,27 @@ export function CreateOrganizationForm({
       // One field, which is what `sm` is for.
       size="sm"
       title="New organization"
-      submitLabel="Create organization"
-      onSubmit={() =>
+      submitLabel={created ? "Switch to organization" : "Create organization"}
+      onSubmit={() => {
+        if (created) {
+          switchTo.mutate(created.id, { onSuccess: onClose })
+          return
+        }
         create.mutate(
           { name: trimmed },
           {
-            onSuccess: (organization) =>
-              switchTo.mutate(organization.id, { onSuccess: onClose }),
+            onSuccess: (organization) => {
+              setCreated(organization)
+              switchTo.mutate(organization.id, { onSuccess: onClose })
+            },
           },
         )
-      }
+      }}
       isPending={create.isPending || switchTo.isPending}
-      isSubmitDisabled={trimmed === ""}
-      isDirty={trimmed !== ""}
+      isSubmitDisabled={created === null && trimmed === ""}
+      // Closing after the create succeeded discards nothing: the organization
+      // exists, and the menu it was started from lists it.
+      isDirty={created === null && trimmed !== ""}
       error={create.error ?? switchTo.error}
     >
       <Field
@@ -54,6 +68,8 @@ export function CreateOrganizationForm({
         placeholder="Research"
         isRequired
         autoFocus
+        // Editing it after the create would change nothing the retry sends.
+        isDisabled={created !== null}
         description="You become its owner, and it starts with a default workspace. Names do not have to be unique."
         reserveMessage
       />

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -71,7 +71,9 @@ export function CreateOrganizationForm({
         // gone rather than disabled, and so is its description, which describes
         // a create that has already happened.
         <p className="text-body">
-          {created.name} was created. Switching into it failed.
+          {switchTo.isPending
+            ? `${created.name} was created. Switching into it…`
+            : `${created.name} was created. Switching into it failed.`}
         </p>
       ) : (
         <Field

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -183,6 +183,29 @@ describe("WorkspacesPage", () => {
     ).toBeNull()
   })
 
+  it("offers a fresh draft on each open of the create dialog", async () => {
+    // Reset on the way in, not on the way out: the dialog keeps its content
+    // while it animates out, so clearing on close blanks the body in front of
+    // the operator. The page keys the form on an open counter instead.
+    mockApi({})
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create workspace" }),
+    )
+    await user.type(screen.getByLabelText("Name"), "half-typed")
+
+    // Out through the guard, which is the only way out of a dirty form.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create workspace" }),
+    )
+    expect(screen.getByLabelText("Name")).toHaveValue("")
+  })
+
   it("puts a refused create on the name that caused it, not in a banner", async () => {
     // A banner above the form resizes whatever frames it, and every way this
     // endpoint refuses is about the name: taken, empty, too long.

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -163,7 +163,11 @@ describe("WorkspacesPage", () => {
   // The form itself carries no band, so that the scope switcher can put it in a
   // modal (otari-ai#2107). The band belongs to this page, and it is pinned here
   // because losing it is invisible in jsdom: the fields render either way.
-  it("frames the create form as a band of the page", async () => {
+  it("opens the create form in the dialog rather than as a band of the page", async () => {
+    // The contract this asserts is the opposite of the one it used to: the form
+    // was a bleeding band between the page's header and its table, and the same
+    // form in the scope switcher was a Modal of its own. One frame now, and it
+    // is over the page rather than in it.
     mockApi({})
     const user = userEvent.setup()
     renderPage(<WorkspacesPage />)
@@ -172,11 +176,11 @@ describe("WorkspacesPage", () => {
       await screen.findByRole("button", { name: "Create workspace" }),
     )
 
-    // Reached from the field rather than from the page, because a page is
-    // several bands and only this one frames the form.
-    const band = screen.getByLabelText("Name").closest("section.otari-bleed")
-    expect(band).not.toBeNull()
-    expect(band).toHaveClass("border-y")
+    const dialog = await screen.findByRole("dialog", { name: "New workspace" })
+    expect(within(dialog).getByLabelText("Name")).toBeInTheDocument()
+    expect(
+      screen.getByLabelText("Name").closest("section.otari-bleed"),
+    ).toBeNull()
   })
 
   it("puts a refused create on the name that caused it, not in a banner", async () => {

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen, within } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -204,6 +204,61 @@ describe("WorkspacesPage", () => {
       await screen.findByRole("button", { name: "Create workspace" }),
     )
     expect(screen.getByLabelText("Name")).toHaveValue("")
+  })
+
+  it("keeps the empty state under the dialog, so focus has somewhere to return", async () => {
+    // The empty state used to unmount while the form was open, which was right
+    // for a band on the page and wrong for a dialog over it: it takes away the
+    // node react-aria stored, and closing drops focus to `<body>` where the
+    // next Tab starts at the top of the document.
+    mockApi({ workspaces: [] })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    const trigger = await screen.findByRole("button", {
+      name: "Create a workspace",
+    })
+    await user.click(trigger)
+    await screen.findByRole("dialog", { name: "New workspace" })
+
+    expect(screen.getByText("No workspaces yet")).toBeInTheDocument()
+    // Nothing typed, so Escape closes rather than arming the guard.
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it("guards a chosen default budget on the way out, with nothing typed", async () => {
+    // The guard reads one snapshot of the whole draft, so it sees the fields
+    // nobody remembered to list. It used to read the name and the description
+    // only: pick a budget, press Escape, and the choice went with no warning.
+    mockApi({
+      budgets: [budget({ budget_id: "bud-team", name: "Team standard" })],
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create workspace" }),
+    )
+    await user.click(
+      screen.getByRole("button", { name: /Default member budget/ }),
+    )
+    await user.click(
+      await screen.findByRole("option", { name: /Team standard/ }),
+    )
+
+    // Through Cancel rather than Escape: in jsdom focus lands on `<body>` after
+    // picking from a `Select`, so a keystroke reaches nothing.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(
+      await screen.findByRole("button", { name: "Discard" }),
+    ).toBeInTheDocument()
+    // Behind the guard rather than gone, so Keep editing returns to the choice.
+    await user.click(screen.getByRole("button", { name: "Keep editing" }))
+    expect(
+      screen.getByRole("button", { name: /Default member budget/ }),
+    ).toHaveTextContent("Team standard")
   })
 
   it("puts a refused create on the name that caused it, not in a banner", async () => {

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -656,6 +656,16 @@ export function WorkspacesPage() {
   const remove = useDeleteWorkspace()
 
   const [creating, setCreating] = useState(false)
+  // Bumped on each open, and the create form is keyed on it, so the draft is
+  // fresh every time and untouched through the exit: the dialog keeps its
+  // content while it animates out, so clearing on the way out would blank the
+  // body in front of the operator. See feedback.md, "A draft is fresh on every
+  // open and untouched through the exit".
+  const [creatingCount, setCreatingCount] = useState(0)
+  const openCreate = () => {
+    setCreatingCount((n) => n + 1)
+    setCreating(true)
+  }
   const [editing, setEditing] = useState<string | null>(null)
   const [deleting, setDeleting] = useState<Workspace | null>(null)
 
@@ -797,7 +807,7 @@ export function WorkspacesPage() {
               variant="primary"
               onPress={() => {
                 setEditing(null)
-                setCreating(true)
+                openCreate()
               }}
             >
               Create workspace
@@ -824,6 +834,7 @@ export function WorkspacesPage() {
       )}
 
       <CreateWorkspaceForm
+        key={creatingCount}
         isOpen={creating}
         onClose={() => setCreating(false)}
       />
@@ -843,7 +854,7 @@ export function WorkspacesPage() {
           title="No workspaces yet"
           description="A workspace groups the work inside this organization and carries its own members and roles. Every organization is created with one, so an empty list usually means the default was deleted."
           actionLabel={manages ? "Create a workspace" : undefined}
-          onAction={manages ? () => setCreating(true) : undefined}
+          onAction={manages ? openCreate : undefined}
         />
       ) : (
         <TableScrollFrame className="otari-workspaces-table">

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -85,6 +85,11 @@ function DefaultBudgetPicker({
       label="Default member budget"
       value={value}
       onChange={onChange}
+      // No description and nothing that can be invalid, so there is no message
+      // this could ever hold. `FieldMessages` reserves the line by default, and
+      // `FilterSelect` reserved nothing, so the swap to `Select` brought ~23px
+      // of empty back with it.
+      reserveMessage={false}
       options={[
         { value: NO_DEFAULT, label: "No default" },
         ...budgetChoices(budgets),
@@ -338,6 +343,13 @@ export function CreateWorkspaceForm({
     }
   }, [])
   const trimmed = name.trim()
+  // One snapshot of everything the form owns, seeded on mount: dirty means
+  // "differs from what was seeded", and a field added to the form is added here
+  // or the guard cannot see it. A predicate of empties had already forgotten
+  // `budgetId`, so picking a default member budget and pressing Escape
+  // discarded it with no guard.
+  const draft = JSON.stringify({ name, description, budgetId })
+  const seededDraft = useRef(draft)
   // The submit promises the navigation only where it performs one, so the label
   // and the hold below are read off the same prop that does it. A form whose
   // button said "and open" while nothing opened would be the worse bug of the
@@ -379,8 +391,10 @@ export function CreateWorkspaceForm({
             // the list and the switcher will both show it, but the
             // operator said not to go there.
             if (!active.current) return
-            // No setHolding here: the form unmounts on close, and the
-            // failure paths below are what release the button.
+            // No setHolding here: nothing unmounts this form, so what
+            // releases the button is the remount on the next open, which both
+            // callers get by keying it on an open counter. The failure paths
+            // below release it in place.
             onClose()
             onCreated?.(workspace)
           }
@@ -417,7 +431,7 @@ export function CreateWorkspaceForm({
       onSubmit={submit}
       isPending={pending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={trimmed !== "" || description.trim() !== ""}
+      isDirty={draft !== seededDraft.current}
       // A refusal about the name is carried by the name, not by a block above
       // the form. What reaches the banner is what no field state can honestly
       // say: a failure the operator cannot retype their way out of, and the
@@ -704,7 +718,10 @@ export function WorkspacesPage() {
   const isOnlyWorkspace = workspaces.isSuccess && rows.length === 1
   const manages = canManage(context.data)
   const editingWorkspace = rows.find((row) => row.id === editing) ?? null
-  const showOnboarding = !workspaces.isLoading && rows.length === 0 && !creating
+  // Not gated on `creating`: unmounting the empty state when the dialog opens
+  // takes away the node react-aria restores focus to, so closing drops focus to
+  // `<body>`. `PageIntro`'s action is ungated for the same reason.
+  const showOnboarding = !workspaces.isLoading && rows.length === 0
 
   // The default-budget column is dropped, not emptied, for a caller who cannot
   // read the budget names it shows; see the note on `operates` above.

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -456,6 +456,9 @@ export function CreateWorkspaceForm({
         label="Description (optional)"
         value={description}
         onChange={setDescription}
+        // No description under it, so no line held open for one. See forms.md:
+        // the reserve exists for an error to replace a description in.
+        reserveMessage={false}
       />
       {/* Withheld from a caller who does not operate the deployment: the
           picker's options come from the operator-gated `/budgets` read, so

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner } from "@heroui/react"
+import { Button } from "@heroui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import type { Budget, Workspace, WorkspaceBudgetDefault } from "@/client"
@@ -8,6 +8,7 @@ import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { EmptyState } from "@/design-system/feedback/EmptyState"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
 import { PageIntro } from "@/design-system/layout/PageIntro"
@@ -277,10 +278,12 @@ const defaultHold = () =>
  * wide there and the dialog clipped it away to an empty modal.
  */
 export function CreateWorkspaceForm({
+  isOpen,
   onClose,
   onCreated,
   hold = defaultHold,
 }: {
+  isOpen: boolean
   onClose: () => void
   /**
    * The acknowledged-press beat, as a gate rather than a duration. Defaults to
@@ -354,16 +357,73 @@ export function CreateWorkspaceForm({
   // a create that failed for another reason, and the default-budget call, which
   // fails after the workspace already exists.
   const bannerError = createDefault.error ?? (nameRefusal ? null : create.error)
+  const submit = () => {
+    // Started before the request, not after it answers, so the two run
+    // together: the operator waits a beat, not a beat plus a round
+    // trip. A create slower than the hold keeps the spinner until it
+    // answers, which is the honest reading of the same indicator.
+    const held = entersWorkspace ? hold() : Promise.resolve()
+    setHolding(entersWorkspace)
+    create.mutate(
+      { name: trimmed, description: description.trim() || null },
+      {
+        // The default is a second call: the workspace has to exist
+        // before anything can be defaulted onto its members. A failure
+        // here leaves the workspace created and undefaulted, which the
+        // banner reports and the edit form can finish.
+        onSuccess: (workspace) => {
+          const finish = async () => {
+            await held
+            // Dismissed while it was held: the workspace exists, and
+            // the list and the switcher will both show it, but the
+            // operator said not to go there.
+            if (!active.current) return
+            // No setHolding here: the form unmounts on close, and the
+            // failure paths below are what release the button.
+            onClose()
+            onCreated?.(workspace)
+          }
+          if (budgetId === NO_DEFAULT) {
+            void finish()
+            return
+          }
+          createDefault.mutate(
+            {
+              workspaceId: workspace.id,
+              body: { budget_id: budgetId },
+            },
+            {
+              onSuccess: () => {
+                void finish()
+              },
+              onError: () => setHolding(false),
+            },
+          )
+        },
+        onError: () => setHolding(false),
+      },
+    )
+  }
+
   return (
-    <div className="flex flex-col gap-4">
-      <h2 className="text-title">Create workspace</h2>
-      {/* A refusal about the name is carried by the name, not by a block above
-          the form that resizes whatever frames it. What is left here is what
-          no field state can honestly say: a failure the operator cannot
-          retype their way out of, and the default-budget call, which is a
-          separate call about a different control and fails after the
-          workspace already exists. */}
-      <ErrorBanner error={bannerError} />
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title="New workspace"
+      submitLabel={entersWorkspace ? "Create and open" : "Create workspace"}
+      onSubmit={submit}
+      isPending={pending}
+      isSubmitDisabled={trimmed === ""}
+      isDirty={trimmed !== "" || description.trim() !== ""}
+      // A refusal about the name is carried by the name, not by a block above
+      // the form. What reaches the banner is what no field state can honestly
+      // say: a failure the operator cannot retype their way out of, and the
+      // default-budget call, which is a separate call about a different control
+      // and fails after the workspace already exists.
+      error={bannerError}
+    >
       <Field
         label="Name"
         value={name}
@@ -408,95 +468,7 @@ export function CreateWorkspaceForm({
           onChange={setBudgetId}
         />
       ) : null}
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={trimmed === ""}
-          isPending={pending}
-          onPress={() => {
-            // Started before the request, not after it answers, so the two run
-            // together: the operator waits a beat, not a beat plus a round
-            // trip. A create slower than the hold keeps the spinner until it
-            // answers, which is the honest reading of the same indicator.
-            const held = entersWorkspace ? hold() : Promise.resolve()
-            setHolding(entersWorkspace)
-            create.mutate(
-              { name: trimmed, description: description.trim() || null },
-              {
-                // The default is a second call: the workspace has to exist
-                // before anything can be defaulted onto its members. A failure
-                // here leaves the workspace created and undefaulted, which the
-                // banner reports and the edit form can finish.
-                onSuccess: (workspace) => {
-                  const finish = async () => {
-                    await held
-                    // Dismissed while it was held: the workspace exists, and
-                    // the list and the switcher will both show it, but the
-                    // operator said not to go there.
-                    if (!active.current) return
-                    // No setHolding here: the form unmounts on close, and the
-                    // failure paths below are what release the button.
-                    onClose()
-                    onCreated?.(workspace)
-                  }
-                  if (budgetId === NO_DEFAULT) {
-                    void finish()
-                    return
-                  }
-                  createDefault.mutate(
-                    {
-                      workspaceId: workspace.id,
-                      body: { budget_id: budgetId },
-                    },
-                    {
-                      onSuccess: () => {
-                        void finish()
-                      },
-                      onError: () => setHolding(false),
-                    },
-                  )
-                },
-                onError: () => setHolding(false),
-              },
-            )
-          }}
-        >
-          {/* The spinner takes the label's place rather than sitting beside
-              it, so pressing moves nothing: the label holds the button's width
-              while faded, and the spinner is centered over it by the `relative`
-              that `.button` already sets.
-
-              `opacity-0`, not `invisible`: visibility removes the label from
-              the accessibility tree, which would leave the button unnamed for
-              the whole wait. Faded, it still names the control while the
-              spinner reports the state. That is also why the spinner is
-              `aria-hidden` (and it is its own live region as of HeroUI 3.2.4,
-              which would announce a bare "Loading" over the name).
-
-              `color="current"` because the default is `accent`, which on this
-              accent-filled variant paints the spinner in the fill's own
-              color; `current` inherits the label's. */}
-          <span className={pending ? "opacity-0" : undefined}>
-            {entersWorkspace ? "Create and open" : "Create workspace"}
-          </span>
-          {pending ? (
-            <Spinner
-              size="sm"
-              color="current"
-              aria-hidden="true"
-              className="absolute inset-0 m-auto"
-            />
-          ) : null}
-        </Button>
-        {/* Disabled while the create is in flight, as `ConfirmDialog` does
-            with its own: the workspace is already being made, so offering to
-            abandon it mid-flight only invites the operator to expect that it
-            was not. */}
-        <Button variant="ghost" onPress={onClose} isDisabled={pending}>
-          Cancel
-        </Button>
-      </div>
-    </div>
+    </FormDialog>
   )
 }
 
@@ -816,7 +788,7 @@ export function WorkspacesPage() {
       <PageIntro
         title="Workspaces"
         action={
-          creating || !manages ? null : (
+          !manages ? null : (
             <Button
               variant="primary"
               onPress={() => {
@@ -847,11 +819,10 @@ export function WorkspacesPage() {
         </InfoBanner>
       )}
 
-      {creating ? (
-        <Section className="border-y border-border py-5">
-          <CreateWorkspaceForm onClose={() => setCreating(false)} />
-        </Section>
-      ) : null}
+      <CreateWorkspaceForm
+        isOpen={creating}
+        onClose={() => setCreating(false)}
+      />
 
       {/* Keyed on the workspace so switching which one is edited remounts the
           form: its fields seed from `workspace` on mount only. */}

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -11,6 +11,7 @@ import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
+import { Select } from "@/design-system/forms/Select"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
@@ -80,7 +81,7 @@ function DefaultBudgetPicker({
   onChange: (budgetId: string) => void
 }) {
   return (
-    <FilterSelect
+    <Select
       label="Default member budget"
       value={value}
       onChange={onChange}

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react"
 
 import type { Budget, Workspace, WorkspaceBudgetDefault } from "@/client"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
@@ -12,6 +12,7 @@ import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
 import { Select } from "@/design-system/forms/Select"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
@@ -288,9 +289,12 @@ export function CreateWorkspaceForm({
   onClose,
   onCreated,
   hold = defaultHold,
+  returnFocusRef,
 }: {
   isOpen: boolean
   onClose: () => void
+  /** Where focus goes when the opener has gone; see `FormDialog`. */
+  returnFocusRef?: RefObject<HTMLElement | null>
   /**
    * The acknowledged-press beat, as a gate rather than a duration. Defaults to
    * `ENTER_HOLD_MS` of wall clock; a test supplies one it opens itself, so the
@@ -348,8 +352,7 @@ export function CreateWorkspaceForm({
   // or the guard cannot see it. A predicate of empties had already forgotten
   // `budgetId`, so picking a default member budget and pressing Escape
   // discarded it with no guard.
-  const draft = JSON.stringify({ name, description, budgetId })
-  const seededDraft = useRef(draft)
+  const { isDirty } = useDirtySnapshot({ name, description, budgetId })
   // The submit promises the navigation only where it performs one, so the label
   // and the hold below are read off the same prop that does it. A form whose
   // button said "and open" while nothing opened would be the worse bug of the
@@ -431,7 +434,8 @@ export function CreateWorkspaceForm({
       onSubmit={submit}
       isPending={pending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
+      returnFocusRef={returnFocusRef}
       // A refusal about the name is carried by the name, not by a block above
       // the form. What reaches the banner is what no field state can honestly
       // say: a failure the operator cannot retype their way out of, and the
@@ -676,6 +680,9 @@ export function WorkspacesPage() {
   // body in front of the operator. See feedback.md, "A draft is fresh on every
   // open and untouched through the exit".
   const [creatingCount, setCreatingCount] = useState(0)
+  // Where focus lands when the empty state's CTA has gone, which is what the
+  // first workspace created does to it.
+  const createButtonRef = useRef<HTMLButtonElement>(null)
   const openCreate = () => {
     setCreatingCount((n) => n + 1)
     setCreating(true)
@@ -821,6 +828,7 @@ export function WorkspacesPage() {
         action={
           !manages ? null : (
             <Button
+              ref={createButtonRef}
               variant="primary"
               onPress={() => {
                 setEditing(null)
@@ -854,6 +862,7 @@ export function WorkspacesPage() {
         key={creatingCount}
         isOpen={creating}
         onClose={() => setCreating(false)}
+        returnFocusRef={createButtonRef}
       />
 
       {/* Keyed on the workspace so switching which one is edited remounts the


### PR DESCRIPTION
## Description

The workspace form had **two frames**: a bleeding band between the page's header and its table, and a `Modal` hand-rolled in the scope switcher around the same component. Both are the dialog now, and `WorkspaceSwitcher` no longer imports `Modal` at all.

"Create and open" stays as the switcher's submit. It is a different verb because it navigates, and the label is the only warning an operator gets that the page is about to change under them.

**Create organization comes with it.** It is the switcher's other menu entry and was the twin of the workspace `Modal` sitting right beside it, so leaving it hand-rolled would have migrated one of two identical things. It was also built on HeroUI's `Card`, which `design/DESIGN.md` lists as "must not be used in new code", so that list drops from six call sites to five.

**Deleting the hand-rolled submit is this change's own argument.** That button had independently reached the same two conclusions `FormDialog` did: `opacity-0` rather than `invisible`, so the label survives in the accessibility tree and the button is never nameless mid-submit; and a spinner at `color="current"`, because the default `accent` paints it in the fill's own color. Its comment also knew something the component did not, that HeroUI 3.2.4's `Spinner` is its own live region, which is why the spinner is `aria-hidden`.

### Three test contracts changed

Each is rewritten where it is asserted, with a sentence saying what it used to hold. None was deleted.

1. **`frames the create form as a band of the page`** (the page) and **`frames the create form without the page's bleeding band`** (the switcher). These existed because the same form had two frames and each entry point had to pin its own. There is one frame now and neither owns it, so what is worth asserting is that both reach the shared dialog.
2. **`does not enter a workspace the operator dismissed the form over`.** The form disabled Cancel while a create was in flight and left Escape as a second answer, so an operator could create a workspace and suppress the navigation into it. `FormDialog` gives one answer: nothing dismisses a dialog while its submit is in flight. A create that cannot be cancelled cannot be half-cancelled either. This is a **user-visible behavior change** and the test now asserts the new contract by name.
3. **`data-pending="true"` on the submit** became `aria-busy` on the form. `FormDialog` withholds `isPending` from that button on purpose: the prop paints it at the product's disabled 0.4, and a submit in flight is working rather than refused.

### One defect found

The form kept its own `ErrorBanner` while the dialog rendered one from the same `error`, so a single failure showed as two `role="alert"` nodes. Caught by a test rather than by eye. Worth knowing for the pages still to migrate: any form with its own banner will do the same, and the other three migrated pages were checked and have none.

The create form takes `returnFocusRef`, pointing at the heading's own trigger, for the case where a successful first create retires the empty state whose CTA opened the dialog and react-aria has nothing left to restore focus to. It carries no test of its own here, deliberately: every version I wrote either passed while the empty state was still mounted, where the prop has no work to do, or turned into a fight with the mock rather than with the behavior. #1040 covers the same prop through the same component with a case that fails when the prop is removed, so the behavior is checked once where the check is trustworthy rather than twice where one of them proves nothing.

## How to test it locally

    pnpm --dir web run build
    pnpm --dir web exec playwright test --project=seed --project=screenshots-desktop-small-light --project=screenshots-mobile-light --grep "workspace dialogs"

Automated, all run on this commit:

- `pnpm --dir web test` — 5320 pass across 153 files; 273 in the three directories this touches.
- `pnpm --dir web run lint`, `run typecheck`, `run build` — clean.
- `storybook:build` then `node .storybook/smoke.mjs` — 383 stories x 2 themes, all rendered clean.
- **The whole behavioral Playwright set** (`onboarding`, `seed`, `parity`, `hybrid`) — 43 passed, 0 failed.

### What would have to break for each changed test to fail

| Change | Fails |
| --- | --- |
| render the page's form in a band again | `opens the create form in the dialog rather than as a band of the page` |
| give the switcher a frame of its own | `opens the same dialog the workspaces page opens` |
| let Escape dismiss while the submit is in flight | `cannot be dismissed mid-create, so the entry it promised happens` |
| pass `isPending` to the submit | `enters the workspace it just created` |

The `hold` gate keeps its own tests untouched: it is an injected wall-clock beat so the acknowledged-press window is entered and left deterministically, and it survives the migration unchanged.

### On the unslop pass

Run over this diff before opening. It tightened three test comments that explained the change at more length than the fact needed, and confirmed the deletions: 8 lines of hand-rolled spinner markup and its rationale go, along with the duplicated banner.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of #1031

Stacked on #1040 → #1038 → #1037 → #1032. Review those first; this branch contains their commits.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      Three contracts rewritten with their reasons, one screenshot capture, and
      the existing 273 cases in the touched directories kept green. The
      dashboard's tests live under `web/src` and `web/e2e`.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      The dashboard's counterparts; `make lint` does not reach `web/`.
- [ ] Documentation was updated where necessary.
      The design system's deprecated-`Card` table names six call sites and this
      leaves five. Left for the change that owns that table rather than edited
      from here, since its own note says the counts are prose and should be
      checked against the tree.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      No API change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The Escape-during-create change is the one thing here that alters what the product does rather than where it draws it, and it was raised and ruled on before it landed rather than discovered in review.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Workspace and organization creation now use the shared `FormDialog`. This removes custom page sections, cards, and modal layouts.

The dialogs now manage submission state, errors, dismissal rules, and responsive layout. Users cannot dismiss a dialog while creation is in progress. The workspace switcher keeps its “Create and open” behavior.

Tests cover dialog opening, fresh forms, blocked dismissal, pending state, retries, and visual snapshots for create dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
