### PR TITLE
docs(skills): say how a PR here loses its checks without saying so

### DIFF
--- a/.github/skills/pr-cycle/SKILL.md
+++ b/.github/skills/pr-cycle/SKILL.md
@@ -91,17 +91,26 @@ a screenshot entry so the page is covered when the suite becomes a gate.
 
 ## What CI runs on a PR, and the two ways it silently does not
 
-Every substantive workflow is declared `pull_request: branches: [ main ]`
+Every substantive workflow but one is declared `pull_request: branches: [ main ]`
 (`otari-dashboard.yml`, `otari-dashboard-parity.yml`, `otari-design-system.yml`,
-`otari-tests.yml`), and that filter is on the **base** branch. Two situations therefore leave a
+`otari-tests.yml`), and that filter is on the **base** branch. The exception is
+`otari-sdk-codegen-check.yml`, which declares `pull_request` with a `paths` filter and no
+`branches` key at all, so it matches any base: a stacked PR touching
+`docs/public/openapi.json` or `scripts/sdk_codegen/**` runs its four-language generate matrix
+and can go red where this section otherwise promises nothing. Two situations therefore leave a
 PR with almost no CI, and neither of them reports anything:
 
 - **A base that is not `main`.** A PR stacked on another feature branch matches no workflow, so
-  it gets only the two `pull_request_target` checks, `Lint PR title` and `PR Template Check`.
-  Retargeting a stacked PR onto its parent branch is what usually causes this, and the trade is
-  invisible in the direction you are looking: the diff gets smaller and the check count drops
-  from seven to one. Keep a stacked PR on base `main` and live with the inherited diff until its
-  parent merges.
+  it gets only the `pull_request_target` checks. Retargeting a stacked PR onto its parent branch
+  is what usually causes this, and the trade is invisible in the direction you are looking: the
+  diff gets smaller and the check count drops from seven to one or two. Both ends of that range
+  depend on when you look, and it is worth knowing why: `otari-pr-title.yml` lists `synchronize`, so
+  `Lint PR title` re-runs on every push and is attached to the current head, while
+  `pr-template-check.yml` lists only `opened` and `edited`, so `check-template` stays attached to
+  the sha the PR was opened (or last edited) at. So the ceiling is seven on that sha and six on
+  every head after a push, and the floor is two and then one. Measured on four stacked heads: one
+  row each, `Lint PR title`, with no `check-template` on any of them. Keep a stacked PR on base `main` and
+  live with the inherited diff until its parent merges.
 - **A `CONFLICTING` PR.** A `pull_request` workflow builds the PR's merge ref, and a conflicting
   PR has none, so nothing runs until the conflict is resolved. The tell is
   `mergeStateStatus: DIRTY` beside a check count that has stopped growing.
@@ -111,17 +120,21 @@ unsquashed commits and the squash on `main` are the same content twice.
 `git rebase --onto origin/main <the parent's old head>` drops the absorbed commits and clears it.
 
 **"Green" means the full expected set is present and none of it is pending**, which is not the
-same as nothing being pending. Both situations above produce a `gh pr checks` that lists one
-passing row, and one passing row reads as a clean result to anyone who does not already know
+same as nothing being pending. Both situations above produce a `gh pr checks` that lists one or
+two passing rows, and a passing row reads as a clean result to anyone who does not already know
 what the set should be. Check the names rather than only the buckets: on a dashboard change the
 substantive ones are `build`, `dashboard`, `e2e`, `catalog` and `serving`, and a run without
 them has covered nothing.
 
 A small set is not always one of the two faults above, though. Every one of these workflows also
 carries a `paths` filter, so a change that touches nothing they watch correctly runs almost
