### PR TITLE
feat(dashboard): reorganize the routing page as list and detail

### DIFF
--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -90,6 +90,7 @@ for a component, not for those.
 | `indicators/Dot` · `/Badge` · `/DismissChip` · `/Kbd` · `/Avatar` | one each |
 | `indicators/Chip` | `Chip`, and the `ChipTone` type |
 | `layout/Divider` | `Divider` |
+| `layout/ListDetail` | `ListDetail`, `ListDetailRow`. See [layout.md](layout.md) |
 | `content/Markdown` | `Markdown` |
 | `ProductMark` | `ProductMark`. At the top level: it belongs to no topic |
 | `@/shared/components/access/EntitlementGate` · `/UnavailableHere` · `/MissingGatewayAddressNotice` | one each |

--- a/web/design/data.md
+++ b/web/design/data.md
@@ -111,7 +111,7 @@ The lane does the aligning; see [layout.md](layout.md).
 tracks horizontal scroll so a first column can pin, and the per-page class is what
 `globals.css` hangs that page's column widths and pinning off. The list is closed:
 `otari-keys-table`, `otari-models-table`, `otari-providers-table`,
-`otari-routing-table`, `otari-domains-table`, `otari-members-table`,
+`otari-domains-table`, `otari-members-table`,
 `otari-provider-keys-table`, `otari-workspaces-table`, `otari-accounts-table`,
 `otari-activity-table`, `otari-budgets-table`, `otari-pricing-table`,
 `otari-mcp-table`, `otari-rate-overrides-table`. Inventing one at the call site

--- a/web/design/layout.md
+++ b/web/design/layout.md
@@ -41,6 +41,7 @@ constants for these; `Section` is the one place the pair is named.
 | `SettingRow` | `label`, `configKey?`, `help?`, `control`, `nested?`, `error?` | One setting inside a group |
 | `KpiStrip` + `KpiCell` | see [metrics.md](metrics.md) | The metrics band |
 | `TableScrollFrame` | `className`, children | Around a wide table |
+| `ListDetail` + `ListDetailRow` | `listLabel`, `listAction?`, `list`, `empty?`, `onEmptyPress?`, `detail`, `detailLabel?`, `isDetailShown`, `onShowList`, `backLabel?` | A set of records where reading one is most of the work |
 
 **`PageIntro` renders its own `<h1 className="text-display">`**, so never put a
 heading inside it and never spell `text-display` on a page yourself. The sentence
@@ -101,6 +102,27 @@ No Save anywhere on that one: a text field commits on blur and on Enter, a
 select on change. Reach for it when the settings are independent of one another,
 so no single button could say what it is about to write.
 `features/tools/ToolsGuardrailsPage` is the worked example.
