### PR TITLE
fix(dashboard): show people by name in the user pickers, not their UUIDs

### DIFF
--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -56,10 +56,10 @@ Checkbox: { isSelected, onChange: (next: boolean) => void, isDisabled?, ariaLabe
   children }
 Select: { label, value, onChange, options: SelectOption[], description?, placeholder?,
   isRequired?, isDisabled?, isInvalid?, errorMessage?, reserveMessage?, className? }
-ComboBoxField: { label, value, onChange, options: ComboBoxOption[], description?,
-  placeholder?, isRequired?, isDisabled?, isInvalid?, errorMessage?, reserveMessage?,
-  className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus", shouldSelectOnFocus?,
-  isSourceEmpty?, emptyMessage?, noMatchesMessage? }
+ComboBoxField: { label, value, onChange, onQueryChange?, options: ComboBoxOption[],
+  description?, placeholder?, isRequired?, isDisabled?, isInvalid?, errorMessage?,
+  reserveMessage?, className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus",
+  shouldSelectOnFocus?, isSourceEmpty?, emptyMessage?, noMatchesMessage? }
 RadioGroup: { label, value, onChange, options: RadioOption[], description?,
   orientation = "vertical", isRequired?, isDisabled?, isInvalid?, errorMessage?,
   className? }
@@ -116,12 +116,22 @@ Rules:
 ## ComboBoxField
 
 `Select`'s vocabulary for everything the two share, plus what a combo box needs
-beyond it. See its docstring for the contract; three things are worth knowing at
+beyond it. See its docstring for the contract; four things are worth knowing at
 a call site.