-nothing: a PR editing only `.github/skills/` or a file under `docs/` gets the template and title
-checks and no more, and that is the right answer rather than a symptom. The question to ask is
-whether the set matches the change, not whether the set is large.
+nothing: a PR editing only `.github/skills/`, or a `docs/` file other than `dashboard.md` and
+`public/openapi.json`, gets the title and template checks and no more, and that is the right
+answer rather than a symptom. Those two `docs/` paths are the exception, watched by
+`otari-dashboard.yml`, `otari-dashboard-parity.yml`, `otari-dashboard-serving.yml` and
+`otari-docker-build.yml` because the dashboard bundles the guide and generates its client from
+the spec, so a one-line edit to either runs `dashboard`, `e2e`, `serving` and `build`. The
+question to ask is whether the set matches the change, not whether the set is large.
 
 ## Generated artifacts a PR can owe
 
@@ -198,9 +211,10 @@ tool, `isolation: "worktree"`), each executing the cycle above.
   issues sharing a file are **sequenced**, with the later ones rebasing once the earlier lands.
 - **Order within a wave:** small and low-risk first, large refactors later, so the rebase surface
   stays small.
-- **A stacked PR loses two protections, so stack deliberately.** Basing a PR on a topic branch
-  instead of `main` buys a clean diff (only your own commits, not the parent's) and costs both of
-  the things that would otherwise catch a mistake. `protect-main` applies to the default branch
+- **A stacked PR loses three protections, so stack deliberately.** Basing a PR on a topic branch
+  instead of `main` buys a clean diff (only your own commits, not the parent's) and costs the
+  things that would otherwise catch a mistake. CI is the third and it has its own section above
+  ("What CI runs on a PR"); the other two: `protect-main` applies to the default branch
   only, so the child reports `mergeStateStatus: CLEAN` and can be merged into its base with **no
   approval and no thread resolution**, silently folding two reviews into one. And
   `.coderabbit.yaml` sets `base_branches: ["main"]`, so **CodeRabbit skips the child entirely**

--- a/.github/skills/pr-cycle/SKILL.md
+++ b/.github/skills/pr-cycle/SKILL.md
@@ -89,6 +89,34 @@ The dashboard has its own, which `make lint` does not touch: `pnpm --dir web run
 that suite runs on demand, so a PR that moves a page owes no PNGs; a PR that **adds** a page owes
 a screenshot entry so the page is covered when the suite becomes a gate.
 
+## What CI runs on a PR, and the two ways it silently does not
+
+Every substantive workflow is declared `pull_request: branches: [ main ]`
+(`otari-dashboard.yml`, `otari-dashboard-parity.yml`, `otari-design-system.yml`,
+`otari-tests.yml`), and that filter is on the **base** branch. Two situations therefore leave a
+PR with almost no CI, and neither of them reports anything:
+
+- **A base that is not `main`.** A PR stacked on another feature branch matches no workflow, so
+  it gets only the two `pull_request_target` checks, `Lint PR title` and `PR Template Check`.
+  Retargeting a stacked PR onto its parent branch is what usually causes this, and the trade is
+  invisible in the direction you are looking: the diff gets smaller and the check count drops
+  from seven to one. Keep a stacked PR on base `main` and live with the inherited diff until its
+  parent merges.
+- **A `CONFLICTING` PR.** A `pull_request` workflow builds the PR's merge ref, and a conflicting
+  PR has none, so nothing runs until the conflict is resolved. The tell is
+  `mergeStateStatus: DIRTY` beside a check count that has stopped growing.
+
+A child PR hits the second case as soon as its parent is squash-merged, because its own
+unsquashed commits and the squash on `main` are the same content twice.
+`git rebase --onto origin/main <the parent's old head>` drops the absorbed commits and clears it.
+
+**"Green" means the full expected set is present and none of it is pending**, which is not the
+same as nothing being pending. Both situations above produce a `gh pr checks` that lists one
+passing row, and one passing row reads as a clean result to anyone who does not already know
+what the set should be. Check the names rather than only the buckets: on a dashboard change the
+substantive ones are `build`, `dashboard`, `e2e`, `catalog` and `serving`, and a run without
+them has covered nothing.
+
 ## Generated artifacts a PR can owe
 
 - A route, a schema, **or a route docstring**: run `uv run python scripts/generate_openapi.py`,
@@ -220,7 +248,9 @@ tool, `isolation: "worktree"`), each executing the cycle above.
   its branch deleted **closes child B permanently**: B's base is gone and GitHub refuses to
   reopen a PR whose base branch was deleted (`422 "state cannot be changed"`), even if you
   recreate the branch. So `gh pr edit B --base main` **while A's branch still exists**, then merge
-  A. If B already closed this way, the only recovery is a fresh PR from B's head branch, linking
+  A. Base `main` is also what gets B any CI at all (see
+  [What CI runs on a PR](#what-ci-runs-on-a-pr-and-the-two-ways-it-silently-does-not)), so it is
+  where a stacked PR should have been sitting all along. If B already closed this way, the only recovery is a fresh PR from B's head branch, linking
   the old one for its review history.
 
 ## Non-negotiables

--- a/.github/skills/pr-cycle/SKILL.md
+++ b/.github/skills/pr-cycle/SKILL.md
@@ -117,6 +117,12 @@ what the set should be. Check the names rather than only the buckets: on a dashb
 substantive ones are `build`, `dashboard`, `e2e`, `catalog` and `serving`, and a run without
 them has covered nothing.
 
+A small set is not always one of the two faults above, though. Every one of these workflows also
+carries a `paths` filter, so a change that touches nothing they watch correctly runs almost
+nothing: a PR editing only `.github/skills/` or a file under `docs/` gets the template and title
+checks and no more, and that is the right answer rather than a symptom. The question to ask is
+whether the set matches the change, not whether the set is large.
+
 ## Generated artifacts a PR can owe
 
 - A route, a schema, **or a route docstring**: run `uv run python scripts/generate_openapi.py`,


### PR DESCRIPTION
## Description

The PR skill did not say that a pull request in this repository can lose almost all of its CI without anything reporting it. Two situations do that, and both were hit in one series of stacked PRs:

- A base branch that is not `main` matches no workflow's `branches` filter, so the PR gets only the two `pull_request_target` checks. Retargeting a stacked PR onto its parent branch to get a readable diff is the usual cause, and the cost is invisible from the direction you are looking: the diff gets smaller and the check count quietly drops from seven to one.
- A `CONFLICTING` PR has no merge ref, and a `pull_request` workflow builds that merge ref, so nothing runs at all until the conflict is resolved. A child PR lands in this state the moment its parent is squash-merged.

Both leave `gh pr checks` listing a single passing row. That reads as a clean result to anyone who does not already know how many checks to expect, which is what makes it worth writing down: the failure mode is a green-looking answer rather than an error. So the new section also states what "green" has to mean here, which is the full expected set present and none of it pending, rather than the absence of anything pending.

Documentation only. No behavior changes, and nothing outside `.github/skills/pr-cycle/SKILL.md`.

## How to test it locally

Read the new section, "What CI runs on a PR, and the two ways it silently does not", and the one sentence added to the stacked-PR bullet under Merging that points at it.

The two claims are checkable against the repository rather than taken on trust:

- The base filter: `grep -A3 'pull_request:' .github/workflows/otari-dashboard.yml` (and the same in `otari-dashboard-parity.yml`, `otari-design-system.yml`, `otari-tests.yml`) shows `branches: [ main ]` in each.
- The merge-ref half: on a PR whose `mergeStateStatus` is `DIRTY`, `gh pr checks <n>` lists only the `pull_request_target` checks, and the substantive ones appear once the conflict is resolved.

`make lint` passes (architecture check, Alembic heads, Ruff). Nothing else applies: the change adds no code, so no test can exercise it, and the automated checks that would matter to a Markdown file under `.github/skills/` do not exist.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. There is no issue for this: it is a correction to the skill, found while working a stack of dashboard PRs, and it is small enough to stand on its own rather than warrant one being filed to point at.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). **Not applicable, and not skipped for convenience:** the change is prose in a skill file. A test asserting the wording would pin the sentence rather than any behavior, which is worse than no test.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` was run and passes. Being precise about the other two: they cannot be affected by a Markdown-only change, so their result here says nothing about it either way.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API contract change.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Both claims in the new section were established by reading the four workflow files and by watching the substantive checks appear on a PR the moment a conflict was resolved, rather than inferred from the symptom.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