+
+A list-and-detail page, which is the shape for a set of records where reading
+one is most of the work (`features/routing/RoutingPage` is the worked example):
+
+```
+PageIntro          title, sentence. No action: the create control goes in the
+                   list column, because that is the column it lengthens
+ErrorBanner        only if a read failed
+ListDetail         the two columns, at 1:1.75, partitioned by a hairline
+  ListDetailRow    one record: its name, and a line summarizing it
+```
+
+The frame does not bleed: it is one framed object inside the page column, the
+way a `bounded` settings group is, rather than rules running to the scroll
+area's edges. Every fact a table would have put in a lane goes in the detail
+column, since the list column holds a name and a line, and so do the controls
+that act on the open record. **Nothing is edited in either column**: a record is
+created and changed in a `FormDialog` over the page, which is the one create
+surface (see [feedback.md](feedback.md)). **Below `md` one column shows at a
+time**, and which one is a prop: two columns at 390px give neither a readable
+measure, and stacking them puts every record above the one being read.
 
 **A save that worked says nothing.** The control disables while the write is in
 flight and that is the whole acknowledgement: a confirmation mark on every row

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "@playwright/test"
 import { API_ROOT } from "@/shared/api/client"
 import {
+  detailColumn,
   dismissComboBox,
   dismissComboBoxInDialog,
+  listRow,
   login,
   MASTER_KEY,
   nav,
@@ -201,13 +203,14 @@ test.describe("dashboard core flows", () => {
   test("create a routing policy", async ({ page }) => {
     await login(page)
     await openNested(page, "Routing", "Policies")
-    // `.first()` is the heading's action. An empty routing list also offers
-    // the same words from its empty state, and a press has to name which.
-    await page.getByRole("button", { name: "Create policy" }).first().click()
+    // One "Create policy" on screen while the dialog is shut: the list column's
+    // action. The empty column's own CTA reads "Create your first policy", so
+    // neither shadows the other.
+    await page.getByRole("button", { name: "Create policy" }).click()
     // Scoped from here: the dialog's submit says "Create policy" too.
     const dialog = page.getByRole("dialog")
-    // Role-scoped for the same reason as the user form: policy rows carry a
-    // "Copy policy name" control.
+    // Role-scoped for the same reason as the user form: the detail column
+    // carries a "Copy policy name" control.
     await dialog.getByRole("textbox", { name: /Policy name/ }).fill("fast")
     // "Serves" is a model combobox (allows custom values); type the selector, then
     // close the popover so it does not aria-hide the submit button.
@@ -215,16 +218,13 @@ test.describe("dashboard core flows", () => {
     await page.keyboard.press("Escape")
     await dialog.getByRole("button", { name: "Create policy" }).click()
 
-    // The policy name is the table's row-header cell (react-aria rowheader).
-    await expect(page.getByRole("rowheader", { name: "fast" })).toBeVisible()
+    await expect(listRow(page, "Policies", "fast")).toBeVisible()
   })
 
   test("grows a policy a fallback chain", async ({ page }) => {
     await login(page)
     await openNested(page, "Routing", "Policies")
-    // `.first()` is the heading's action. An empty routing list also offers
-    // the same words from its empty state, and a press has to name which.
-    await page.getByRole("button", { name: "Create policy" }).first().click()
+    await page.getByRole("button", { name: "Create policy" }).click()
     // Scoped from here: the dialog's submit says "Create policy" too.
     const dialog = page.getByRole("dialog")
     await dialog.getByRole("textbox", { name: /Policy name/ }).fill("chained")
@@ -244,9 +244,7 @@ test.describe("dashboard core flows", () => {
     // Scoped to the row this test created: "+1 on failure" anywhere on the page
     // would also be satisfied by another policy's chain, so a `chained` saved
     // without its fallback would still pass.
-    const chained = page
-      .getByRole("row")
-      .filter({ has: page.getByRole("rowheader", { name: "chained" }) })
+    const chained = listRow(page, "Policies", "chained")
     await expect(chained).toBeVisible()
     await expect(chained).toContainText(/\+1 on failure/)
   })
@@ -266,10 +264,12 @@ test.describe("dashboard core flows", () => {
     await login(page)
     await openNested(page, "Routing", "Policies")
 
-    const chained = page
-      .getByRole("row")
-      .filter({ has: page.getByRole("rowheader", { name: "chained" }) })
-    await chained.getByRole("button", { name: "Edit" }).click()
+    // Editing is a two-step press: the row opens the policy in the detail
+    // column, and Edit there opens the dialog (otari-ai#2109).
+    await listRow(page, "Policies", "chained").click()
+    await detailColumn(page, "Policy detail")
+      .getByRole("button", { name: "Edit" })
+      .click()
     // The edit opens the same dialog, so its fields are scoped the same way.
     const dialog = page.getByRole("dialog")
     await dialog.getByRole("textbox", { name: /Policy name/ }).fill("renamed")
@@ -277,12 +277,10 @@ test.describe("dashboard core flows", () => {
 
     // A rename moves the row rather than copying it, so the old name has to be
     // gone: two rows would mean callers could still reach the policy either way.
-    const renamed = page
-      .getByRole("row")
-      .filter({ has: page.getByRole("rowheader", { name: "renamed" }) })
+    const renamed = listRow(page, "Policies", "renamed")
     await expect(renamed).toBeVisible()
     await expect(renamed).toContainText(/\+1 on failure/)
-    await expect(page.getByRole("rowheader", { name: "chained" })).toBeHidden()
+    await expect(listRow(page, "Policies", "chained")).toHaveCount(0)
   })
 
   // The share card is the one flow whose output cannot be checked in jsdom: it

--- a/web/e2e/helpers.ts
+++ b/web/e2e/helpers.ts
@@ -250,6 +250,25 @@ export function tableRows(page: Page, ariaLabel: string): Locator {
     .filter({ has: page.getByRole("rowheader") })
 }
 
+// ---------- a list-and-detail page ----------
+
+// A row in a `ListDetail`'s list column. Found by the exact name the row
+// carries rather than by the row's own accessible name, which runs that name
+// together with the line summarizing it. A name is unique in these specs; a
+// page whose rows can repeat one (the same routing policy name global and
+// user-scoped) needs the summary line in the filter too.
+export function listRow(page: Page, column: string, name: string): Locator {
+  return page
+    .getByRole("region", { name: column })
+    .locator("button")
+    .filter({ has: page.getByText(name, { exact: true }) })
+}
+
+// The column a row opens in, which is where its facts and its actions are.
+export function detailColumn(page: Page, label: string): Locator {
+  return page.getByRole("region", { name: label })
+}
+
 // ---------- stat tiles ----------
 
 // A StatCard renders its label and its value as sibling spans with no

--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -1,9 +1,11 @@
 import { expect, type Locator, type Page, test } from "@playwright/test"
 
 import {
+  detailColumn,
   dismissComboBox,
   dismissComboBoxInDialog,
   gotoRoute,
+  listRow,
   login,
   nav,
   openNested,
@@ -252,9 +254,9 @@ test.describe("fallback routing", () => {
     await openNested(page, "Routing", "Policies")
     await expect(pageHeading(page, "Routing")).toBeVisible()
 
-    // `.first()` is the heading's action. An empty routing list also offers
-    // the same words from its empty state, and a press has to name which.
-    await page.getByRole("button", { name: "Create policy" }).first().click()
+    // One "Create policy" on screen while the dialog is shut: the list column's
+    // action. The empty column's own CTA reads "Create your first policy".
+    await page.getByRole("button", { name: "Create policy" }).click()
     // Scoped from here: the dialog's submit says "Create policy" too.
     const dialog = page.getByRole("dialog")
     await dialog.getByRole("textbox", { name: /Policy name/ }).fill(POLICY)
@@ -268,14 +270,17 @@ test.describe("fallback routing", () => {
     await fillModelBox(page, /Fallback 2/, "groq:llama-3.3-70b-versatile")
     await dialog.getByRole("button", { name: "Create policy" }).click()
 
-    // The table summarises the chain by its length, so the count is the assertion
+    // The row summarizes the chain by its length, so the count is the assertion
     // that both fallbacks were saved and not just the first.
-    const policy = row(page, "Routing policies", POLICY)
+    const policy = listRow(page, "Policies", POLICY)
     await expect(policy).toContainText(/\+2 on failure/)
 
     // Shrinking has to be possible too: a chain that could only grow would strand
-    // an operator who added a candidate by mistake.
-    await policy.getByRole("button", { name: "Edit" }).click()
+    // an operator who added a candidate by mistake. The row opens the policy in
+    // the detail column, and Edit there opens the dialog (otari-ai#2109).
+    await policy.click()
+    const detail = detailColumn(page, "Policy detail")
+    await detail.getByRole("button", { name: "Edit" }).click()
     const fallbackTwo = page.getByRole("combobox", { name: /Fallback 2/ })
     await expect(fallbackTwo).toBeVisible()
     // Scoped to the row holding Fallback 2 rather than taken by index off the
@@ -296,17 +301,17 @@ test.describe("fallback routing", () => {
       page.getByRole("combobox", { name: /Fallback 2/ }),
     ).toHaveCount(0)
     await page.getByRole("button", { name: "Save" }).click()
-    await expect(row(page, "Routing policies", POLICY)).toContainText(
+    await expect(listRow(page, "Policies", POLICY)).toContainText(
       /\+1 on failure/,
     )
 
-    await row(page, "Routing policies", POLICY)
-      .getByRole("button", { name: "Delete" })
-      .click()
+    // Delete lives beside the facts it acts on, and names the policy in the
+    // confirm dialog: the column is behind the backdrop once it is open.
+    await detail.getByRole("button", { name: "Delete" }).click()
     const confirmPolicy = page.getByRole("alertdialog")
     await expect(confirmPolicy).toContainText(POLICY)
     await confirmPolicy.getByRole("button", { name: "Delete policy" }).click()
-    await expect(row(page, "Routing policies", POLICY)).toHaveCount(0)
+    await expect(listRow(page, "Policies", POLICY)).toHaveCount(0)
   })
 })
 

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -124,7 +124,7 @@ const BASE_NAV_SECTIONS = [
         // Policies and Guardrails as the navigation prototype groups them. The
         // prototype's third entry, Aliases, is deliberately absent: this
         // dashboard lists an alias as the one-target policy it is, in the same
-        // table (see `RoutingPage`), so `/aliases` is a compatibility redirect
+        // list (see `RoutingPage`), so `/aliases` is a compatibility redirect
         // onto `/routing` rather than a destination. Linking it would give the
         // group two entries for one page, and the second could never highlight.
         // It comes back if and when Routing grows a separate alias view.

--- a/web/src/design-system/layout/ListDetail.stories.tsx
+++ b/web/src/design-system/layout/ListDetail.stories.tsx
@@ -1,0 +1,268 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { FiTrash2 } from "react-icons/fi"
+
+import { Button } from "../actions/Button"
+import { IconButton } from "../actions/IconButton"
+import { ListDetail, ListDetailRow } from "./ListDetail"
+
+/**
+ * A list of records beside the one that is open, at 1:1.75.
+ *
+ * Documented as a pair, like `TabRow` and `Tab`: the frame owns the two columns
+ * and the partition between them, the row owns one record and the lane its
+ * actions sit in, and neither is any use alone.
+ *
+ * Nothing here holds state. Which record is open is the page's, which is what
+ * lets one selection drive the URL, the detail column, and (below `md`) which
+ * of the two columns is the one on screen. An editor is not one of the two
+ * columns: a record is created and changed in a `FormDialog` over the page.
+ *
+ * **Narrow the canvas to see the other half of the layout.** From `md` up both
+ * columns are on screen and `isDetailShown` does nothing; below it exactly one
+ * is, and the Back control is the way between them.
+ */
+const meta = {
+  title: "Design system/Layout/ListDetail",
+  component: ListDetail,
+  args: {
+    listLabel: "Policies",
+    list: null,
+    detail: null,
+    isDetailShown: false,
+    onShowList: () => {},
+  },
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ListDetail>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const POLICIES = [
+  { name: "fast", serves: "openai:gpt-5-mini  +1 on failure" },
+  { name: "cheap", serves: "Learned · 2 candidates, openai:gpt-5 by default" },
+  { name: "balanced", serves: "Weighted · 70% / 30% across 2 models" },
+  { name: "strict", serves: "anthropic:claude-sonnet-4-5" },
+]
+
+function Facts({ serves }: { serves: string }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {[
+        ["Serves", serves],
+        ["Applies to", "Every caller"],
+        ["Source", "STORED"],
+      ].map(([label, value]) => (
+        <div key={label} className="flex min-w-0 flex-col gap-1">
+          <span className="text-overline">{label}</span>
+          <span className="text-body">{value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** A record open, which is the state the shape exists for. */
+export const Default: Story = {
+  render: () => {
+    const [open, setOpen] = useState<string | undefined>("fast")
+    const selected = POLICIES.find((policy) => policy.name === open)
+    return (
+      <ListDetail
+        listLabel="Policies"
+        backLabel="All policies"
+        detailLabel="Policy detail"
+        listAction={
+          <Button size="sm" variant="primary" onPress={() => {}}>
+            Create policy
+          </Button>
+        }
+        isDetailShown={selected !== undefined}
+        onShowList={() => setOpen(undefined)}
+        list={POLICIES.map((policy) => (
+          <ListDetailRow
+            key={policy.name}
+            label={policy.name}
+            isSelected={policy.name === open}
+            onSelect={() => setOpen(policy.name)}
+            actions={
+              <IconButton label={`Delete ${policy.name}`} onPress={() => {}}>
+                <FiTrash2 aria-hidden="true" className="size-4" />
+              </IconButton>
+            }
+          >
+            {policy.serves}
+          </ListDetailRow>
+        ))}
+        detail={
+          selected === undefined ? (
+            <div className="px-4 py-10 text-center text-caption">
+              Pick a policy to see what it serves.
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+                <h2 className="text-title">{selected.name}</h2>
+                <div className="flex gap-2">
+                  <Button size="sm" onPress={() => {}}>
+                    Edit
+                  </Button>
+                  <Button size="sm" onPress={() => {}}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+              <div className="px-4 py-4">
+                <Facts serves={selected.serves} />
+              </div>
+            </div>
+          )
+        }
+      />
+    )
+  },
+}
+
+/**
+ * Nothing open, which is where a wide viewport lands before the first click.
+ * The detail column holds what to do rather than a blank half-page.
+ */
+export const NothingOpen: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={false}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="px-4 py-10 text-center text-caption">
+          Pick a policy to see what it serves.
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * An empty list, where the only thing to do with the column is start the first
+ * record, so the column is the button. It is a real one: a whole-column press
+ * target that a keyboard cannot reach is a control that is not there.
+ */
+export const Empty: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      listAction={
+        <Button size="sm" variant="primary" onPress={() => {}}>
+          Create policy
+        </Button>
+      }
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={null}
+      empty="Create your first policy"
+      onEmptyPress={() => {}}
+      detail={
+        <div className="flex flex-col gap-2 px-4 py-5">
+          <h2 className="text-title">No policies yet</h2>
+          <p className="text-body">
+            A policy is a name your callers send as their model, and what serves
+            it.
+          </p>
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * The same empty column for a reader who cannot write: the sentence without
+ * the invitation, since pressing it would only be refused.
+ */
+export const EmptyReadOnly: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={null}
+      empty="No policies yet."
+      detail={
+        <div className="px-4 py-10 text-center text-caption">
+          Your organization&apos;s admins define these.
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * Below `md`, where the detail column is the one on screen and the Back control
+ * is the way out of it. The frame is drawn here as it is at every width, so
+ * narrow the canvas to see the list disappear behind it.
+ */
+export const DetailShown: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      backLabel="All policies"
+      detailLabel="Policy detail"
+      isDetailShown
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={policy.name === "cheap"}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="flex flex-col gap-4 px-4 py-5">
+          <h2 className="text-title">cheap</h2>
+          <Facts serves="Learned · 2 candidates, openai:gpt-5 by default" />
+        </div>
+      }
+    />
+  ),
+}
+
+/** The open record on the dark artboard, where the selection tint is its own value. */
+export const Dark: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={policy.name === "cheap"}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="flex flex-col gap-4 px-4 py-5">
+          <h2 className="text-title">cheap</h2>
+          <Facts serves="Learned · 2 candidates, openai:gpt-5 by default" />
+        </div>
+      }
+    />
+  ),
+  globals: { theme: "dark" },
+}

--- a/web/src/design-system/layout/ListDetail.test.tsx
+++ b/web/src/design-system/layout/ListDetail.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ListDetail, ListDetailRow } from "./ListDetail"
+
+describe("ListDetail", () => {
+  it("names both columns, so neither half is anonymous", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>Nothing open.</p>}
+        detailLabel="Policy detail"
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole("region", { name: "Policies" })).toContainElement(
+      screen.getByRole("heading", { name: "Policies" }),
+    )
+    expect(
+      screen.getByRole("region", { name: "Policy detail" }),
+    ).toHaveTextContent("Nothing open.")
+  })
+
+  it("puts the create control in the column it adds to", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        listAction={<button type="button">Create policy</button>}
+        list={null}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole("region", { name: "Policies" })).toContainElement(
+      screen.getByRole("button", { name: "Create policy" }),
+    )
+  })
+
+  it("offers the way back only while a column is hidden", async () => {
+    // The control is `md:hidden`, and jsdom applies no media query, so what is
+    // asserted here is the other half: it exists while the detail column is
+    // the one on screen and not while both are.
+    const onShowList = vi.fn()
+    const { rerender } = render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>fast</p>}
+        isDetailShown
+        onShowList={onShowList}
+        backLabel="All policies"
+      />,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "All policies" }))
+    expect(onShowList).toHaveBeenCalledOnce()
+
+    rerender(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>fast</p>}
+        isDetailShown={false}
+        onShowList={onShowList}
+      />,
+    )
+    expect(
+      screen.queryByRole("button", { name: /All policies|Back to the list/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("makes the empty column a real button, reachable by keyboard", async () => {
+    // The whole column is the target, which a div with an onClick would also
+    // manage while being unreachable without a pointer.
+    const onEmptyPress = vi.fn()
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        empty="Create your first policy"
+        onEmptyPress={onEmptyPress}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    await userEvent.tab()
+    await userEvent.keyboard("{Enter}")
+    expect(onEmptyPress).toHaveBeenCalledOnce()
+    expect(
+      screen.getByRole("button", { name: "Create your first policy" }),
+    ).toBeInTheDocument()
+  })
+
+  it("states the empty column without offering it to a reader who cannot write", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        empty="No policies yet."
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("No policies yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("shows the list when nothing is empty about it", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={<p>fast</p>}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("fast")).toBeInTheDocument()
+  })
+})
+
+describe("ListDetailRow", () => {
+  it("presses its label to open the record, not the whole row", async () => {
+    const onSelect = vi.fn()
+    render(
+      <ListDetailRow label="fast" isSelected={false} onSelect={onSelect}>
+        openai:gpt-5-mini
+      </ListDetailRow>,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /fast/ }))
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(screen.getByText("openai:gpt-5-mini")).toBeInTheDocument()
+  })
+
+  it("says which record is the one being shown", () => {
+    render(
+      <>
+        <ListDetailRow label="fast" isSelected onSelect={() => {}} />
+        <ListDetailRow label="cheap" isSelected={false} onSelect={() => {}} />
+      </>,
+    )
+
+    expect(screen.getByRole("button", { name: "fast" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    )
+    expect(screen.getByRole("button", { name: "cheap" })).not.toHaveAttribute(
+      "aria-current",
+    )
+  })
+
+  it("keeps a row's actions out of the press target that opens it", async () => {
+    // Nested buttons are neither valid nor operable, so the label and the
+    // actions are siblings. Pressing an action must not also open the record.
+    const onSelect = vi.fn()
+    const onDelete = vi.fn()
+    render(
+      <ListDetailRow
+        label="cheap"
+        isSelected={false}
+        onSelect={onSelect}
+        actions={
+          <button type="button" onClick={onDelete}>
+            Delete cheap
+          </button>
+        }
+      />,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete cheap" }))
+    expect(onDelete).toHaveBeenCalledOnce()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/design-system/layout/ListDetail.tsx
+++ b/web/src/design-system/layout/ListDetail.tsx
@@ -1,0 +1,186 @@
+import type { ReactNode } from "react"
+import { FiChevronLeft } from "react-icons/fi"
+
+import { Button } from "../actions/Button"
+import { EmptyMessage } from "../feedback/EmptyMessage"
+
+/**
+ * A list of records beside the one that is open: the page shape for a set of
+ * things where reading one is most of the work.
+ *
+ * The ratio is 1:1.75 and lives here rather than at a call site, because it is
+ * the whole reason the frame exists. The left column holds a name and a line
+ * about it; the right one holds every fact a table would have spread across
+ * lanes, plus the controls that act on the record. Two columns at equal width
+ * give the reading half a page and the naming half more than it needs.
+ *
+ * **Below `md` one column shows at a time**, chosen by `isDetailShown`. Side by
+ * side at 390px gives neither column a readable measure, and stacking them puts
+ * every record above the one being read, so an operator scrolls past the list
+ * to reach what they opened. The swap is a prop rather than state in here, so
+ * the page's own selection stays the single source of what is open.
+ *
+ * Presentational: which record is selected is the caller's, and so is every
+ * row. Pair with `ListDetailRow`, which is the row this frame's list is made
+ * of, and whose separators the frame supplies.
+ */
+export function ListDetail({
+  listLabel,
+  listAction,
+  list,
+  empty,
+  onEmptyPress,
+  detail,
+  detailLabel = "Details",
+  isDetailShown,
+  onShowList,
+  backLabel = "Back to the list",
+}: {
+  /** What the left column holds, as its heading and as its region's name. */
+  listLabel: string
+  /** The control that adds a record, at the top of the column it adds to. */
+  listAction?: ReactNode
+  /** The rows, which are `ListDetailRow`s. */
+  list: ReactNode
+  /**
+   * What stands in for the rows, and so how the frame is told there are none to
+   * show: an empty list's message, or a line while the list is still loading. A
+   * node cannot be counted from in here, which is why this rather than a flag.
+   */
+  empty?: ReactNode
+  /**
+   * Makes the empty column one press target, for a list whose first record is
+   * the only thing to do with it. Omitted where the caller cannot write, so a
+   * reader who would be refused is told rather than invited.
+   */
+  onEmptyPress?: () => void
+  /** The open record, or what stands in for it while none is. */
+  detail: ReactNode
+  /**
+   * Names the detail column's region, which holds whatever the caller puts in
+   * it and so has no heading of its own to be named by.
+   */
+  detailLabel?: string
+  /** Below `md`: whether the detail column is the one on screen. */
+  isDetailShown: boolean
+  /** Below `md`: the way back, since only one column is reachable at a time. */
+  onShowList: () => void
+  /** Names the list on that control, where "the list" is not what to call it. */
+  backLabel?: string
+}) {
+  const rows =
+    empty === undefined ? (
+      // The frame divides its children, so a row draws no rule of its own and
+      // the last one leaves none hanging over the space below it.
+      <div className="flex flex-1 flex-col divide-y divide-border-subtle">
+        {list}
+      </div>
+    ) : onEmptyPress === undefined ? (
+      <EmptyMessage>{empty}</EmptyMessage>
+    ) : (
+      <button
+        type="button"
+        onClick={onEmptyPress}
+        className="flex flex-1 flex-col justify-center transition-colors hover:bg-surface-alt motion-reduce:transition-none"
+      >
+        <EmptyMessage>{empty}</EmptyMessage>
+      </button>
+    )
+
+  return (
+    <div className="grid border border-border md:grid-cols-[1fr_1.75fr]">
+      {/* Both halves are regions, so a reader can move between them rather
+          than through one to reach the other. */}
+      <section
+        aria-label={listLabel}
+        className={`min-w-0 flex-col ${isDetailShown ? "hidden md:flex" : "flex"}`}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
+          <h2 className="text-overline">{listLabel}</h2>
+          {listAction}
+        </div>
+        {rows}
+      </section>
+      <section
+        aria-label={detailLabel}
+        className={`min-w-0 flex-col border-border md:border-l ${
+          isDetailShown ? "flex" : "hidden md:flex"
+        }`}
+      >
+        {isDetailShown ? (
+          // Only where a column is hidden. From `md` up the list is right
+          // there, and a Back control beside it would point at what it is
+          // sitting next to.
+          <div className="border-b border-border px-2 py-1 md:hidden">
+            <Button className="min-h-11" onPress={onShowList}>
+              <FiChevronLeft aria-hidden="true" className="size-4" />
+              {backLabel}
+            </Button>
+          </div>
+        ) : null}
+        <div className="flex min-w-0 flex-1 flex-col">{detail}</div>
+      </section>
+    </div>
+  )
+}
+
+/**
+ * One record in a `ListDetail`'s list: its name, a line about it, and the
+ * actions that belong to the list rather than to the record.
+ *
+ * The row is not itself the press target. Its label is, and the actions sit
+ * beside it, because a button inside a button is neither valid nor operable.
+ *
+ * **The action lane is there whether or not a row has actions**, so the
+ * trailing controls form a vertical lane down the list instead of landing
+ * wherever their row's label ends. Its width is the touch floor, which is also
+ * the width of the one control it is sized for.
+ *
+ * `aria-current` rather than `aria-pressed`: this is the record being shown out
+ * of a set, not a control that stays down. The selected row wears the accent as
+ * a tint, which is the accent spent on selection the way an active nav row
+ * spends it, and keeps the page's ink: the accent's own ink is under AA on its
+ * tint.
+ */
+export function ListDetailRow({
+  label,
+  isSelected,
+  onSelect,
+  actions,
+  children,
+}: {
+  /** The record's name, in the lane every row shares. */
+  label: ReactNode
+  isSelected: boolean
+  onSelect: () => void
+  /**
+   * Controls acting on this record from the list, always visible: a touch
+   * device has no hover, so a control revealed by one does not exist there.
+   */
+  actions?: ReactNode
+  /** A second line under the label: what this record is, in a few words. */
+  children?: ReactNode
+}) {
+  return (
+    <div
+      className={`flex items-stretch ${isSelected ? "bg-primary-subtle" : ""}`}
+    >
+      <button
+        type="button"
+        aria-current={isSelected ? "true" : undefined}
+        onClick={onSelect}
+        className={`flex min-h-11 min-w-0 flex-1 flex-col justify-center gap-0.5 px-4 py-2 text-left transition-colors motion-reduce:transition-none ${
+          isSelected ? "" : "hover:bg-surface-alt"
+        }`}
+      >
+        <span className="truncate text-body">{label}</span>
+        {children === undefined ? null : (
+          <span className="truncate text-caption">{children}</span>
+        )}
+      </button>
+      <div className="flex min-w-11 shrink-0 items-center justify-end pr-2">
+        {actions}
+      </div>
+    </div>
+  )
+}

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -324,12 +324,48 @@ function adminContext(): OrganizationContext {
   })
 }
 
+type User = ReturnType<typeof userEvent.setup>
+
+/**
+ * A policy's row in the list column.
+ *
+ * Reached through its name rather than by the row's own accessible name, which
+ * runs that name together with the line summarizing the policy.
+ */
+async function policyRow(name: string): Promise<HTMLElement> {
+  const row = (await screen.findAllByText(name))
+    .map((label) => label.closest("button"))
+    .find((button) => button !== null)
+  if (!row) throw new Error(`${name} has no row in the list column`)
+  return row
+}
+
+/** The detail column, which holds one policy's facts and its actions. */
+function detail(): HTMLElement {
+  return screen.getByRole("region", { name: "Policy detail" })
+}
+
+/** Open a policy, and hand back the column it opens in. */
+async function openPolicy(user: User, name: string): Promise<HTMLElement> {
+  await user.click(await policyRow(name))
+  return detail()
+}
+
+/** The confirm dialog a delete opens, and its confirming button. */
+async function confirmDelete(user: User, label: string): Promise<void> {
+  await user.click(
+    within(await screen.findByRole("alertdialog")).getByRole("button", {
+      name: label,
+    }),
+  )
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
 /**
- * The page's own create action, resolved while the dialog is shut.
+ * The list column's create action, resolved while the dialog is shut.
  *
  * That is the only time it is unambiguous: the dialog's submit says "Create
  * policy" too, and both are on screen together once it is open, which is why
@@ -341,40 +377,55 @@ const createTrigger = () =>
 describe("RoutingPage", () => {
   it("lists policies with what they serve and where they come from", async () => {
     mockApi()
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const fastRow = (await screen.findByText("fast")).closest("tr")!
-    // The chain is summarised rather than hidden: an operator scanning the table
-    // needs to see that a fallback exists without opening the policy.
+    // The chain is summarized on the row rather than hidden: an operator
+    // scanning the list needs to see that a fallback exists without opening
+    // the policy.
+    const fastRow = await policyRow("fast")
     expect(within(fastRow).getByText(/openai:gpt-5-mini/)).toBeInTheDocument()
     expect(within(fastRow).getByText(/\+1 on failure/)).toBeInTheDocument()
-    expect(within(fastRow).getByText("STORED")).toBeInTheDocument()
+    // Where it came from is one of the facts a row has no room for, so it is in
+    // the column that shows one policy at a time.
+    expect(
+      within(await openPolicy(user, "fast")).getByText("STORED"),
+    ).toBeInTheDocument()
   })
 
   it("marks a policy that decides per request, since it has no single target", async () => {
     mockApi()
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const autoRow = (await screen.findByText("auto")).closest("tr")!
-    expect(within(autoRow).getByText("DYNAMIC")).toBeInTheDocument()
+    const autoRow = await policyRow("auto")
     expect(within(autoRow).getByText(/Chosen per request/)).toBeInTheDocument()
+    expect(
+      within(await openPolicy(user, "auto")).getByText("DYNAMIC"),
+    ).toBeInTheDocument()
   })
 
   it("does not offer to edit or delete a policy that lives in config.yml", async () => {
     mockApi()
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const autoRow = (await screen.findByText("auto")).closest("tr")!
-    expect(within(autoRow).getByText("set in config.yml")).toBeInTheDocument()
+    // The reason is stated in the column rather than a control offered there,
+    // since every one of them would be refused.
+    const panel = await openPolicy(user, "auto")
+    expect(within(panel).getByText(/Set in config.yml/)).toBeInTheDocument()
     expect(
-      within(autoRow).queryByRole("button", { name: "Delete" }),
+      within(panel).queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(panel).queryByRole("button", { name: "Delete" }),
     ).not.toBeInTheDocument()
   })
 
-  it("keeps the page's create action visible while the dialog is open", async () => {
+  it("keeps the create action visible while the dialog is open", async () => {
     // It used to hide itself while the inline form was on the page. The form is
     // over the page now, so hiding the control that opened it would take the
-    // heading's action away mid-task for no reason.
+    // list column's action away mid-task for no reason.
     mockApi([])
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
@@ -385,26 +436,47 @@ describe("RoutingPage", () => {
     expect(trigger).toBeInTheDocument()
   })
 
-  it("offers the same dialog from the empty state", async () => {
-    // The empty state's explanation is the page's onboarding and stays; what it
-    // gained is the action, so a first policy does not have to be started from
-    // the heading a reader has already scrolled past.
+  it("starts the first policy from the empty column, not only from its button", async () => {
+    // otari-ai#2109: with nothing in it, the only thing to do with the list
+    // column is start the first policy, so the whole column is a press target.
+    // A real button, because a whole-column click a keyboard cannot reach is
+    // not a control.
     mockApi([])
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    // Two of them on screen deliberately, the heading's and this one, so the
-    // press is scoped to the empty state rather than picked by position.
-    const empty = (
-      await screen.findByRole("heading", {
-        name: "No routing policies yet",
-      })
-    ).closest("div")!.parentElement!
     await user.click(
-      within(empty).getByRole("button", { name: "Create policy" }),
+      await screen.findByRole("button", { name: "Create your first policy" }),
     )
+
     const dialog = await screen.findByRole("dialog")
     expect(dialog).toHaveAccessibleName("New policy")
+  })
+
+  it("keeps the page's onboarding in the detail column while there is nothing to read", async () => {
+    // The steps are what the page is for before it has any policies, and the
+    // detail column is the half with room for them.
+    mockApi([])
+    renderPage(<RoutingPage />)
+
+    const heading = await screen.findByRole("heading", {
+      name: "No routing policies yet",
+    })
+    const panel = detail()
+    expect(panel).toContainElement(heading)
+    expect(
+      within(panel).getByText(/Have your callers send the policy name/),
+    ).toBeInTheDocument()
+  })
+
+  it("says what the detail column is for while nothing is open", async () => {
+    mockApi()
+    renderPage(<RoutingPage />)
+
+    await policyRow("fast")
+    expect(
+      within(detail()).getByText(/Pick a policy to see what it serves/),
+    ).toBeInTheDocument()
   })
 
   it("names the object in the title and the policy in the description when editing", async () => {
@@ -415,8 +487,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const fastRow = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(fastRow).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     const dialog = await screen.findByRole("dialog")
     expect(dialog).toHaveAccessibleName("Edit policy")
     expect(dialog).toHaveTextContent("fast")
@@ -606,8 +678,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     const nameField = screen.getByRole("textbox", { name: /policy name/i })
     await user.clear(nameField)
@@ -642,8 +714,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(
       within(screen.getByRole("dialog")).getByRole("button", { name: "Save" }),
     )
@@ -661,8 +733,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     const nameField = screen.getByRole("textbox", { name: /policy name/i })
     await user.clear(nameField)
@@ -684,8 +756,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     const nameField = screen.getByRole("textbox", { name: /policy name/i })
     await user.clear(nameField)
@@ -710,8 +782,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("gpt")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "gpt")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     expect(
       screen.queryByRole("textbox", { name: /policy name/i }),
@@ -731,16 +803,17 @@ describe("RoutingPage", () => {
         ],
       }),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("api-authored")).closest("tr")!
+    const panel = await openPolicy(user, "api-authored")
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(panel).queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument()
-    expect(within(row).getByText(/cannot show yet/)).toBeInTheDocument()
+    expect(within(panel).getByText(/cannot show yet/)).toBeInTheDocument()
     // Delete stays available: removing a policy is never lossy.
     expect(
-      within(row).getByRole("button", { name: "Delete" }),
+      within(panel).getByRole("button", { name: "Delete" }),
     ).toBeInTheDocument()
   })
 
@@ -755,36 +828,39 @@ describe("RoutingPage", () => {
         user_id: null,
       },
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("legacy")).closest("tr")!
-    expect(within(row).getByText("openai:gpt-4o-mini")).toBeInTheDocument()
-    expect(within(row).getByText("alias")).toBeInTheDocument()
+    // An alias says so on its own row, because what a write to it can hold
+    // differs from a policy's.
+    const row = await policyRow("legacy")
+    expect(within(row).getByText(/openai:gpt-4o-mini/)).toBeInTheDocument()
+    expect(within(row).getByText(/alias/)).toBeInTheDocument()
     expect(
-      within(row).getByRole("button", { name: "Delete" }),
+      within(await openPolicy(user, "legacy")).getByRole("button", {
+        name: "Delete",
+      }),
     ).toBeInTheDocument()
   })
 
   it("names the policy in a confirm dialog before deleting it", async () => {
     // otari-ai#2110: the confirmation used to arm inside the row, where it read
-    // as part of the table rather than as a decision. It is a modal now, and
-    // the policy it is about has to be named in it: the row is behind the
-    // backdrop, so the name on the row is no longer the operator's reference.
+    // as part of the list rather than as a decision. It is a modal now, and the
+    // policy it is about has to be named in it: the column behind the backdrop
+    // is no longer the operator's reference.
     const { calls } = mockApi([policy("fast", CHAIN)])
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Delete" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
 
     const dialog = await screen.findByRole("alertdialog")
     expect(within(dialog).getByText(/^fast stops resolving/)).toBeVisible()
     // Nothing is sent by opening it.
     expect(calls.some((call) => call.method === "DELETE")).toBe(false)
 
-    await user.click(
-      within(dialog).getByRole("button", { name: "Delete policy" }),
-    )
+    await confirmDelete(user, "Delete policy")
 
     const deletes = calls.filter((call) => call.method === "DELETE")
     expect(deletes).toHaveLength(1)
@@ -796,13 +872,13 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Delete" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
     const dialog = await screen.findByRole("alertdialog")
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }))
 
     expect(calls.some((call) => call.method === "DELETE")).toBe(false)
-    expect(screen.getByText("fast")).toBeInTheDocument()
+    expect(await policyRow("fast")).toBeInTheDocument()
   })
 
   it("reports a refused delete inside the dialog, leaving the row", async () => {
@@ -814,20 +890,18 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Delete" }))
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
     const dialog = await screen.findByRole("alertdialog")
-    await user.click(
-      within(dialog).getByRole("button", { name: "Delete policy" }),
-    )
+    await confirmDelete(user, "Delete policy")
 
     expect(
       await within(dialog).findByText(/referenced by an alias/),
     ).toBeVisible()
     // Still open, so the operator can retry or back out rather than being
-    // returned to a table that looks unchanged for no stated reason.
+    // returned to a list that looks unchanged for no stated reason.
     expect(screen.getByRole("alertdialog")).toBeInTheDocument()
-    expect(screen.getByText("fast")).toBeInTheDocument()
+    expect(await policyRow("fast")).toBeInTheDocument()
   })
 
   it("does not greet the next row's confirm with the last row's refusal", async () => {
@@ -840,21 +914,35 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const fast = (await screen.findByText("fast")).closest("tr")!
+    const fast = await openPolicy(user, "fast")
     await user.click(within(fast).getByRole("button", { name: "Delete" }))
     const first = await screen.findByRole("alertdialog")
-    await user.click(
-      within(first).getByRole("button", { name: "Delete policy" }),
-    )
+    await confirmDelete(user, "Delete policy")
     await within(first).findByText(/referenced by an alias/)
     await user.click(within(first).getByRole("button", { name: "Cancel" }))
 
-    const smart = screen.getByText("smart").closest("tr")!
+    const smart = await openPolicy(user, "smart")
     await user.click(within(smart).getByRole("button", { name: "Delete" }))
 
     const second = await screen.findByRole("alertdialog")
     expect(within(second).getByText(/^smart stops resolving/)).toBeVisible()
     expect(within(second).queryByText(/referenced by an alias/)).toBeNull()
+  })
+
+  it("returns the detail column to the prompt when the policy it shows is deleted", async () => {
+    // The column cannot go on describing a policy that no longer resolves.
+    mockApi([policy("fast", CHAIN), policy("smart", LEARNED)])
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    const panel = await openPolicy(user, "fast")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
+    await confirmDelete(user, "Delete policy")
+
+    expect(
+      await within(detail()).findByText(/Pick a policy to see what it serves/),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("fast")).not.toBeInTheDocument()
   })
 
   it("deletes an alias through the alias endpoint, not the policy one", async () => {
@@ -869,13 +957,9 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("legacy")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Delete" }))
-    await user.click(
-      within(await screen.findByRole("alertdialog")).getByRole("button", {
-        name: "Delete alias",
-      }),
-    )
+    const panel = await openPolicy(user, "legacy")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
+    await confirmDelete(user, "Delete alias")
 
     const deletes = calls.filter((call) => call.method === "DELETE")
     expect(deletes).toHaveLength(1)
@@ -896,8 +980,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("legacy")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "legacy")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(
       await screen.findByRole("button", { name: /Add a fallback chain/ }),
     )
@@ -910,14 +994,14 @@ describe("RoutingPage", () => {
     ).toBeDisabled()
   })
 
-  it("summarises a learned policy by its pool rather than as an opaque dynamic row", async () => {
+  it("summarizes a learned policy by its pool rather than as an opaque dynamic row", async () => {
     // "Chosen per request" is true of a tier-down too. What an operator needs to
     // see here is that a router picks between named models, and which one serves
     // when it declines.
     mockApi([policy("smart", LEARNED, { is_dynamic: true })])
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
+    const row = await policyRow("smart")
     expect(
       within(row).getByText(/Learned . 2 candidates, openai:gpt-5 by default/),
     ).toBeInTheDocument()
@@ -938,8 +1022,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     // Both models in one list, and the default target marked.
     expect(screen.getByRole("combobox", { name: /model 1/i })).toHaveValue(
@@ -961,8 +1045,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(
       screen.getAllByRole("radio", { name: /serves when unsure/i })[0],
     )
@@ -991,8 +1075,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     expect(screen.getByRole("combobox", { name: /model 1/i })).toHaveValue(
       "openai:gpt-5-nano",
     )
@@ -1042,16 +1126,19 @@ describe("RoutingPage", () => {
     expect(calls.some((call) => call.method === "POST")).toBe(false)
   })
 
-  it("summarises a weighted policy by its split, not by its pool size", async () => {
+  it("summarizes a weighted policy by its split, not by its pool size", async () => {
     // Two provider:model strings do not fit the cell, and the shares are what tells
     // one weighted policy from another at a glance.
     mockApi([policy("balanced", WEIGHTED, { is_dynamic: true })])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    expect(within(row).getByText("WEIGHTED")).toBeInTheDocument()
+    const row = await policyRow("balanced")
     expect(
       within(row).getByText(/70% \/ 30% across 2 models/),
+    ).toBeInTheDocument()
+    expect(
+      within(await openPolicy(user, "balanced")).getByText("WEIGHTED"),
     ).toBeInTheDocument()
   })
 
@@ -1115,8 +1202,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     const shares = screen.getAllByRole("textbox", { name: /share/i })
     expect(shares[0]).toHaveValue("70")
@@ -1155,8 +1242,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     const shares = screen.getAllByRole("textbox", { name: /share/i })
     await user.clear(shares[0])
@@ -1213,9 +1300,9 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    expect(within(row).getByText("WEIGHTED")).toBeInTheDocument()
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    expect(within(panel).getByText("WEIGHTED")).toBeInTheDocument()
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
 
     // Loading it as weighted is half the claim; saving it back unchanged is the
     // other half. The spelling is normalized on the way out, which is what the
@@ -1248,8 +1335,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     for (const share of screen.getAllByRole("textbox", { name: /share/i })) {
       await user.clear(share)
       await user.type(share, "0")
@@ -1270,8 +1357,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(screen.getByRole("button", { name: "+ Another model" }))
 
     const shares = screen.getAllByRole("textbox", { name: /share/i })
@@ -1287,8 +1374,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "balanced")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     const second = screen.getByRole("combobox", { name: /model 2/i })
     await user.clear(second)
     await user.type(second, "openai:gpt-5")
@@ -1302,8 +1389,8 @@ describe("RoutingPage", () => {
   })
 
   it("names a router backend it does not know without claiming it learns", async () => {
-    // Only "knn" learns. Labelling every other backend "Learned" would make the table
-    // lie about the first backend added after this line was written.
+    // Only "knn" learns. Labeling every other backend "Learned" would make the
+    // page lie about the first backend added after this line was written.
     mockApi([
       policy("future", {
         select: [
@@ -1315,23 +1402,27 @@ describe("RoutingPage", () => {
         ],
       }),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("future")).closest("tr")!
-    expect(within(row).getByText("ROUTED")).toBeInTheDocument()
-    expect(within(row).queryByText("Learned")).not.toBeInTheDocument()
+    const row = await policyRow("future")
+    expect(within(row).getByText(/Routed . 2 candidates/)).toBeInTheDocument()
+    const panel = await openPolicy(user, "future")
+    expect(within(panel).getByText("ROUTED")).toBeInTheDocument()
+    expect(within(panel).queryByText("Learned")).not.toBeInTheDocument()
   })
 
   it("does not offer the examples panel for a weighted policy, which learns nothing", async () => {
     mockApi([policy("balanced", WEIGHTED, { is_dynamic: true })])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("balanced")).closest("tr")!
+    const panel = await openPolicy(user, "balanced")
     expect(
-      within(row).queryByRole("button", { name: "Examples" }),
+      within(panel).queryByRole("button", { name: "Examples" }),
     ).not.toBeInTheDocument()
     expect(
-      within(row).getByRole("button", { name: "Edit" }),
+      within(panel).getByRole("button", { name: "Edit" }),
     ).toBeInTheDocument()
   })
 
@@ -1349,11 +1440,13 @@ describe("RoutingPage", () => {
         ],
       }),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("legacy")).closest("tr")!
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(await openPolicy(user, "legacy")).queryByRole("button", {
+        name: "Edit",
+      }),
     ).not.toBeInTheDocument()
   })
 
@@ -1369,49 +1462,55 @@ describe("RoutingPage", () => {
         ],
       }),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("future")).closest("tr")!
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(await openPolicy(user, "future")).queryByRole("button", {
+        name: "Edit",
+      }),
     ).not.toBeInTheDocument()
   })
 
   it("offers the examples panel only on a policy that actually uses a router", async () => {
-    // Readiness is a per-policy question, so it belongs on the row like Edit does
-    // rather than in a panel that is always on the page.
+    // Readiness is a per-policy question, so it opens in the column showing
+    // that policy rather than in a panel that is always on the page.
     mockApi([
       policy("smart", LEARNED, { is_dynamic: true }),
       policy("fast", CHAIN),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const learnedRow = (await screen.findByText("smart")).closest("tr")!
-    const plainRow = (await screen.findByText("fast")).closest("tr")!
     expect(
-      within(learnedRow).getByRole("button", { name: "Examples" }),
+      within(await openPolicy(user, "smart")).getByRole("button", {
+        name: "Examples",
+      }),
     ).toBeInTheDocument()
-    expect(
-      within(plainRow).queryByRole("button", { name: "Examples" }),
-    ).not.toBeInTheDocument()
     // Nothing about learned routing is on the page until asked for.
     expect(screen.queryByText(/Whose memory/)).not.toBeInTheDocument()
+    expect(
+      within(await openPolicy(user, "fast")).queryByRole("button", {
+        name: "Examples",
+      }),
+    ).not.toBeInTheDocument()
   })
 
   it("offers the examples panel for a config.yml policy, which cannot be edited", async () => {
     // Reading readiness is safe for a policy this page cannot change, and without it
     // a config-defined learned policy would be entirely opaque here.
     mockApi([policy("smart", LEARNED, { is_dynamic: true, source: "config" })])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
+    const panel = await openPolicy(user, "smart")
     expect(
-      within(row).getByRole("button", { name: "Examples" }),
+      within(panel).getByRole("button", { name: "Examples" }),
     ).toBeInTheDocument()
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(panel).queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument()
-    expect(within(row).getByText("set in config.yml")).toBeInTheDocument()
+    expect(within(panel).getByText(/Set in config.yml/)).toBeInTheDocument()
   })
 
   it("names the pool and what serves when the router declines", async () => {
@@ -1419,8 +1518,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Examples" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Examples" }))
 
     expect(
       await screen.findByText(/ranks openai:gpt-5-nano, openai:gpt-5/),
@@ -1435,8 +1534,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Examples" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Examples" }))
     await user.type(
       screen.getByRole("combobox", { name: /whose memory/i }),
       "alice",
@@ -1458,8 +1557,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Examples" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Examples" }))
 
     expect(
       await screen.findByText(/POST \/api\/v1\/routing\/preferences\/rank/),
@@ -1481,8 +1580,8 @@ describe("RoutingPage", () => {
     const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("smart")).closest("tr")!
-    await user.click(within(row).getByRole("button", { name: "Examples" }))
+    const panel = await openPolicy(user, "smart")
+    await user.click(within(panel).getByRole("button", { name: "Examples" }))
 
     expect(
       screen.queryByRole("combobox", { name: /whose memory/i }),
@@ -1535,16 +1634,17 @@ describe("RoutingPage", () => {
         ],
       }),
     ])
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("api-authored")).closest("tr")!
+    const panel = await openPolicy(user, "api-authored")
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(panel).queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument()
-    expect(within(row).getByText(/cannot show yet/)).toBeInTheDocument()
+    expect(within(panel).getByText(/cannot show yet/)).toBeInTheDocument()
     // Reading its readiness is still fine.
     expect(
-      within(row).getByRole("button", { name: "Examples" }),
+      within(panel).getByRole("button", { name: "Examples" }),
     ).toBeInTheDocument()
   })
 
@@ -1558,27 +1658,29 @@ describe("RoutingPage", () => {
       }),
       memberPolicies: [policy("fast", CHAIN)],
     })
+    const user = userEvent.setup()
     renderPage(<RoutingPage />)
 
-    const row = (await screen.findByText("fast")).closest("tr")!
+    const row = await policyRow("fast")
     expect(within(row).getByText(/openai:gpt-5-mini/)).toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: "New policy" }),
+      screen.queryByRole("button", { name: "Create policy" }),
+    ).not.toBeInTheDocument()
+    // Opening it reads. It offers nothing that writes, and the Examples panel
+    // reads the operator-only /routing/status, so that goes too.
+    const panel = await openPolicy(user, "fast")
+    expect(
+      within(panel).queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument()
     expect(
-      within(row).queryByRole("button", { name: "Edit" }),
+      within(panel).queryByRole("button", { name: "Delete" }),
     ).not.toBeInTheDocument()
     expect(
-      within(row).queryByRole("button", { name: "Delete" }),
-    ).not.toBeInTheDocument()
-    // The Examples panel reads the operator-only /v1/routing/status, so its
-    // opener goes with the rest of the actions column.
-    expect(
-      within(row).queryByRole("button", { name: "Examples" }),
+      within(panel).queryByRole("button", { name: "Examples" }),
     ).not.toBeInTheDocument()
   })
 
-  it("keeps cached operator rows out of a member's table", async () => {
+  it("keeps cached operator rows out of a member's list", async () => {
     // A disabled query still serves whatever sits under its key, so a caller
     // demoted mid-session would otherwise keep seeing the deployment-wide
     // policies and aliases they fetched as an operator. The pre-seeded client
@@ -1757,13 +1859,9 @@ describe("RoutingPage for an organization admin", () => {
     const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("doomed")
-    await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(
-      within(await screen.findByRole("alertdialog")).getByRole("button", {
-        name: "Delete policy",
-      }),
-    )
+    const panel = await openPolicy(user, "doomed")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
+    await confirmDelete(user, "Delete policy")
 
     const deleted = calls.find((call) => call.method === "DELETE")
     expect(deleted?.url).toContain(
@@ -1786,8 +1884,8 @@ describe("RoutingPage for an organization admin", () => {
     const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("elsewhere")
-    await user.click(screen.getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "elsewhere")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(await screen.findByRole("button", { name: "Save" }))
 
     const written = calls.find(
@@ -1838,8 +1936,8 @@ describe("RoutingPage for an organization admin", () => {
     const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("elsewhere-alias")
-    await user.click(screen.getByRole("button", { name: "Edit" }))
+    const panel = await openPolicy(user, "elsewhere-alias")
+    await user.click(within(panel).getByRole("button", { name: "Edit" }))
     await user.click(await screen.findByRole("button", { name: "Save" }))
 
     const written = calls.find(
@@ -1868,13 +1966,9 @@ describe("RoutingPage for an organization admin", () => {
     const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("doomed-alias")
-    await user.click(screen.getByRole("button", { name: "Delete" }))
-    await user.click(
-      within(await screen.findByRole("alertdialog")).getByRole("button", {
-        name: "Delete alias",
-      }),
-    )
+    const panel = await openPolicy(user, "doomed-alias")
+    await user.click(within(panel).getByRole("button", { name: "Delete" }))
+    await confirmDelete(user, "Delete alias")
 
     const deleted = calls.find((call) => call.method === "DELETE")
     expect(deleted?.url).toContain(`${API_ROOT}/organizations/me/aliases/`)
@@ -1892,14 +1986,16 @@ describe("RoutingPage for an organization admin", () => {
       }),
       memberPolicies: [policy("mine", CHAIN)],
     })
+    const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("mine")
     expect(
-      screen.queryByRole("button", { name: "New policy" }),
+      within(await openPolicy(user, "mine")).queryByRole("button", {
+        name: "Delete",
+      }),
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: "Delete" }),
+      screen.queryByRole("button", { name: "Create policy" }),
     ).not.toBeInTheDocument()
   })
 
@@ -1914,14 +2010,16 @@ describe("RoutingPage for an organization admin", () => {
       }),
       memberPolicies: [policy("mine", CHAIN)],
     })
+    const user = userEvent.setup()
     renderInWorkspace(<RoutingPage />)
 
-    await screen.findByText("mine")
     expect(
-      screen.queryByRole("button", { name: "New policy" }),
+      within(await openPolicy(user, "mine")).queryByRole("button", {
+        name: "Delete",
+      }),
     ).not.toBeInTheDocument()
     expect(
-      screen.queryByRole("button", { name: "Delete" }),
+      screen.queryByRole("button", { name: "Create policy" }),
     ).not.toBeInTheDocument()
   })
 })

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@heroui/react"
 import { Link } from "@tanstack/react-router"
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 
 import type {
   AliasResponse,
@@ -8,19 +7,18 @@ import type {
   PolicySpec,
   RoutingPolicyResponse,
 } from "@/client"
+import { Button } from "@/design-system/actions/Button"
+import { CopyButton } from "@/design-system/actions/CopyButton"
 import { CopyableValue } from "@/design-system/actions/CopyField"
-import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
-import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
-import { EmptyState } from "@/design-system/feedback/EmptyState"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import { FieldAction } from "@/design-system/forms/FieldAction"
 import { ControlField } from "@/design-system/forms/FieldMessages"
 import { Dot } from "@/design-system/indicators/Dot"
+import { ListDetail, ListDetailRow } from "@/design-system/layout/ListDetail"
 import { PageIntro } from "@/design-system/layout/PageIntro"
-import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
 import { Tab, TabRow } from "@/design-system/navigation/TabRow"
 import { ModelComboBox } from "@/features/models/ModelComboBox"
 import { canManage, isDeploymentOperator } from "@/features/organization/roles"
@@ -269,14 +267,14 @@ function conditionsOf(
     }))
 }
 
-/** One line summarising what a policy serves, for the table. */
+/** One line summarizing what a policy serves, for a row and the column it opens. */
 function servesSummary(policy: RoutingPolicyResponse): string {
   const chain = policy.spec.on_failure ?? []
   const pool = candidatesOf(policy.spec)
   if (pool.length > 0 && routerBackendOf(policy.spec) === WEIGHTED_BACKEND) {
-    // The split shape, not the model names: two provider:model strings do not fit a
-    // table cell, and the shares are what distinguishes one weighted policy from
-    // another. The pool is spelled out in the editor and in explain.
+    // The split shape, not the model names: two provider:model strings do not fit
+    // one line of a row, and the shares are what distinguishes one weighted
+    // policy from another. The pool is spelled out in the editor and in explain.
     const declared = weightsOf(policy.spec)
     const target = defaultTargetOf(policy.spec)
     const full = pool.includes(target) ? pool : [...pool, target]
@@ -1306,6 +1304,241 @@ function KindMark({ label }: { label: string }) {
   )
 }
 
+/** A `sm` control at the touch floor below `md`: 32px where there is a pointer,
+ *  44px where there is not. */
+const ACTION_CLASS = "min-h-11 md:min-h-0"
+
+/** A list row's second line: what it serves, then what changes what can be done
+ *  with it. One string rather than marks, so a narrow column ellipsizes it. */
+function rowSummary(row: RoutingRow): string {
+  return [
+    servesSummary(row),
+    row.user_id ? `for ${row.user_id}` : "",
+    row.kind === "alias" ? "alias" : "",
+    row.source === "config" ? "config" : "",
+  ]
+    .filter((part) => part !== "")
+    .join(" · ")
+}
+
+/** One policy read-only, in the column its row opens.
+ *
+ *  The list column holds a name and a line, so every fact the table spread
+ *  across lanes is here, and so are the controls that act on the row. Nothing
+ *  the table showed became unreachable.
+ */
+function PolicyDetail({
+  row,
+  canEdit,
+  isOperator,
+  isReadinessShown,
+  onToggleReadiness,
+  onEdit,
+  onDelete,
+}: {
+  row: RoutingRow
+  canEdit: boolean
+  isOperator: boolean
+  isReadinessShown: boolean
+  onToggleReadiness: () => void
+  onEdit: () => void
+  onDelete: () => void
+}) {
+  const chain = row.spec.on_failure ?? []
+  const guardrails = row.spec.guardrails ?? []
+  const pool = candidatesOf(row.spec)
+  const isConfig = row.source === "config"
+  const isEditable = isEditableInForm(row.spec)
+  // Teaching is data, not configuration, so the panel is offered even for a
+  // policy defined in config.yml: an operator can score examples for a policy
+  // they cannot edit here, and without this that policy could never route.
+  // Operator-only, because it reads `/routing/status`, which is
+  // deployment-wide: an admin has no readiness to be shown.
+  //
+  // "Examples" rather than "Router": on a Routing page full of routing
+  // policies, "Router" names the thing rather than what opens, and the count of
+  // scored examples is the one number in there that changes.
+  const hasReadiness = isOperator && routerBackendOf(row.spec) === KNN_BACKEND
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        {/* Copy beside the heading rather than inside it: nested in the `h2`
+            its name joins the heading's, which is then read as the policy name
+            plus "Copy policy name". */}
+        <div className="flex min-w-0 items-center gap-1">
+          <h2 className="truncate text-title">{row.name}</h2>
+          <CopyButton value={row.name} label="policy name" />
+        </div>
+        {/* No control at all for a caller who cannot act: each of these is
+            either a write or the operator-only Examples read. Dense on a desk
+            and at the touch floor on a phone, where they are the only controls
+            in the column that is on screen. */}
+        <div className="flex flex-wrap items-center gap-2">
+          {hasReadiness ? (
+            <Button
+              size="sm"
+              className={ACTION_CLASS}
+              onPress={onToggleReadiness}
+            >
+              {isReadinessShown ? "Hide examples" : "Examples"}
+            </Button>
+          ) : null}
+          {canEdit && !isConfig && isEditable ? (
+            <Button size="sm" className={ACTION_CLASS} onPress={onEdit}>
+              Edit
+            </Button>
+          ) : null}
+          {canEdit && !isConfig ? (
+            <Button size="sm" className={ACTION_CLASS} onPress={onDelete}>
+              Delete
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 border-b border-border px-4 py-4">
+        <span className="text-overline">Serves</span>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-body">{servesSummary(row)}</span>
+          {/* The kind of routing, as an affirmative mark: a learned router or a
+              weighted split is a decision somebody made about this policy,
+              where a plain single-target policy is just the default shape. */}
+          {pool.length > 0 ? (
+            <KindMark label={routerLabelOf(row.spec)} />
+          ) : row.is_dynamic ? (
+            <KindMark label="Dynamic" />
+          ) : null}
+        </div>
+        {chain.length > 0 ? (
+          <span className="text-caption">If it fails: {chain.join(", ")}</span>
+        ) : null}
+      </div>
+
+      <div className="grid gap-4 border-b border-border px-4 py-4 sm:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <span className="text-overline">Guards</span>
+          <span className="text-body">
+            {guardrails.length === 0
+              ? "None"
+              : guardrails
+                  .map(
+                    (guardrail) => `${guardrail.profile} (${guardrail.mode})`,
+                  )
+                  .join(", ")}
+          </span>
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-overline">Applies to</span>
+          <span className="text-body">
+            {(row.user_id ?? null) === null ? (
+              "Every caller"
+            ) : (
+              <CopyableValue value={row.user_id ?? ""} label="user id" />
+            )}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-overline">Source</span>
+          <span className="flex flex-wrap items-center gap-3 text-mono-caption text-muted">
+            <span className="flex items-center gap-2">
+              <Dot className={isConfig ? "bg-text-subtle" : "bg-accent"} />
+              {row.source.toUpperCase()}
+            </span>
+            {row.kind === "alias" ? (
+              <span className="text-mono-overline text-subtle">alias</span>
+            ) : null}
+          </span>
+        </div>
+      </div>
+
+      {isConfig ? (
+        <p className="max-w-prose px-4 py-3 text-caption">
+          Set in config.yml, so it cannot be edited or deleted here.
+        </p>
+      ) : isEditable ? null : (
+        <p className="max-w-prose px-4 py-3 text-caption">
+          Uses options this form cannot show yet. Edit it through the API so
+          nothing is lost.
+        </p>
+      )}
+
+      {isReadinessShown ? (
+        <div className="border-t border-border">
+          <RouterReadiness
+            policyName={row.name}
+            candidates={pool}
+            defaultTarget={defaultTargetOf(row.spec)}
+            backend={routerBackendOf(row.spec) ?? KNN_BACKEND}
+            scopedUserId={row.user_id ?? null}
+            onClose={onToggleReadiness}
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/** The detail column with nothing open, which is where a wide viewport lands
+ *  before the first click and where an empty page says what to do.
+ *
+ *  Three readings, the same three the page has: pick one, or the steps for a
+ *  caller who can write and has no policies, or who defines these for one who
+ *  cannot.
+ */
+function NothingOpen({
+  canEdit,
+  hasRows,
+  isLoading,
+}: {
+  canEdit: boolean
+  hasRows: boolean
+  isLoading: boolean
+}) {
+  // Nothing rather than a guess: until the lists answer, "no policies yet" and
+  // "pick one" are both claims about a page that has not loaded.
+  if (isLoading) return null
+  if (hasRows)
+    return (
+      <p className="px-4 py-10 text-center text-caption">
+        Pick a policy to see what it serves and what it applies to.
+      </p>
+    )
+  if (!canEdit)
+    return (
+      <div className="flex flex-col gap-2 px-4 py-5">
+        <h2 className="text-title">No routing policies yet</h2>
+        <p className="text-body">
+          Policies that apply in your workspaces will be listed here once your
+          organization&apos;s admins define them.
+        </p>
+      </div>
+    )
+  return (
+    <div className="flex flex-col gap-3 px-4 py-5">
+      <h2 className="text-title">No routing policies yet</h2>
+      <ol className="flex list-decimal flex-col gap-1 pl-5 text-body">
+        <li>
+          Create a policy and point it at the model that should normally serve.
+        </li>
+        <li>
+          Add a fallback chain so a provider outage does not become a failed
+          request.
+        </li>
+        <li>
+          Or split the traffic across two providers by weight, and move the
+          shares as you learn.
+        </li>
+        <li>
+          Or let a router choose per request between a cheap and a strong model,
+          then teach it with a few scored examples.
+        </li>
+        <li>Have your callers send the policy name as their `model`.</li>
+      </ol>
+    </div>
+  )
+}
+
 export function RoutingPage() {
   // Deliberately unscoped, unlike keys and usage. The gateway stores every
   // policy and alias in the default workspace on purpose, because resolution
@@ -1347,23 +1580,26 @@ export function RoutingPage() {
     isOperator || (canManage(organization.data) && writeWorkspaceId !== null)
   // An admin's list spans every workspace of the organization, not just the
   // selected one, so a write to an existing row goes back to the workspace that
-  // row lives in (`rowWorkspace` below, and the Edit form's `workspaceId`).
-  // Using the selection would create a second policy of the same name in the
-  // selected workspace and leave the edited one untouched.
-  // A deep link may pre-fill the add form with ?target=provider:model.
+  // row lives in (`deleteWorkspaceFor` below, and the Edit dialog's
+  // `workspaceId`). Using the selection would create a second policy of the
+  // same name in the selected workspace and leave the edited one untouched.
+  // A deep link may pre-fill the new-policy dialog with ?target=provider:model.
   const initialTarget = useUrlValue("target")
   const [adding, setAdding] = useState(initialTarget !== "")
   const [editing, setEditing] = useState<RoutingRow | null>(null)
   const [pendingDelete, setPendingDelete] = useState<RoutingRow>()
-  // Readiness opens inline under its own row (DataTable's accordion), because it
-  // describes one policy and the operator clicked that policy. A card above the
-  // table would put the panel nowhere near the control that opened it.
-  const [expanded, setExpanded] = useState<string | null>(null)
+  // The open row, held as its key rather than as the row itself, so the detail
+  // column reads from the list rather than from a snapshot taken at the click.
+  const [openKey, setOpenKey] = useState<string | null>(null)
+  // Readiness opens under the control that opened it, in the column showing the
+  // policy it describes. It belongs to that policy, so opening another closes
+  // it.
+  const [isReadinessShown, setIsReadinessShown] = useState(false)
   // `adding` is seeded from ?target= before the membership context settles, so
   // the role is applied here rather than in the initializer: gating the
   // initializer would drop an operator's deep link, since `isOperator` is still
   // false at the moment it runs. A member arriving on that link gets the
-  // read-only empty state instead of a form whose only outcome is a refusal.
+  // read-only empty column instead of a form whose only outcome is a refusal.
   const isAdding = adding && canEdit
 
   // Aliases and policies are listed together: an alias is the one-target case,
@@ -1388,175 +1624,22 @@ export function RoutingPage() {
       (a.user_id ?? "").localeCompare(b.user_id ?? ""),
   )
   // The context counts as loading too: until it settles, neither list has been
-  // asked, and an empty table would read as "no policies" rather than "not yet".
+  // asked, and an empty column would read as "no policies" rather than "not
+  // yet".
   const isListLoading =
     !isContextSettled ||
     (isOperator
       ? policies.isLoading || aliases.isLoading
       : memberPolicies.isLoading || memberAliases.isLoading)
 
-  // Stable so DataTable's row cache holds; see its docstring.
-  const renderDetail = useCallback(
-    (row: RoutingRow) => (
-      <RouterReadiness
-        policyName={row.name}
-        candidates={candidatesOf(row.spec)}
-        defaultTarget={defaultTargetOf(row.spec)}
-        backend={routerBackendOf(row.spec) ?? KNN_BACKEND}
-        scopedUserId={row.user_id ?? null}
-        onClose={() => setExpanded(null)}
-      />
-    ),
-    [],
-  )
-
-  const columns = useMemo<DataTableColumn<RoutingRow>[]>(() => {
-    const base: DataTableColumn<RoutingRow>[] = [
-      {
-        id: "name",
-        header: "Policy",
-        isRowHeader: true,
-        cell: (policy) => (
-          <CopyableValue value={policy.name} label="policy name" />
-        ),
-      },
-      {
-        id: "serves",
-        header: "Serves",
-        cell: (policy) => (
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-foreground">
-              {servesSummary(policy)}
-            </span>
-            {/* The kind of routing, as an affirmative mark: a fallback chain or
-                a learned router is a decision somebody made about this policy,
-                where a plain single-target policy is just the default shape. */}
-            {candidatesOf(policy.spec).length > 0 ? (
-              <KindMark label={routerLabelOf(policy.spec)} />
-            ) : policy.is_dynamic ? (
-              <KindMark label="Dynamic" />
-            ) : null}
-          </div>
-        ),
-      },
-      {
-        id: "guards",
-        header: "Guards",
-        cell: (policy) => {
-          const guardrails = policy.spec.guardrails ?? []
-          // An em dash: no guardrails is an absence, not a zero.
-          if (guardrails.length === 0)
-            return <span className="text-muted">—</span>
-          return (
-            <span className="text-body">
-              {guardrails
-                .map((guardrail) => `${guardrail.profile} (${guardrail.mode})`)
-                .join(", ")}
-            </span>
-          )
-        },
-      },
-      {
-        id: "scope",
-        header: "Applies to",
-        cell: (policy) =>
-          (policy.user_id ?? null) === null ? (
-            <span className="text-muted">Every caller</span>
-          ) : (
-            <CopyableValue value={policy.user_id ?? ""} label="user id" />
-          ),
-      },
-      {
-        id: "source",
-        header: "Source",
-        cell: (row) => (
-          <div className="flex items-center gap-4">
-            <span className="flex items-center gap-2 text-mono-caption text-muted">
-              <Dot
-                className={
-                  row.source === "config" ? "bg-text-subtle" : "bg-accent"
-                }
-              />
-              {row.source.toUpperCase()}
-            </span>
-            {row.kind === "alias" ? (
-              <span className="text-mono-overline text-subtle">alias</span>
-            ) : null}
-          </div>
-        ),
-      },
-    ]
-    // No actions column for a caller who cannot act: every affordance in it is
-    // either a write or the Examples panel, whose read is operator-only.
-    if (!canEdit) return base
-    base.push({
-      id: "actions",
-      header: "",
-      cell: (policy) => {
-        // Teaching is data, not configuration, so it is offered even for a policy
-        // defined in config.yml: an operator can score examples for a policy they
-        // cannot edit here, and without this that policy could never route.
-        // "Examples" rather than "Router": on a Routing page full of routing
-        // policies, "Router" names the thing rather than what opens, and the count
-        // of scored examples is the one number in there that changes.
-        //
-        // Three outcomes, not two. Operator-only within an actions column an
-        // admin now also gets, because the panel reads `/routing/status`,
-        // which is deployment-wide: an admin sees no readiness at all. Then an
-        // em dash where a policy has no readiness to report, rather than an
-        // empty cell, since a fallback chain has nothing to learn and that
-        // absence is worth stating and is not the same as zero examples. Then
-        // the control, for a backend that learns.
-        const readiness = !isOperator ? null : routerBackendOf(policy.spec) !==
-          KNN_BACKEND ? (
-          <span className="text-muted">—</span>
-        ) : (
-          <RowAction
-            onPress={() =>
-              setExpanded((current) =>
-                current === rowKeyOf(policy) ? null : rowKeyOf(policy),
-              )
-            }
-          >
-            {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
-          </RowAction>
-        )
-        return policy.source === "config" ? (
-          <RowActionRow>
-            {readiness}
-            <span className="text-xs text-subtle">set in config.yml</span>
-          </RowActionRow>
-        ) : (
-          <RowActionRow>
-            {readiness}
-            {isEditableInForm(policy.spec) ? (
-              <RowAction
-                onPress={() => {
-                  // The table stays mounted while the create form is open, so
-                  // Edit is still reachable from it. Closing the other panels
-                  // keeps this to one form: two stacked forms do not recover on
-                  // their own, since each only closes when cancelled.
-                  setAdding(false)
-                  setEditing(policy)
-                }}
-              >
-                Edit
-              </RowAction>
-            ) : (
-              <span className="max-w-xs text-xs text-muted">
-                Uses options this form cannot show yet. Edit it through the API
-                so nothing is lost.
-              </span>
-            )}
-            <RowAction onPress={() => setPendingDelete(policy)}>
-              Delete
-            </RowAction>
-          </RowActionRow>
-        )
-      },
-    })
-    return base
-  }, [canEdit, expanded, isOperator])
+  // A rename moves the row and a delete removes it, so the key can name a row
+  // the list no longer has. Resolving it every render rather than holding the
+  // row is what makes that a return to the prompt instead of a column
+  // describing something that does not resolve any more.
+  const openRow = rows.find((row) => rowKeyOf(row) === openKey)
+  // Read by both halves of the empty column, its message and its press target,
+  // so the two cannot disagree about whether the list has answered yet.
+  const isListEmpty = !isListLoading && rows.length === 0
 
   // Which of the four delete surfaces a row goes to. The tenant one names the
   // workspace and has no user scope; the deployment-wide one defaults the
@@ -1578,26 +1661,14 @@ export function RoutingPage() {
     ? deleteMutationFor(pendingDelete)
     : undefined
 
+  const startCreate = () => {
+    setEditing(null)
+    setAdding(true)
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <PageIntro
-        title="Routing"
-        action={
-          canEdit ? (
-            <Button
-              // Visible while the dialog is open: the dialog is over the page,
-              // so there is nothing for hiding this to prevent.
-              variant="primary"
-              onPress={() => {
-                setEditing(null)
-                setAdding(true)
-              }}
-            >
-              Create policy
-            </Button>
-          ) : undefined
-        }
-      >
+      <PageIntro title="Routing">
         {/* Three readings of the same page, because what a caller may do here
             differs: an operator sees the deployment-wide capabilities, an
             admin sees what their own workspace writes reach, and a member is
@@ -1610,14 +1681,85 @@ export function RoutingPage() {
             : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the ones in force in your workspaces; your organization's admins manage them."}
       </PageIntro>
 
-      {/* The reads only. Every delete on this page reports inside its own
-          confirm dialog, which is where the operator is looking. */}
+      {/* The reads only. A delete reports inside its own confirm dialog and a
+          write inside the form dialog that made it, which is where the operator
+          is looking in each case. */}
       <ErrorBanner
         error={
           policies.error ??
           memberPolicies.error ??
           aliases.error ??
           memberAliases.error
+        }
+      />
+
+      <ListDetail
+        listLabel="Policies"
+        backLabel="All policies"
+        detailLabel="Policy detail"
+        listAction={
+          canEdit ? (
+            // In the column it adds to rather than beside the page title: the
+            // dialog it opens sits over the page, so the control belongs to the
+            // list it lengthens.
+            <Button
+              size="sm"
+              variant="primary"
+              className={ACTION_CLASS}
+              onPress={startCreate}
+            >
+              Create policy
+            </Button>
+          ) : undefined
+        }
+        isDetailShown={openRow !== undefined}
+        onShowList={() => setOpenKey(null)}
+        empty={
+          isListLoading
+            ? "Loading…"
+            : !isListEmpty
+              ? undefined
+              : canEdit
+                ? "Create your first policy"
+                : "No routing policies yet."
+        }
+        // Only once the lists have answered, and only for a caller who can
+        // write: a press whose one outcome is a refusal is not an invitation.
+        onEmptyPress={canEdit && isListEmpty ? startCreate : undefined}
+        list={rows.map((row) => (
+          <ListDetailRow
+            key={rowKeyOf(row)}
+            label={row.name}
+            isSelected={rowKeyOf(row) === openKey}
+            onSelect={() => {
+              setIsReadinessShown(false)
+              setOpenKey(rowKeyOf(row))
+            }}
+          >
+            {rowSummary(row)}
+          </ListDetailRow>
+        ))}
+        detail={
+          openRow === undefined ? (
+            <NothingOpen
+              canEdit={canEdit}
+              hasRows={rows.length > 0}
+              isLoading={isListLoading}
+            />
+          ) : (
+            <PolicyDetail
+              row={openRow}
+              canEdit={canEdit}
+              isOperator={isOperator}
+              isReadinessShown={isReadinessShown}
+              onToggleReadiness={() => setIsReadinessShown((shown) => !shown)}
+              onEdit={() => {
+                setAdding(false)
+                setEditing(openRow)
+              }}
+              onDelete={() => setPendingDelete(openRow)}
+            />
+          )
         }
       />
 
@@ -1638,59 +1780,6 @@ export function RoutingPage() {
           onClose={() => setEditing(null)}
         />
       ) : null}
-
-      {rows.length === 0 && !isListLoading ? (
-        canEdit ? (
-          <EmptyState
-            title="No routing policies yet"
-            actionLabel="Create policy"
-            onAction={() => {
-              setEditing(null)
-              setAdding(true)
-            }}
-          >
-            <ol className="flex list-decimal flex-col gap-1 pl-5 text-sm text-muted">
-              <li>
-                Create a policy and point it at the model that should normally
-                serve.
-              </li>
-              <li>
-                Add a fallback chain so a provider outage does not become a
-                failed request.
-              </li>
-              <li>
-                Or split the traffic across two providers by weight, and move
-                the shares as you learn.
-              </li>
-              <li>
-                Or let a router choose per request between a cheap and a strong
-                model, then teach it with a few scored examples.
-              </li>
-              <li>Have your callers send the policy name as their `model`.</li>
-            </ol>
-          </EmptyState>
-        ) : (
-          <EmptyState title="No routing policies yet">
-            <p className="text-sm text-muted">
-              Policies that apply in your workspaces will be listed here once
-              your organization's admins define them.
-            </p>
-          </EmptyState>
-        )
-      ) : (
-        <TableScrollFrame className="otari-routing-table">
-          <DataTable
-            ariaLabel="Routing policies"
-            columns={columns}
-            rows={rows}
-            getRowKey={rowKeyOf}
-            detailKey={expanded}
-            renderDetail={renderDetail}
-            isLoading={isListLoading}
-            emptyContent="No routing policies yet."
-          />
-        </TableScrollFrame>
-      )}
 
       <ConfirmDialog
         isOpen={pendingDelete !== undefined}

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -645,7 +645,6 @@ describe("a table is a region, not a card", () => {
     "otari-provider-keys-table",
     "otari-providers-table",
     "otari-rate-overrides-table",
-    "otari-routing-table",
     "otari-workspaces-table",
   ]
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2606,8 +2606,7 @@ main {
    rather than relying on the cell padding both sides already spend. */
 .otari-models-table .otari-table.table-root,
 .otari-domains-table .otari-table.table-root,
-.otari-providers-table .otari-table.table-root,
-.otari-routing-table .otari-table.table-root {
+.otari-providers-table .otari-table.table-root {
   border-top: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
 }
@@ -2630,9 +2629,7 @@ main {
 .otari-domains-table .table__column:first-child,
 .otari-domains-table .table__row .table__cell:first-child,
 .otari-providers-table .table__column:first-child,
-.otari-providers-table .table__row .table__cell:first-child,
-.otari-routing-table .table__column:first-child,
-.otari-routing-table .table__row .table__cell:first-child {
+.otari-providers-table .table__row .table__cell:first-child {
   position: sticky;
   left: 0;
   z-index: 1;
@@ -2645,9 +2642,7 @@ main {
   .table__row
   .table__cell:first-child,
 .otari-domains-table[data-scrolled="true"] .table__column:first-child,
-.otari-domains-table[data-scrolled="true"] .table__row .table__cell:first-child,
-.otari-routing-table[data-scrolled="true"] .table__column:first-child,
-.otari-routing-table[data-scrolled="true"]
+.otari-domains-table[data-scrolled="true"]
   .table__row
   .table__cell:first-child {
   border-right: 1px solid var(--color-control-border);


### PR DESCRIPTION
> **Stacked on #1038.** That PR merges first. This one deliberately keeps its
> dialog as the create-and-edit surface: the editor stays in a `FormDialog` over
> the page and nothing is edited in a column.
>
> #1038 itself owes a rebase onto `main`, because its parent (#1032, which added
> `FormDialog`) was squash-merged and left the child conflicted. This PR
> therefore owes a rebase of its own once #1038 is rebased or merged. Two
> protections are also missing here, both a consequence of stacking:
> `.coderabbit.yaml` sets `base_branches: ["main"]`, so CodeRabbit skips a child
> and has to be summoned by comment; and `protect-main` covers the default branch
> only, so this can report `CLEAN` and be mergeable with no approval. **Please do
> not merge it on that basis.**

## Description

The Routing page listed every policy in one wide table and put the editor above
it, so nothing said which row you were changing and the facts about a policy were
spread across six columns you had to scroll sideways to read.

It is now two columns. The left one lists the policies and aliases, with the
"Create policy" control at its top, and each row shows a policy's name and one
line saying what it serves. Click a row and the right column shows that policy on
its own: what serves it, what is tried if that fails, which guardrails always run,
who it applies to, where it came from, and whether it is an alias. That column is
also where the policy's own controls live, so Edit, Delete and Examples all sit
beside the facts they act on rather than in a lane at the far right of a table.

With no policies yet, the left column is one big "Create your first policy"
button and the right one carries the getting-started steps.

On a phone the two columns become one: the list, until you open a policy, and
then the policy with a way back to the list. Every control is at the 44px touch
floor there and none of them depends on hover.

Nothing about what a policy *is* changed, and nothing about who may write one: an
operator still writes deployment-wide, an admin still writes into the selected
workspace, and a member still gets a page with no controls on it at all. A policy
defined in `config.yml` still says so instead of offering an edit, and a policy
using options the form cannot represent is still read-only with the sentence
explaining why.

### Where the Examples panel went

It used to open as an accordion row underneath its own row in the table. It is now
a panel at the foot of the detail column, opened by a control in that column's
header. The detail column is the better home for it: the panel is about the one
policy that column is already showing, so it no longer has to be tucked between
two unrelated rows, and it gets the width to lay out a candidate pool and a
warmth bar without a table's lanes squeezing it. It stays operator-only, because
it reads the deployment-wide `/v1/routing/status`.

### The new primitive

`ListDetail` and `ListDetailRow` are in `design-system/layout/`, because the shape
will be reused. They own the 1:1.75 ratio, the hairline between the columns, the
row separators, and the single-column swap below `md`; which row is selected is a
prop and a callback, so the page keeps being the one place that knows what is
open. They import nothing under `src/` beyond their own layer, which
`architecture.test.ts` proves.

Two things worth knowing about the deliberate choices in it. There is no
per-row Edit or Delete: both would have to be repeated in the detail column
anyway, since below `md` the list is not on screen while a policy is being read,
and one home per action beats two. And the empty column's "click anywhere" is a
real `<button>`, not a div with a click handler, so a keyboard reaches it.

One known limitation: below `md` with no policies, the column that shows is the
list, so the getting-started steps in the detail column are not visible on a
phone. The action is what a phone gets, which seems the right way round, but it
is a trade rather than an oversight.

## How to test it locally

```
make dashboard && otari serve      # or however you run the gateway
```

Then sign in and go to Routing → Policies.

1. With no policies, click anywhere in the left column. The create dialog opens.
   Tab to it instead of clicking: it takes focus as a button.
2. Create two policies, one plain and one with a fallback chain. Both appear as
   rows with a summary line. Click each: the right column fills in, and the row
   you clicked wears the selection tint.
3. From the right column, Edit opens the same dialog with the policy loaded, and
   Delete opens a confirm dialog naming the policy. Cancel it, then confirm it:
   the row goes and the column returns to "pick a policy".
4. Create a policy with a learned router (`+ Let a router pick…`), open it, and
   press Examples. The readiness panel opens at the foot of the column.
5. Narrow the window to 390px. One column at a time, and the Back control appears
   above an open policy.
6. Switch themes. The selection tint and the hairlines are both tokens, so both
   follow.

Automated, and run locally:

- `pnpm --dir web run lint` (Biome, including the layer boundaries): clean.
- `pnpm --dir web run typecheck`: clean.
- `pnpm --dir web test --run src/features/routing src/design-system src/styles`:
  43 files, 3828 tests, all passing. That covers the rewritten
  `RoutingPage.test.tsx` (69 tests: the three role readings, the config.yml and
  not-representable read-only cases, the four delete surfaces, the confirm
  dialog's error handling, and the `?target=` deep link), the new
  `ListDetail.test.tsx`, and the foundation gates, which include the one that
  fails when a design-system prop no story passes.
- `pnpm --dir web test --run src/architecture.test.ts`: 30 tests, passing. Run on
  its own, because it plants probe files that race the tree walk in
  `monoScale.test.ts` when the two run together.

Not run locally, and why:

- **The full Vitest suite and the Storybook sweep.** Deliberate: an earlier
  attempt at this task ran several suites at once and froze the machine. CI runs
  the whole suite and builds the catalog, so both are covered there.
- **The Playwright suites.** They need a live gateway. `dashboard.spec.ts` and
  `parity.management.spec.ts` are updated for the new list shape (two new helpers,
  `listRow` and `detailColumn`, replace the `rowheader` locators), and the roles
  and accessible names were kept coherent with what the Vitest tests query, but
  the e2e runs have not been executed here.
- Screenshot baselines are gitignored and `/routing` already has an entry, so
  there is nothing to commit and no new entry owed.

Nothing on the Python side changed, so no OpenAPI or Postman artifact is stale,
and no route moved, so `routeTree.gen.ts` is unchanged.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2109

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

On the third box: this change is entirely under `web/`, so the dashboard's own
checks are the applicable ones and they are listed above. No Python changed, so
the API contract did not move and there was no spec to regenerate.

Docs updated: `web/design/layout.md` gains the band-component row and a
list-and-detail page recipe, `web/design/DESIGN.md` gains the module row, and
`web/design/data.md` loses `otari-routing-table` from its closed list of table
places, since that class and its CSS went with the table.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

The design-system primitive was drafted in an earlier interrupted run and reviewed
rather than taken as finished: its docstring justified the 1:1.75 ratio partly
with "the right one a form", which #1038 made untrue, and the row was drawing its
own bottom border where the frame should divide its children the way
`SettingsGroup` does. Both are corrected here, along with the touch floor on the
controls the detail column adds.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced the Routing table with a responsive list-and-detail layout.
- Added policy selection, detail actions, mobile navigation, and improved empty states.
- Added reusable `ListDetail` and `ListDetailRow` design-system components.
- Updated documentation, styles, tests, and end-to-end helpers for the new layout.

## Benefits

- Improves routing policy navigation on small and large screens.
- Keeps permissions, read-only behavior, and policy semantics unchanged.
- Provides reusable layout primitives for similar pages.

## Technical notes

- No Python, API, or route-generation changes were made.
- Routing, design-system, architecture, lint, and type checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->