+
+**`value` is the option's `value`, exactly as in `Select`**, and the input shows
+that option's `label`. The field never reports a label; the docstring says why.
+`allowsCustomValue` is the one addition: text matching no row is reported as the
+value too, as itself rather than as a lookup. So typing somebody's name names a
+new id rather than resolving to theirs, which is what `description` is for
+(`UserComboBox`'s `unknownHint` says the id will be created).
 
 **It filters nothing.** `options` is what the popover holds, already matched and
 capped by the caller, because what counts as a match differs per field (an id as
 well as a name) and a ceiling wants a "showing 50 of 300" line under it.
+`onQueryChange` is what the caller matches on: the field owns the input's text,
+so it is the only thing that can publish it. It reports empty once a row is
+picked, since the field is then showing a choice rather than a search.
 
 **An empty popover has to say which empty it is.** Every combo box here keeps
 its menu open on an empty collection, so that a query matching nothing does not

--- a/web/src/design-system/forms/ComboBoxField.stories.tsx
+++ b/web/src/design-system/forms/ComboBoxField.stories.tsx
@@ -41,10 +41,27 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+/**
+ * `value` is the picked option's `value` and the input shows its `label`, the
+ * same division `Select` makes. The field filters nothing: `onQueryChange`
+ * publishes what is in the input and the caller decides what matches.
+ */
 export const Default: Story = {
   render: (args) => {
     const [value, setValue] = useState("")
-    return <ComboBoxField {...args} value={value} onChange={setValue} />
+    const [query, setQuery] = useState("")
+    const match = query.trim().toLowerCase()
+    return (
+      <ComboBoxField
+        {...args}
+        value={value}
+        onChange={setValue}
+        onQueryChange={setQuery}
+        options={MODELS.filter((option) =>
+          option.label.toLowerCase().includes(match),
+        )}
+      />
+    )
   },
 }
 
@@ -63,11 +80,13 @@ export const WithDescription: Story = {
 
 /**
  * `hint` is the option's secondary line: text that identifies the label rather
- * than repeating it, such as the id a person is billed under.
+ * than repeating it, such as the id a person is billed under. The value here is
+ * an id, and the box shows the name it belongs to.
  */
 export const OptionHints: Story = {
   args: {
     label: "Owner",
+    value: "018f0000-0000-4000-8000-000000000001",
     placeholder: "Pick a user, or type a new id…",
     options: [
       {

--- a/web/src/design-system/forms/ComboBoxField.test.tsx
+++ b/web/src/design-system/forms/ComboBoxField.test.tsx
@@ -16,7 +16,7 @@ const OPTIONS: ComboBoxOption[] = [
   },
 ]
 
-/** The field is controlled, so a test that types into it has to hold the text. */
+/** The field is controlled, so a test that picks or types has to hold the value. */
 function Harness({
   options = OPTIONS,
   onValue,
@@ -41,7 +41,7 @@ function Harness({
 }
 
 describe("ComboBoxField", () => {
-  it("reports a picked option once, as its value rather than its label", async () => {
+  it("reports a picked row once, as its id, and displays its label", async () => {
     const seen: string[] = []
     render(
       <Harness
@@ -50,16 +50,86 @@ describe("ComboBoxField", () => {
       />,
     )
 
-    await userEvent.click(screen.getByRole("combobox", { name: "Serves" }))
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
     await userEvent.click(
       await screen.findByRole("option", { name: "Ada Lovelace" }),
     )
 
-    // One report, not two. react-aria writes the row's display text into the
-    // input after reporting the selection; forwarding that echo would hand the
-    // caller a label after a key, and a label does not identify a row (two rows
-    // may share one, and one row's label may be another row's value).
+    // One report, and it is the id. The label is what the box shows, which is
+    // the whole division of labor here.
     expect(seen).toEqual(["018f-0001"])
+    expect(field).toHaveValue("Ada Lovelace")
+  })
+
+  it("displays a label the caller resolves after mount", () => {
+    const { rerender } = render(
+      <ComboBoxField
+        label="Owner"
+        value="018f-0001"
+        onChange={() => {}}
+        options={[]}
+      />,
+    )
+
+    // A roster or a catalog read lands after the field paints, so the id it
+    // arrives with has to give way to the name it resolves to.
+    const field = screen.getByRole("combobox", { name: "Owner" })
+    expect(field).toHaveValue("018f-0001")
+
+    rerender(
+      <ComboBoxField
+        label="Owner"
+        value="018f-0001"
+        onChange={() => {}}
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+      />,
+    )
+
+    expect(field).toHaveValue("Ada Lovelace")
+  })
+
+  it("repaints when the caller moves the value out from under it", async () => {
+    const props = {
+      label: "Serves" as const,
+      onChange: () => {},
+      options: OPTIONS,
+      allowsCustomValue: true,
+    }
+    const { rerender } = render(
+      <ComboBoxField {...props} value="openai:gpt-4o" />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.type(field, "!")
+
+    rerender(<ComboBoxField {...props} value="anthropic:claude-sonnet-4-5" />)
+
+    // A row of these fields whose neighbor is removed hands a mounted field
+    // somebody else's value, so a value the field did not report wins over the
+    // text left in the box.
+    expect(field).toHaveValue("anthropic:claude-sonnet-4-5")
+  })
+
+  it("clears the value when the box is emptied", async () => {
+    const seen: string[] = []
+    render(
+      <Harness
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onValue={(value) => seen.push(value)}
+      />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.clear(field)
+
+    // Emptying the box is the one edit a whitelist reports, since it is the
+    // only way to take a selection back.
+    expect(seen).toEqual(["018f-0001", ""])
   })
 
   it("still reports text the operator edits after picking a row", async () => {
@@ -79,10 +149,78 @@ describe("ComboBoxField", () => {
     )
     await userEvent.type(field, "!")
 
-    // Only the one echo is swallowed. Anything typed afterwards is the
-    // operator's, so a field that went quiet after a pick would be a worse bug
-    // than the one the swallowing fixes.
-    expect(seen.at(-1)).toBe("018f-0001!")
+    // Editing the box is not holding a selection: what is in it is text, and a
+    // field that went quiet after a pick would be the worse bug.
+    expect(seen.at(-1)).toBe("Ada Lovelace!")
+  })
+
+  it("keeps text typed over a picked row when the field is left", async () => {
+    const seen: string[] = []
+    render(
+      <Harness
+        allowsCustomValue
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onValue={(value) => seen.push(value)}
+      />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.clear(field)
+    await userEvent.type(field, "ci-bot")
+    await userEvent.tab()
+
+    // Leaving the field is what commits it, and react-aria clears its selection
+    // there when the text no longer matches the row. The typed value has to
+    // survive that: it is what the form submits.
+    expect(seen.at(-1)).toBe("ci-bot")
+    expect(field).toHaveValue("ci-bot")
+  })
+
+  it("returns to the picked row when custom values are not allowed", async () => {
+    render(
+      <Harness options={[{ value: "018f-0001", label: "Ada Lovelace" }]} />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.type(field, "zzz")
+    await userEvent.tab()
+
+    // A whitelist keeps no text nobody offered, so the box goes back to
+    // reading as the value rather than sitting on a search that lost.
+    expect(field).toHaveValue("Ada Lovelace")
+  })
+
+  it("publishes the input's text for a caller that filters", async () => {
+    const queries: string[] = []
+    render(
+      <Harness
+        allowsCustomValue
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onQueryChange={(query) => queries.push(query)}
+      />,
+    )
+
+    await userEvent.type(
+      screen.getByRole("combobox", { name: "Serves" }),
+      "ada",
+    )
+    expect(queries.at(-1)).toBe("ada")
+
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+
+    // Empty once a row is picked: the field shows a choice rather than a
+    // search, so the caller offers its whole list again, not the one row.
+    expect(queries.at(-1)).toBe("")
   })
 
   it("reports free text when the caller allows it", async () => {

--- a/web/src/design-system/forms/ComboBoxField.tsx
+++ b/web/src/design-system/forms/ComboBoxField.tsx
@@ -22,8 +22,16 @@ export interface ComboBoxOption {
   isDisabled?: boolean
 }
 
-const optionText = (option: ComboBoxOption) =>
-  option.hint ? `${option.label} (${option.hint})` : option.label
+/**
+ * A row's accessible name: its label, with its hint in parentheses.
+ *
+ * Exported for a picker that renders its own `ListBox` rows rather than going
+ * through this field, so two controls an operator reads as a pair cannot
+ * describe one row differently.
+ */
+export const comboBoxOptionText = (
+  option: Pick<ComboBoxOption, "label" | "hint">,
+) => (option.hint ? `${option.label} (${option.hint})` : option.label)
 
 /**
  * One of a set, searchable, in a form the operator submits.
@@ -142,7 +150,7 @@ export function ComboBoxField({
       onSelectionChange={(key) => {
         if (key == null) return
         const picked = options.find((option) => option.value === String(key))
-        echoRef.current = picked ? optionText(picked) : undefined
+        echoRef.current = picked ? comboBoxOptionText(picked) : undefined
         onChange(String(key))
       }}
       isRequired={isRequired}
@@ -187,12 +195,12 @@ export function ComboBoxField({
           {(option: ComboBoxOption) => (
             <ListBoxItem
               id={option.value}
-              textValue={optionText(option)}
+              textValue={comboBoxOptionText(option)}
               // Spelled out, because the row has two text nodes and the name
               // computed from them runs the hint onto the end of the label with
               // no separator. The hint belongs in the name rather than being
               // dropped from it: it is what tells two rows with one label apart.
-              aria-label={option.hint ? optionText(option) : undefined}
+              aria-label={option.hint ? comboBoxOptionText(option) : undefined}
               isDisabled={option.isDisabled}
             >
               <span className="flex flex-col">

--- a/web/src/design-system/forms/ComboBoxField.tsx
+++ b/web/src/design-system/forms/ComboBoxField.tsx
@@ -7,15 +7,16 @@ import {
   ListBox,
   ListBoxItem,
 } from "@heroui/react"
-import { type ReactNode, useRef } from "react"
+import { type ReactNode, useState } from "react"
 
 import { ComboBoxEmpty } from "@/design-system/forms/ComboBoxEmpty"
 import { FieldMessages } from "@/design-system/forms/FieldMessages"
 
 /** One choice in a `ComboBoxField`. `isDisabled` shows a choice that exists but cannot be taken. */
 export interface ComboBoxOption {
-  /** What the field reports, and the key react-aria carries. Never empty: react-aria reads an empty key as "nothing selected". */
+  /** The option's id: what the field reports and the key react-aria carries. Never empty: react-aria reads an empty key as "nothing selected". */
   value: string
+  /** What the row and the input display. Never what the field reports. */
   label: string
   /** A second, muted line inside the row, for text that identifies the label rather than repeating it. */
   hint?: string
@@ -32,6 +33,12 @@ export interface ComboBoxOption {
 export const comboBoxOptionText = (
   option: Pick<ComboBoxOption, "label" | "hint">,
 ) => (option.hint ? `${option.label} (${option.hint})` : option.label)
+
+// `options` is the whole popover, so react-aria must not filter it again: its
+// own filter reads a row's `textValue`, which is the label, and would drop a
+// row the caller matched on its hint. Hoisted so the collection it feeds is not
+// rebuilt on every render.
+const KEEP_EVERY_OPTION = () => true
 
 /**
  * One of a set, searchable, in a form the operator submits.
@@ -51,22 +58,26 @@ export const comboBoxOptionText = (
  * `ComboBoxEmpty` is the sentence that tells those apart, and there is no way
  * to render this control without one.
  *
- * `value` is the input's text rather than a chosen key, which is what lets a
- * caller with `allowsCustomValue` submit something the list never offered.
- * Picking a row reports that option's `value`, and reports it once: react-aria
- * echoes the row's display text into the input afterwards, and that echo is
- * swallowed here rather than forwarded. So `onChange` carries a key when a row
- * was picked and text when text was typed, and never a label. See the handlers
- * for why the caller cannot be the one to sort those out.
+ * `value` is an option's `value`, as in `forms/Select`, and never a label. An
+ * id and a name point at the same thing, so identity travels as the id,
+ * through react-aria's `selectedKey`, and the label is only displayed: this
+ * field owns the input's text and shows the matched option's label. Picking a
+ * row reports its id, once. With `allowsCustomValue` the text an operator
+ * types is reported as the value too, because a list that is a shortcut rather
+ * than a whitelist has to let something it never offered stand; that text is
+ * then itself rather than a lookup, since a label maps back to no single id
+ * (two rows may share one, and one row's label may be another row's id).
  *
- * No filtering of its own: `options` is what the popover holds. The caller
- * matches and caps, because what counts as a match differs per field (an id as
- * well as a name, a ceiling with a "showing N of M" line under it).
+ * No filtering of its own: `options` is what the popover holds, and
+ * `onQueryChange` is what the caller matches on. The caller matches and caps,
+ * because what counts as a match differs per field (an id as well as a name, a
+ * ceiling with a "showing N of M" line under it).
  */
 export function ComboBoxField({
   label,
   value,
   onChange,
+  onQueryChange,
   options,
   description,
   placeholder,
@@ -85,10 +96,16 @@ export function ComboBoxField({
   noMatchesMessage,
 }: {
   label: ReactNode
-  /** The input's text. Not a key: a field allowing custom values holds text no option carries. */
+  /** The selected option's `value`, or, where custom values are allowed, text no option carries. */
   value: string
   /** Takes the value, never an event, which is the convention every control here follows. */
   onChange: (value: string) => void
+  /**
+   * The input's text, for a caller that filters `options` by it. Empty once a
+   * row is picked, because the field is then showing a choice rather than a
+   * search. Only this field can report it: it owns the input's text.
+   */
+  onQueryChange?: (query: string) => void
   /** Already filtered and capped by the caller, whose match rules and ceiling are its own. */
   options: readonly ComboBoxOption[]
   description?: ReactNode
@@ -120,9 +137,31 @@ export function ComboBoxField({
   /** What it says when the source has options and the query matched none. */
   noMatchesMessage?: ReactNode
 }) {
-  // Not state: nothing renders from it, and a re-render between the pick and
-  // its echo would drop it.
-  const echoRef = useRef<string | undefined>(undefined)
+  const selected = options.find((option) => option.value === value)
+  // What the value reads as: the matched row's label, or the value itself,
+  // which is then text no row carries.
+  const shown = selected?.label ?? value
+
+  // What is being typed, which stands in for the value's own text until a row
+  // is picked or the field is committed. Undefined the rest of the time, so a
+  // label the caller resolves after mount reaches the input rather than leaving
+  // an id in the box.
+  const [typed, setTyped] = useState<string>()
+
+  // The value as this field last saw it, which is what tells a value the caller
+  // moved from one this field reported. The first kind leaves whatever is in the
+  // box stale: a list of these fields that drops a row moves a value under a
+  // field that is still mounted.
+  const [seen, setSeen] = useState(value)
+  if (value !== seen) {
+    setSeen(value)
+    if (value !== typed) setTyped(undefined)
+  }
+
+  const setQuery = (next: string | undefined) => {
+    setTyped(next)
+    onQueryChange?.(next ?? "")
+  }
 
   return (
     <ComboBox.Root
@@ -132,26 +171,29 @@ export function ComboBoxField({
       // empty message below reachable at all.
       allowsEmptyCollection
       menuTrigger={menuTrigger}
-      inputValue={value}
-      // The echo, and why it is caught here. react-aria reports a pick through
-      // `onSelectionChange` and then writes that row's display text into the
-      // input, firing `onInputChange` with a label where the previous call
-      // carried a key. A caller that forwarded both would have to turn the
-      // label back into a key, and two rows may share a label, or one row's
-      // label may be another row's value, so that mapping can land on the wrong
-      // row. Here the picked option is in hand, so the echo is recognized by
-      // identity and dropped. Anything else the operator types passes through.
+      defaultFilter={KEEP_EVERY_OPTION}
+      // Both halves controlled, which is what keeps a pick reported once:
+      // react-aria writes the picked row's text back into the input only while
+      // one of the two is uncontrolled, and leaves the text here otherwise.
+      inputValue={typed ?? shown}
+      // The row an open list marks as selected. Nothing is selected while text
+      // is being typed, because text that happens to match a row's id is still
+      // text, and treating it as a pick would close the list mid-search.
+      selectedKey={selected && typed === undefined ? selected.value : null}
       onInputChange={(next) => {
-        const echoed = echoRef.current
-        echoRef.current = undefined
-        if (echoed !== undefined && next === echoed) return
-        onChange(next)
+        setQuery(next)
+        // A field offering the list as suggestions reports what was typed.
+        // Elsewhere the value stays whichever row is selected, except that an
+        // emptied box is how that selection is cleared.
+        if (allowsCustomValue || next === "") onChange(next)
       }}
       onSelectionChange={(key) => {
-        if (key == null) return
-        const picked = options.find((option) => option.value === String(key))
-        echoRef.current = picked ? comboBoxOptionText(picked) : undefined
-        onChange(String(key))
+        // The input goes back to showing the value, which after a pick is that
+        // row's label. `key` is null when the field was committed on text no
+        // row matches, which needs no report: with custom values that text is
+        // already the value, and without them the value never left the row.
+        setQuery(undefined)
+        if (key != null) onChange(String(key))
       }}
       isRequired={isRequired}
       isDisabled={isDisabled}
@@ -195,7 +237,10 @@ export function ComboBoxField({
           {(option: ComboBoxOption) => (
             <ListBoxItem
               id={option.value}
-              textValue={comboBoxOptionText(option)}
+              // The label alone, because this is also the text react-aria reads
+              // the selection as, and it has to agree with what the input shows
+              // or re-picking the selected row rewrites the input.
+              textValue={option.label}
               // Spelled out, because the row has two text nodes and the name
               // computed from them runs the hint onto the end of the label with
               // no separator. The hint belongs in the name rather than being

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -442,7 +442,6 @@ function CreateKeyForm({
     useSelectedWorkspace()
   const [keyName, setKeyName] = useState("")
   const [expiresAt, setExpiresAt] = useState("")
-  const memberLabels = useMemberAttributionLabels()
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [userId, setUserId] = useState("")
   const [allowedModels, setAllowedModels] = useState<string[] | null>(null)
@@ -539,7 +538,6 @@ function CreateKeyForm({
           value={userId}
           onChange={setUserId}
           users={users.data ?? []}
-          memberLabels={memberLabels}
         />
       ) : (
         <p className="text-caption">

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -12,7 +12,8 @@ import type {
 import { RoutingPage } from "@/features/routing/RoutingPage"
 import { API_ROOT } from "@/shared/api/client"
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
-import { organizationContext } from "@/tests/fixtures"
+import { DeploymentProvider } from "@/shared/hooks/useDeployment"
+import { bootstrap, organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
 const policy = (
@@ -165,6 +166,11 @@ function mockApi(
       if (url.endsWith(`${API_ROOT}/organizations/me`)) {
         return jsonResponse(opts.context ?? organizationContext())
       }
+      // The user picker's roster read. Empty here: these tests are about
+      // policies, and every owner in `USERS` is a plain id rather than a member.
+      if (url.includes(`${API_ROOT}/organizations/me/members`)) {
+        return jsonResponse({ data: [], count: 0 })
+      }
       if (url.includes(`${API_ROOT}/routing/policies/explain`)) {
         return jsonResponse({
           name: "fast",
@@ -286,12 +292,17 @@ function mockApi(
   return { spy, calls }
 }
 
+// The user picker asks the organization roster what to call each owner, and that
+// read is gated on the `organizations` surface, so these pages need the
+// deployment context the shell always gives them.
 function renderPage(ui: ReactElement, url = "/") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
   return render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+    <DeploymentProvider value={bootstrap()}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </DeploymentProvider>,
     { wrapper: withRouter({ url }) },
   )
 }
@@ -307,9 +318,11 @@ function renderInWorkspace(ui: ReactElement, url = "/") {
     defaultOptions: { queries: { retry: false } },
   })
   return render(
-    <QueryClientProvider client={client}>
-      <SelectedWorkspaceProvider>{ui}</SelectedWorkspaceProvider>
-    </QueryClientProvider>,
+    <DeploymentProvider value={bootstrap()}>
+      <QueryClientProvider client={client}>
+        <SelectedWorkspaceProvider>{ui}</SelectedWorkspaceProvider>
+      </QueryClientProvider>
+    </DeploymentProvider>,
     { wrapper: withRouter({ url }) },
   )
 }
@@ -1468,9 +1481,11 @@ describe("RoutingPage", () => {
       memberPolicies: [policy("mine", CHAIN)],
     })
     render(
-      <QueryClientProvider client={client}>
-        <RoutingPage />
-      </QueryClientProvider>,
+      <DeploymentProvider value={bootstrap()}>
+        <QueryClientProvider client={client}>
+          <RoutingPage />
+        </QueryClientProvider>
+      </DeploymentProvider>,
       { wrapper: withRouter({ url: "/" }) },
     )
 

--- a/web/src/features/users/UserComboBox.stories.tsx
+++ b/web/src/features/users/UserComboBox.stories.tsx
@@ -8,9 +8,12 @@ import { UserComboBox } from "./UserComboBox"
 /**
  * The owner picker: choose an existing user, or type an id that does not exist yet.
  *
- * It takes `users` as a prop rather than fetching, which is what lets the same
- * control serve the keys, budgets and routing pages without each of them growing
- * its own copy of the list.
+ * It takes `users` as a prop rather than fetching them, which is what lets the
+ * same control serve the keys and routing pages without each of them growing its
+ * own copy of the list. The one thing it does read for itself is the organization
+ * roster, which is how a member's row reads as their name with the id they are
+ * billed under beneath it; these stories run against no roster, so every row here
+ * is a plain id.
  *
  * Fixtures come from `src/tests/fixtures.ts`, so a field the gateway adds to
  * `User` arrives in these stories at the same time as in the tests.
@@ -58,29 +61,6 @@ export const WithDescription: Story = {
   args: {
     value: "ops@example.com",
     description: "The key is attributed to this user in usage and activity.",
-  },
-  render: (args) => (
-    <div className="w-[24rem]">
-      <UserComboBox {...args} />
-    </div>
-  ),
-}
-
-/**
- * `memberLabels` puts a human name beside an opaque id, for a deployment where a
- * user id is a UUID rather than an email.
- */
-export const WithMemberLabels: Story = {
-  args: {
-    value: "018f0000-0000-4000-8000-000000000001",
-    users: [
-      user({ user_id: "018f0000-0000-4000-8000-000000000001" }),
-      user({ user_id: "018f0000-0000-4000-8000-000000000002" }),
-    ],
-    memberLabels: new Map([
-      ["018f0000-0000-4000-8000-000000000001", "Ada Lovelace"],
-      ["018f0000-0000-4000-8000-000000000002", "Grace Hopper"],
-    ]),
   },
   render: (args) => (
     <div className="w-[24rem]">

--- a/web/src/features/users/UserComboBox.test.tsx
+++ b/web/src/features/users/UserComboBox.test.tsx
@@ -205,9 +205,10 @@ describe("UserComboBox", () => {
   })
 
   it("submits a typed id even when it is another owner's roster name", async () => {
-    // The collision: this member's roster name is exactly another user's id, and
-    // a member sorts ahead of it. Matching either field in one scan would
-    // resolve the typed id to the member's UUID and bill the key to them.
+    // The collision that used to need a tie-break rule: this member's roster
+    // name is exactly another user's id, and a member sorts ahead of it. What
+    // answers it now is that typed text is not looked up at all, so there is
+    // nothing for the two rows to compete over.
     mockRoster([member(UUID, "ci-bot")])
     const changes: string[] = []
     renderBox(
@@ -241,9 +242,8 @@ describe("UserComboBox", () => {
       await screen.findByRole("option", { name: `ci-bot (${UUID})` }),
     )
 
-    // The member, not the `ci-bot` owner. This is what the display-text echo
-    // would get wrong: the label reported after the id resolves by id first, and
-    // an id match on "ci-bot" is a different row than the one that was clicked.
+    // The member, not the `ci-bot` owner. A picked row reports its own id, so
+    // the row that was clicked is the only answer this can have.
     expect(changes.at(-1)).toBe(UUID)
   })
 
@@ -273,5 +273,26 @@ describe("UserComboBox", () => {
     // Resolving the label back to a row would always answer with the first one,
     // so the second person could never be picked.
     expect(changes.at(-1)).toBe(second)
+  })
+
+  it("does not turn a typed display name into the id it names", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    const changes: string[] = []
+    renderBox(
+      <UserComboBox
+        value=""
+        onChange={(id) => changes.push(id)}
+        users={[user(UUID)]}
+      />,
+    )
+
+    await userEvent.type(screen.getByRole("combobox"), "Alice Example")
+
+    // Deliberate, and the honest version of the two collisions above: picking
+    // the row is how an existing person is chosen, and a typed name is an id of
+    // its own. Resolving it to Alice's UUID would be a guess, since a roster
+    // puts no uniqueness rule on a name.
+    expect(changes.at(-1)).toBe("Alice Example")
+    expect(changes).not.toContain(UUID)
   })
 })

--- a/web/src/features/users/UserComboBox.test.tsx
+++ b/web/src/features/users/UserComboBox.test.tsx
@@ -1,18 +1,74 @@
-import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it } from "vitest"
+import type { ReactElement } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { User } from "@/client"
+import type { DeploymentBootstrap, OrganizationMember, User } from "@/client"
 import { UserComboBox } from "@/features/users/UserComboBox"
+import { API_ROOT } from "@/shared/api/client"
+import { DeploymentProvider } from "@/shared/hooks/useDeployment"
+import { bootstrap, organizationMember } from "@/tests/fixtures"
 
 // Only the fields the picker reads; the rest of User is irrelevant here.
 function user(user_id: string, alias: string | null = null): User {
   return { user_id, alias } as User
 }
 
+// A roster row for the owner id it bills through, which is the join the picker
+// reads to put a name on that id.
+function member(
+  attributionUserId: string,
+  fullName: string,
+): OrganizationMember {
+  return organizationMember({
+    organization_member_id: attributionUserId,
+    attribution_user_id: attributionUserId,
+    full_name: fullName,
+  })
+}
+
+// Mocked at the transport rather than at the hook, so the component's own query,
+// its key and its surface gate all run.
+function mockRoster(members: OrganizationMember[], status = 200) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const isRoster = String(input).includes(
+      `${API_ROOT}/organizations/me/members`,
+    )
+    const body = isRoster
+      ? { data: members, count: members.length }
+      : { detail: "not mocked" }
+    return new Response(JSON.stringify(body), {
+      status: isRoster ? status : 501,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+}
+
+function renderBox(
+  ui: ReactElement,
+  deployment: DeploymentBootstrap = bootstrap(),
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <DeploymentProvider value={deployment}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </DeploymentProvider>,
+  )
+}
+
+const UUID = "33333333-3333-3333-3333-333333333333"
+
 describe("UserComboBox", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("caps its width so the field and dropdown trigger stay within reach", () => {
-    render(<UserComboBox value="" onChange={() => {}} users={[]} />)
+    mockRoster([])
+    renderBox(<UserComboBox value="" onChange={() => {}} users={[]} />)
 
     // The field is bounded rather than stretching across the whole form (#328).
     const field = screen.getByRole("combobox").closest(".max-w-md")
@@ -20,7 +76,8 @@ describe("UserComboBox", () => {
   })
 
   it("says why the popover is empty rather than opening a silent box", async () => {
-    render(<UserComboBox value="" onChange={() => {}} users={[]} />)
+    mockRoster([])
+    renderBox(<UserComboBox value="" onChange={() => {}} users={[]} />)
 
     await userEvent.click(screen.getByRole("combobox"))
 
@@ -31,79 +88,133 @@ describe("UserComboBox", () => {
     ).toBeInTheDocument()
   })
 
-  it("names a member by the roster instead of the UUID they were minted under", async () => {
-    const uuid = "33333333-3333-3333-3333-333333333333"
-    render(
+  it("names a member by the roster, with their owner id as the second line", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    renderBox(
       <UserComboBox
         value=""
         onChange={() => {}}
-        users={[user(uuid, "alice@example.com"), user("ci-bot")]}
-        memberLabels={new Map([[uuid, "Alice Example"]])}
+        users={[user(UUID, "alice@example.com"), user("ci-bot")]}
       />,
     )
 
     await userEvent.click(screen.getByRole("combobox"))
 
-    // The member reads as a person. Without the map this option would render as
+    // The name leads and the id follows it as a muted line, which is what the
+    // row's accessible name carries too: without the roster this option read as
     // "33333333-… (alice@example.com)", which nobody can pick out of a list.
-    expect(
-      screen.getByRole("option", { name: "Alice Example" }),
-    ).toBeInTheDocument()
-    // A hand-made owner is already readable, so it is left exactly as it was.
+    const row = await screen.findByRole("option", {
+      name: `Alice Example (${UUID})`,
+    })
+    expect(within(row).getByText("Alice Example")).toBeInTheDocument()
+    expect(within(row).getByText(UUID)).toBeInTheDocument()
+    // A hand-made owner is already its own name, so it is left exactly as it was
+    // rather than given a hint that repeats the label.
     expect(screen.getByRole("option", { name: "ci-bot" })).toBeInTheDocument()
   })
 
-  it("sorts members ahead of the ids nobody named", async () => {
-    const uuid = "33333333-3333-3333-3333-333333333333"
-    render(
+  it("finds a member by the id they are billed under, not only by name", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    renderBox(
       <UserComboBox
         value=""
         onChange={() => {}}
-        users={[user("aaa-bot"), user(uuid, "zoe@example.com")]}
-        memberLabels={new Map([[uuid, "Zoe Example"]])}
+        users={[user(UUID), user("ci-bot")]}
       />,
+    )
+
+    await userEvent.type(screen.getByRole("combobox"), UUID)
+
+    // The id an operator pastes out of a log or an API response still reaches
+    // the person, even though the row no longer leads with it.
+    expect(
+      await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "ci-bot" })).toBeNull()
+  })
+
+  it("falls back to the bare id when the roster cannot be read", async () => {
+    mockRoster([], 500)
+    renderBox(
+      <UserComboBox value="" onChange={() => {}} users={[user(UUID)]} />,
     )
 
     await userEvent.click(screen.getByRole("combobox"))
 
+    // A failed roster read leaves the owner as findable as it was before names
+    // existed, rather than an empty row.
+    expect(
+      await screen.findByRole("option", { name: UUID }),
+    ).toBeInTheDocument()
+  })
+
+  it("asks for no roster on a deployment that hosts none", async () => {
+    const fetchMock = mockRoster([member(UUID, "Alice Example")])
+    renderBox(
+      <UserComboBox value="" onChange={() => {}} users={[user(UUID)]} />,
+      bootstrap({ surfaces: [] }),
+    )
+
+    await userEvent.click(screen.getByRole("combobox"))
+
+    expect(
+      await screen.findByRole("option", { name: UUID }),
+    ).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("sorts members ahead of the ids nobody named", async () => {
+    mockRoster([member(UUID, "Zoe Example")])
+    renderBox(
+      <UserComboBox
+        value=""
+        onChange={() => {}}
+        users={[user("aaa-bot"), user(UUID)]}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole("combobox"))
+    await screen.findByRole("option", { name: `Zoe Example (${UUID})` })
+
     // Alphabetically "aaa-bot" wins; by relevance the member does, because a
-    // member is who someone means when issuing a key.
-    const options = screen.getAllByRole("option").map((o) => o.textContent)
-    expect(options).toEqual(["Zoe Example", "aaa-bot"])
+    // member is who someone means when issuing a key. The member's row reads as
+    // its two lines, name then id; the bot's is one line.
+    const rows = screen.getAllByRole("option").map((o) => o.textContent)
+    expect(rows).toEqual([`Zoe Example${UUID}`, "aaa-bot"])
   })
 
   it("submits the owner id, not the label shown for it", async () => {
-    const uuid = "33333333-3333-3333-3333-333333333333"
+    mockRoster([member(UUID, "Alice Example")])
     const changes: string[] = []
-    render(
+    renderBox(
       <UserComboBox
         value=""
         onChange={(id) => changes.push(id)}
-        users={[user(uuid, "alice@example.com")]}
-        memberLabels={new Map([[uuid, "Alice Example"]])}
+        users={[user(UUID, "alice@example.com")]}
       />,
     )
 
     await userEvent.click(screen.getByRole("combobox"))
-    await userEvent.click(screen.getByRole("option", { name: "Alice Example" }))
+    await userEvent.click(
+      await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
+    )
 
     // The value that reaches POST /v1/keys has to be the id. Submitting the
     // label would have the keys API create a second user called "Alice Example".
-    expect(changes.at(-1)).toBe(uuid)
+    expect(changes.at(-1)).toBe(UUID)
   })
 
   it("submits a typed id even when it is another owner's roster name", async () => {
-    const uuid = "33333333-3333-3333-3333-333333333333"
+    // The collision: this member's roster name is exactly another user's id, and
+    // a member sorts ahead of it. Matching either field in one scan would
+    // resolve the typed id to the member's UUID and bill the key to them.
+    mockRoster([member(UUID, "ci-bot")])
     const changes: string[] = []
-    render(
+    renderBox(
       <UserComboBox
         value=""
         onChange={(id) => changes.push(id)}
-        users={[user(uuid), user("ci-bot")]}
-        // The collision: this member's roster name is exactly another user's id,
-        // and a member sorts ahead of it. Matching either field in one scan would
-        // resolve the typed id to the member's UUID and bill the key to them.
-        memberLabels={new Map([[uuid, "ci-bot"]])}
+        users={[user(UUID), user("ci-bot")]}
       />,
     )
 
@@ -113,52 +224,51 @@ describe("UserComboBox", () => {
   })
 
   it("submits the picked member, not the owner whose id is their roster name", async () => {
-    const uuid = "33333333-3333-3333-3333-333333333333"
+    // The same collision as above, reached from the other side: the row that was
+    // picked is the member, and their label is the other owner's id.
+    mockRoster([member(UUID, "ci-bot")])
     const changes: string[] = []
-    render(
+    renderBox(
       <UserComboBox
         value=""
         onChange={(id) => changes.push(id)}
-        users={[user(uuid), user("ci-bot")]}
-        // The same collision as above, reached from the other side: the row that
-        // was picked is the member, and their label is the other owner's id.
-        memberLabels={new Map([[uuid, "ci-bot"]])}
+        users={[user(UUID), user("ci-bot")]}
       />,
     )
 
     await userEvent.click(screen.getByRole("combobox"))
-    await userEvent.click(screen.getAllByRole("option", { name: "ci-bot" })[0])
+    await userEvent.click(
+      await screen.findByRole("option", { name: `ci-bot (${UUID})` }),
+    )
 
     // The member, not the `ci-bot` owner. This is what the display-text echo
     // would get wrong: the label reported after the id resolves by id first, and
     // an id match on "ci-bot" is a different row than the one that was clicked.
-    expect(changes.at(-1)).toBe(uuid)
+    expect(changes.at(-1)).toBe(UUID)
   })
 
   it("submits the member that was picked when two of them share a name", async () => {
     const first = "11111111-1111-1111-1111-111111111111"
     const second = "22222222-2222-2222-2222-222222222222"
+    // Two people, one name. A roster carries no uniqueness rule over
+    // `full_name`, so this is ordinary rather than a corner case.
+    mockRoster([member(first, "Alex Smith"), member(second, "Alex Smith")])
     const changes: string[] = []
-    render(
+    renderBox(
       <UserComboBox
         value=""
         onChange={(id) => changes.push(id)}
         users={[user(first), user(second)]}
-        // Two people, one name. A roster carries no uniqueness rule over
-        // `full_name`, so this is ordinary rather than a corner case.
-        memberLabels={
-          new Map([
-            [first, "Alex Smith"],
-            [second, "Alex Smith"],
-          ])
-        }
       />,
     )
 
     await userEvent.click(screen.getByRole("combobox"))
-    const rows = screen.getAllByRole("option", { name: "Alex Smith" })
-    expect(rows).toHaveLength(2)
-    await userEvent.click(rows[1])
+    // One name on screen twice, told apart by the id under it, which is the
+    // whole reason the hint joins the accessible name.
+    expect(await screen.findAllByText("Alex Smith")).toHaveLength(2)
+    await userEvent.click(
+      screen.getByRole("option", { name: `Alex Smith (${second})` }),
+    )
 
     // Resolving the label back to a row would always answer with the first one,
     // so the second person could never be picked.

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 
 import type { User } from "@/client"
 import {
@@ -15,6 +14,10 @@ import { userOptionText } from "./userOptions"
 // know). This is the dashboard's user-first gate; it never mints an anonymous
 // virtual user the way an omitted id at the API would. Virtual users are left out
 // of the options: you attach keys to people/teams you name, not to key-shadows.
+//
+// `value` is the owner id, never the name shown for it. Picking a row is how an
+// existing person is chosen; typed text is an id of its own, so typing somebody's
+// display name names a new user rather than resolving to their UUID.
 export function UserComboBox({
   value,
   onChange,
@@ -55,43 +58,27 @@ export function UserComboBox({
       return a.label.localeCompare(b.label)
     })
 
-  const [text, setText] = useState(value)
-  const query = text.trim().toLowerCase()
+  // What is being searched for, reported by the field because it owns the
+  // input's text. Not the value: an id an operator types is a value, and a name
+  // they type is only ever a search.
+  const [query, setQuery] = useState("")
+  const q = query.trim().toLowerCase()
   const visible = options
     .filter(
       (o) =>
-        !query ||
-        o.value.toLowerCase().includes(query) ||
-        o.label.toLowerCase().includes(query),
+        !q ||
+        o.value.toLowerCase().includes(q) ||
+        o.label.toLowerCase().includes(q),
     )
     .slice(0, 50)
 
-  // What the operator types is not necessarily a user_id: it may be a label they
-  // copied, or an id for a user who does not exist yet. Resolve either form to
-  // the canonical id, or the submitted owner would be the label and the keys API
-  // would silently create a second user named after it.
-  const resolveId = (raw: string): string => {
-    const trimmed = raw.trim()
-    // An id match outranks a name match, and the order matters because a
-    // member's label is a free-form roster name rather than its own id: a roster
-    // name can equal another user's `user_id`, members sort to the front, and a
-    // single scan matching either field would then bill the key to whichever of
-    // the two came first. Only the typed path reaches here. Picking a row reports
-    // that row's id, because `ComboBoxField` swallows the display-text echo, so
-    // a label shared by two rows cannot resolve to the wrong one.
-    const byId = options.find((o) => o.value === trimmed)
-    if (byId) return byId.value
-    const byName = options.find((o) => o.label === trimmed)
-    return byName ? byName.value : trimmed
-  }
-
-  const selectedId = resolveId(text)
-  const known = options.some((o) => o.value === selectedId)
+  const ownerId = value.trim()
+  const isKnownOwner = options.some((o) => o.value === ownerId)
   const creatingHint =
-    selectedId !== "" && !known
+    ownerId !== "" && !isKnownOwner
       ? (unknownHint ?? (
           <span>
-            Creates a new user <code>{selectedId}</code>.
+            Creates a new user <code>{ownerId}</code>.
           </span>
         ))
       : (description ?? "Spend and budgets track against this user.")
@@ -99,11 +86,11 @@ export function UserComboBox({
   return (
     <ComboBoxField
       label={label}
-      value={text}
-      onChange={(next) => {
-        setText(next)
-        onChange(resolveId(next))
-      }}
+      value={value}
+      // Trimmed, because a pasted id often carries a space and every caller
+      // submits this as an owner id.
+      onChange={(next) => onChange(next.trim())}
+      onQueryChange={setQuery}
       options={visible}
       description={creatingHint}
       placeholder={placeholder}

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -6,10 +6,9 @@ import {
   ComboBoxField,
   type ComboBoxOption,
 } from "@/design-system/forms/ComboBoxField"
+import { useMemberAttributionLabels } from "@/features/organization/attribution"
 
-interface Option extends ComboBoxOption {
-  isMember: boolean
-}
+import { userOptionText } from "./userOptions"
 
 // A required "owner" picker for a new API key: choose an existing user or type a
 // new id to create one (the keys API creates a named user for any id it does not
@@ -24,7 +23,6 @@ export function UserComboBox({
   label = "Owner",
   placeholder = "Pick a user, or type a new id…",
   unknownHint,
-  memberLabels,
 }: {
   value: string
   onChange: (userId: string) => void
@@ -32,33 +30,28 @@ export function UserComboBox({
   description?: ReactNode
   label?: ReactNode
   placeholder?: string
-  // Names the organization members among these users, keyed by the owner id
-  // they bill through. Without it a member reads as the bare UUID their
-  // identity was minted under, which nobody can pick from a list.
-  memberLabels?: ReadonlyMap<string, string>
   // What to say when the typed id is not an existing user. Defaults to the
   // keys-page truth (that endpoint creates the user); callers whose endpoint
   // rejects an unknown id must override it rather than promise a creation that
   // will 404.
   unknownHint?: ReactNode
 }) {
-  // A member is named by the roster and sorted to the front: those are the
-  // owners someone means when issuing a key, and their raw id is a UUID that
-  // reads as noise next to a hand-made one like `ci-bot`. The id stays the
-  // value submitted either way; only the label changes.
-  const options: Option[] = users
+  // Read here rather than taken as a prop, so no call site can forget it and
+  // leave a person reading as the UUID their identity was minted under. The
+  // read is gated on the `organizations` surface and shares its query key with
+  // every other reader of the roster.
+  const memberLabels = useMemberAttributionLabels()
+
+  // The id stays the value submitted whatever the row reads as, and rides along
+  // as the hint so it is still what a search can match.
+  const options: ComboBoxOption[] = users
     .filter((u) => !u.user_id.startsWith("apikey-"))
-    .map((u) => {
-      const member = memberLabels?.get(u.user_id)
-      if (member) return { value: u.user_id, label: member, isMember: true }
-      return {
-        value: u.user_id,
-        label: u.alias ? `${u.user_id} (${u.alias})` : u.user_id,
-        isMember: false,
-      }
-    })
+    .map((u) => ({ value: u.user_id, ...userOptionText(u, memberLabels) }))
     .sort((a, b) => {
-      if (a.isMember !== b.isMember) return a.isMember ? -1 : 1
+      // A roster-named row is the one carrying a hint, and it sorts to the
+      // front: a member is who someone means when issuing a key, where a
+      // hand-made id like `ci-bot` is a tool.
+      if (Boolean(a.hint) !== Boolean(b.hint)) return a.hint ? -1 : 1
       return a.label.localeCompare(b.label)
     })
 

--- a/web/src/features/users/UserMultiSelect.test.tsx
+++ b/web/src/features/users/UserMultiSelect.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { type ReactElement, useState } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { OrganizationMember, User } from "@/client"
+import { UserMultiSelect } from "@/features/users/UserMultiSelect"
+import { API_ROOT } from "@/shared/api/client"
+import { DeploymentProvider } from "@/shared/hooks/useDeployment"
+import { bootstrap, organizationMember } from "@/tests/fixtures"
+
+// Only the fields the picker reads; the rest of User is irrelevant here.
+function user(user_id: string, alias: string | null = null): User {
+  return { user_id, alias } as User
+}
+
+function member(
+  attributionUserId: string,
+  fullName: string,
+): OrganizationMember {
+  return organizationMember({
+    organization_member_id: attributionUserId,
+    attribution_user_id: attributionUserId,
+    full_name: fullName,
+  })
+}
+
+// The transport, not the hook: the component's own query and surface gate run.
+function mockRoster(members: OrganizationMember[]) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const isRoster = String(input).includes(
+      `${API_ROOT}/organizations/me/members`,
+    )
+    return new Response(
+      JSON.stringify(
+        isRoster
+          ? { data: members, count: members.length }
+          : { detail: "not mocked" },
+      ),
+      { status: isRoster ? 200 : 501 },
+    )
+  })
+}
+
+function renderPicker(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <DeploymentProvider value={bootstrap()}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </DeploymentProvider>,
+  )
+}
+
+const UUID = "33333333-3333-3333-3333-333333333333"
+
+// The picker is controlled, so a test about what a pick reports needs something
+// holding the value the way the budget form does.
+function Controlled({ users }: { users: User[] }) {
+  const [value, setValue] = useState<string[]>([])
+  return (
+    <>
+      <UserMultiSelect
+        label="Applies to"
+        value={value}
+        onChange={setValue}
+        users={users}
+      />
+      <p>selected: {value.join(", ")}</p>
+    </>
+  )
+}
+
+describe("UserMultiSelect", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("names a member by the roster, with their owner id as the second line", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    renderPicker(
+      <UserMultiSelect
+        label="Applies to"
+        value={[]}
+        onChange={() => {}}
+        users={[user(UUID, "alice@example.com"), user("ci-bot")]}
+      />,
+    )
+
+    // `menuTrigger="input"`, so the list opens on typing or on ArrowDown rather
+    // than on a click.
+    await userEvent.click(screen.getByLabelText("Add a person"))
+    await userEvent.keyboard("{ArrowDown}")
+
+    // The same shape the owner picker uses, so a person reads the same way in
+    // both: name first, billing id under it and in the row's name.
+    const row = await screen.findByRole("option", {
+      name: `Alice Example (${UUID})`,
+    })
+    expect(within(row).getByText("Alice Example")).toBeInTheDocument()
+    expect(within(row).getByText(UUID)).toBeInTheDocument()
+    // An id an operator named over the API is already its own name.
+    expect(screen.getByRole("option", { name: "ci-bot" })).toBeInTheDocument()
+  })
+
+  it("finds a member by the id they are billed under, not only by name", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    renderPicker(
+      <UserMultiSelect
+        label="Applies to"
+        value={[]}
+        onChange={() => {}}
+        users={[user(UUID), user("ci-bot")]}
+      />,
+    )
+
+    await userEvent.type(screen.getByLabelText("Add a person"), UUID)
+
+    expect(
+      await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "ci-bot" })).toBeNull()
+  })
+
+  it("reports the owner id of the person picked, and chips them by name", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    renderPicker(<Controlled users={[user(UUID)]} />)
+
+    // `menuTrigger="input"`, so the list opens on typing or on ArrowDown rather
+    // than on a click.
+    await userEvent.click(screen.getByLabelText("Add a person"))
+    await userEvent.keyboard("{ArrowDown}")
+    await userEvent.click(
+      await screen.findByRole("option", { name: `Alice Example (${UUID})` }),
+    )
+
+    // The id is what a budget assignment PATCHes; the chip is what the operator
+    // reads back, and it is their name rather than that id.
+    expect(await screen.findByText(`selected: ${UUID}`)).toBeInTheDocument()
+    // The open popover aria-hides the rest of the form, chips included.
+    await userEvent.keyboard("{Escape}")
+    expect(
+      screen.getByRole("button", { name: "Remove Alice Example" }),
+    ).toBeInTheDocument()
+  })
+})

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -3,13 +3,15 @@ import { type ReactNode, useMemo, useState } from "react"
 
 import type { User } from "@/client"
 import { ComboBoxEmpty } from "@/design-system/forms/ComboBoxEmpty"
+import { comboBoxOptionText } from "@/design-system/forms/ComboBoxField"
 import { ControlField } from "@/design-system/forms/FieldMessages"
 import { DismissChip } from "@/design-system/indicators/DismissChip"
 import { useMemberAttributionLabels } from "@/features/organization/attribution"
 
-interface Option {
+import { type UserOptionText, userOptionText } from "./userOptions"
+
+interface Option extends UserOptionText {
   id: string
-  label: string
 }
 
 const MAX_VISIBLE = 50
@@ -18,11 +20,10 @@ const MAX_VISIBLE = 50
 // named rows (virtual apikey-* shadows are excluded); it never creates one,
 // matching the model where a person exists before they are assigned a budget.
 //
-// The rows are keyed by the id the request plane bills to, which for anyone added
-// through the roster is a bare UUID. Showing that is useless to a human, so the
-// organization roster is asked what to call them (`attribution_user_id` is the
-// join). An id with no member behind it, such as one an operator named directly
-// over the API, keeps the id, since that *is* its name.
+// Rows are keyed by the id the request plane bills to, which for anyone added
+// through the roster is a bare UUID (`attribution_user_id` is the join).
+// `userOptionText` decides what that reads as, so this picker and the owner
+// picker name a person the same way.
 export function UserMultiSelect({
   value,
   onChange,
@@ -39,22 +40,12 @@ export function UserMultiSelect({
   const [query, setQuery] = useState("")
   const memberLabels = useMemberAttributionLabels()
 
-  const labelFor = useMemo(
-    () =>
-      (user: User): string => {
-        const member = memberLabels.get(user.user_id)
-        if (member) return member
-        return user.alias ? `${user.user_id} (${user.alias})` : user.user_id
-      },
-    [memberLabels],
-  )
-
   const options = useMemo<Option[]>(
     () =>
       users
         .filter((u) => !u.user_id.startsWith("apikey-"))
-        .map((u) => ({ id: u.user_id, label: labelFor(u) })),
-    [users, labelFor],
+        .map((u) => ({ id: u.user_id, ...userOptionText(u, memberLabels) })),
+    [users, memberLabels],
   )
   const labelById = useMemo(
     () => new Map(options.map((option) => [option.id, option.label])),
@@ -133,8 +124,25 @@ export function UserMultiSelect({
               )}
             >
               {(option: Option) => (
-                <ListBoxItem id={option.id} textValue={option.label}>
-                  {option.label}
+                <ListBoxItem
+                  id={option.id}
+                  textValue={comboBoxOptionText(option)}
+                  // Spelled out for the reason `ComboBoxField` spells it out: a
+                  // two-line row's computed name runs the hint onto the label
+                  // with no separator, and the hint is what tells two people of
+                  // one name apart.
+                  aria-label={
+                    option.hint ? comboBoxOptionText(option) : undefined
+                  }
+                >
+                  <span className="flex flex-col">
+                    <span>{option.label}</span>
+                    {option.hint ? (
+                      <span className="text-caption text-subtle">
+                        {option.hint}
+                      </span>
+                    ) : null}
+                  </span>
                 </ListBoxItem>
               )}
             </ListBox>

--- a/web/src/features/users/userOptions.test.ts
+++ b/web/src/features/users/userOptions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { userOptionText } from "@/features/users/userOptions"
+import { user } from "@/tests/fixtures"
+
+const UUID = "33333333-3333-3333-3333-333333333333"
+const ROSTER = new Map([[UUID, "Alice Example"]])
+
+describe("userOptionText", () => {
+  it("leads with the roster name and keeps the billing id as the hint", () => {
+    expect(userOptionText(user({ user_id: UUID }), ROSTER)).toEqual({
+      label: "Alice Example",
+      hint: UUID,
+    })
+  })
+
+  it("prefers the roster name to the alias the request plane carries", () => {
+    // The alias is whatever the gateway was told; the roster is who the person
+    // is, so it wins and the alias drops out of the row entirely.
+    expect(
+      userOptionText(user({ user_id: UUID, alias: "svc-alice" }), ROSTER),
+    ).toEqual({ label: "Alice Example", hint: UUID })
+  })
+
+  it("leaves an id nobody named alone, with no hint repeating it", () => {
+    expect(userOptionText(user({ user_id: "ci-bot" }), ROSTER)).toEqual({
+      label: "ci-bot",
+    })
+    expect(
+      userOptionText(user({ user_id: "ci-bot", alias: "release" }), ROSTER),
+    ).toEqual({ label: "ci-bot (release)" })
+  })
+})

--- a/web/src/features/users/userOptions.ts
+++ b/web/src/features/users/userOptions.ts
@@ -1,0 +1,32 @@
+import type { User } from "@/client"
+
+/** How a person reads in a user picker: what to show, and what to show under it. */
+export interface UserOptionText {
+  label: string
+  /**
+   * The id the row submits, when the label does not already carry it. Rendered
+   * as the row's muted second line and folded into its accessible name, so two
+   * people who share a name stay distinguishable.
+   */
+  hint?: string
+}
+
+/**
+ * Names a picker row from the organization roster, falling back to the id.
+ *
+ * Shared by the two user pickers rather than written in each: they sit in the
+ * same forms, and somebody who reads as a name in one and as a UUID in the
+ * other reads as two different people (otari-ai#2101).
+ */
+export function userOptionText(
+  user: User,
+  memberLabels: ReadonlyMap<string, string>,
+): UserOptionText {
+  const member = memberLabels.get(user.user_id)
+  if (member) return { label: member, hint: user.user_id }
+  // An id an operator chose, like `ci-bot`, is already its own name, so a hint
+  // would only repeat the label.
+  return {
+    label: user.alias ? `${user.user_id} (${user.alias})` : user.user_id,
+  }
+}


### PR DESCRIPTION
## Description

Picking a person in the dashboard now shows their name. The user pickers on the
routing, keys and budgets pages listed anyone added through the organization
roster as the raw UUID their identity was minted under, sometimes with an alias
after it: `0010b727-754c-4c79-9a0e-321bb0425546 (Harry Hutsby)`. That is
unreadable, and on a workspace of any size it is unpickable.

A person's row now leads with their name and carries the id they are billed
under as a smaller, muted second line. The id is still what a search matches, so
an id pasted out of a log or an API response finds its person, and it is still
the value the form submits. It also stays part of the row's accessible name,
which is what keeps two people who happen to share a name distinguishable to a
screen reader. An id an operator chose over the API, like `ci-bot`, is already
its own name, so it is left exactly as it was rather than given a second line
repeating itself.

The reason it only worked in one place: the owner picker could render a roster
name, but only when the page that mounted it passed the names in, and three of
its four call sites never did. It now reads the roster itself, which is what the
multi-select picker already did, so there is no longer a prop a page can forget.
A deployment that hosts no roster is unaffected: that read is gated on the
`organizations` surface, and an owner id stays the bare string it always was.

This is half of the issue on purpose. The issue also asks for a routing policy to
apply to several users at once, shown as removable chips. That part lives inside
the policy form on the routing page, which two in-flight PRs are restructuring
right now (#1038 moves it into a `FormDialog`, and a stacked PR reorganizes the
page around it), so writing it here would be writing against a function being
rewritten underneath it. It follows as its own PR once those land, and the issue
stays open until it does. Nothing in this PR touches a routing file: both routing
pickers are named for free by the fix above.

## How to test it locally

1. `make dashboard && otari serve`, sign in, and add a member under
   Organization, Members and roles. The roster mints them an owner id.
2. Open Routing, Policies, then New policy, and set the scope to a user. The
   member reads as their name with their owner id under it, where it used to read
   as the id with the alias in parentheses.
3. Type part of their owner id: they still come up. Pick them, and the policy is
   still written against the id.
4. The same rows appear in API keys, Create key, Owner, and in Spend and budgets,
   Assign to people, where the chosen person also chips by name.

Automated, and run locally on this branch:

- `pnpm --dir web run lint` and `pnpm --dir web run typecheck`, both clean.
- Vitest over `src/features/users`, `src/features/keys`, `src/features/budgets`
  and `src/design-system/forms` (138 passing), plus `src/features/routing`
  (62 passing), whose harness now mounts the deployment context the shell always
  gives it. Between them they cover a member rendering as their name with the id as the second line, a raw
  UUID search resolving to that member, an unnamed id left alone, the roster read
  failing and the surface being absent, and the two collision regressions #1039
  added (two people with one name, and one person whose name is another owner's
  id). I did not run the whole suite or build the Storybook catalog locally; CI
  does both.
- Playwright was not run: it needs a live gateway. I read both suites that drive
  a user picker (`dashboard.spec.ts`, `parity.management.spec.ts`); every owner
  they use is created directly over the API rather than through the roster, so no
  option's visible text changes and no selector needed updating.

Nothing under `src/gateway/` changed, so there is no OpenAPI or Postman artifact
to regenerate and `make lint` has nothing to say about this diff.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of mozilla-ai/otari-ai#2101

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

The dashboard's own checks are the applicable ones here (`pnpm --dir web run
lint`, `typecheck`, and Vitest over the changed paths); the API contract did not
change, so there was no spec to regenerate.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

Implemented, self-reviewed and opened by an agent following the repository's
`pr-cycle` and `frontend-standards` skills.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
