### PR TITLE
fix(dashboard): key Storybook's API mock on the API root

### DIFF
--- a/web/.storybook/apiMock.tsx
+++ b/web/.storybook/apiMock.tsx
@@ -27,14 +27,14 @@ import { type ApiMocks, pathOf, route } from "./apiRouting"
  *
  *   parameters: {
  *     api: {
- *       "/v1/settings/mail": { configured: true, from_address: "otari@example.com" },
- *       "/v1/organizations/me": organizationContext(),
+ *       [`${API_ROOT}/settings/mail`]: { configured: true, from_address: "otari@example.com" },
+ *       [`${API_ROOT}/organizations/me`]: organizationContext(),
  *     },
  *   }
  *
  * To exercise a failure, give the path a `$status` envelope instead of a body:
  *
- *   api: { "/v1/settings/mail": { $status: 503, $body: { detail: "No transport." } } }
+ *   api: { [`${API_ROOT}/settings/mail`]: { $status: 503, $body: { detail: "No transport." } } }
  *
  * The `$` prefix is what makes that unambiguous, and it is worth the ugliness. An
  * earlier version guessed instead -- "has a `status` or `body` key, therefore it is

--- a/web/.storybook/apiRouting.test.ts
+++ b/web/.storybook/apiRouting.test.ts
@@ -1,19 +1,25 @@
 import { describe, expect, it } from "vitest"
 
+import { API_ROOT } from "@/shared/api/client"
 import { type ApiMocks, pathOf, route } from "./apiRouting"
+
+// Every path here is built from `API_ROOT` rather than written out. These cases
+// used to spell `/v1/`, which is why they went on passing when the API moved:
+// they were checking the mock against the same stale literal the mock had, so
+// the suite was self-consistent with the bug and the catalog 404d anyway.
 
 describe("pathOf", () => {
   it("normalizes every shape fetch accepts to a path and query", () => {
     // The three cases used to be returned as they came, which is why the
     // gateway test below could be fooled: the same path is a relative string
     // from `apiFetch` and an absolute URL on a `Request`.
-    expect(pathOf("/v1/organizations/me")).toBe("/v1/organizations/me")
-    expect(pathOf("/v1/usage?window=7d")).toBe("/v1/usage?window=7d")
-    expect(pathOf(new URL("https://example.com/v1/usage?window=7d"))).toBe(
-      "/v1/usage?window=7d",
+    expect(pathOf(`${API_ROOT}/organizations/me`)).toBe(`${API_ROOT}/organizations/me`)
+    expect(pathOf(`${API_ROOT}/usage?window=7d`)).toBe(`${API_ROOT}/usage?window=7d`)
+    expect(pathOf(new URL(`https://example.com${API_ROOT}/usage?window=7d`))).toBe(
+      `${API_ROOT}/usage?window=7d`,
     )
-    expect(pathOf(new Request("https://example.com/v1/organizations/me"))).toBe(
-      "/v1/organizations/me",
+    expect(pathOf(new Request(`https://example.com${API_ROOT}/organizations/me`))).toBe(
+      `${API_ROOT}/organizations/me`,
     )
   })
 })
@@ -28,8 +34,8 @@ describe("route", () => {
   })
 
   it("answers a gateway path the story declared", () => {
-    const table: ApiMocks = { "/v1/settings/mail": { configured: true } }
-    expect(route("/v1/settings/mail", [table])).toEqual({
+    const table: ApiMocks = { [`${API_ROOT}/settings/mail`]: { configured: true } }
+    expect(route(`${API_ROOT}/settings/mail`, [table])).toEqual({
       kind: "response",
       status: 200,
       body: { configured: true },
@@ -38,9 +44,9 @@ describe("route", () => {
 
   it("reads the $status envelope as a failure rather than a body", () => {
     const table: ApiMocks = {
-      "/v1/settings/mail": { $status: 503, $body: { detail: "No transport." } },
+      [`${API_ROOT}/settings/mail`]: { $status: 503, $body: { detail: "No transport." } },
     }
-    expect(route("/v1/settings/mail", [table])).toEqual({
+    expect(route(`${API_ROOT}/settings/mail`, [table])).toEqual({
       kind: "response",
       status: 503,
       body: { detail: "No transport." },
@@ -48,8 +54,8 @@ describe("route", () => {
   })
 
   it("matches a declared pathname when the request carries a query", () => {
-    const table: ApiMocks = { "/v1/usage": { total: 1 } }
-    expect(route("/v1/usage?window=7d", [table])).toEqual({
+    const table: ApiMocks = { [`${API_ROOT}/usage`]: { total: 1 } }
+    expect(route(`${API_ROOT}/usage?window=7d`, [table])).toEqual({
       kind: "response",
       status: 200,
       body: { total: 1 },
@@ -60,18 +66,28 @@ describe("route", () => {
     // The regression this exists for. Every story is wrapped in
     // `SelectedWorkspaceProvider`, which queries the organization, so a story
     // that declared nothing still asks. It used to reach the network and 404.
-    const routed = route("/v1/organizations/me", [])
+    const routed = route(`${API_ROOT}/organizations/me`, [])
     expect(routed.kind).toBe("response")
     if (routed.kind !== "response") return
     expect(routed.status).toBe(200)
     expect(routed.body).toMatchObject({ organization_member_id: expect.any(String) })
   })
 
+  it("keys on the API root, so a path at the old prefix is not the gateway's", () => {
+    // The case that would have caught #1026. The API moved to `/api/v1` while
+    // this mock still matched `/v1/`, so every story's request missed it and
+    // went to the network, where the static catalog answers 404. Both halves
+    // matter: the current root is intercepted, and the old prefix is not, which
+    // is what a second literal of the path would break again.
+    expect(route(`${API_ROOT}/organizations/me`, []).kind).toBe("response")
+    expect(route("/v1/organizations/me", [])).toEqual({ kind: "network" })
+  })
+
   it("lets a story override the baseline", () => {
     const table: ApiMocks = {
-      "/v1/organizations/me": { $status: 403, $body: { detail: "Not a member." } },
+      [`${API_ROOT}/organizations/me`]: { $status: 403, $body: { detail: "Not a member." } },
     }
-    expect(route("/v1/organizations/me", [table])).toEqual({
+    expect(route(`${API_ROOT}/organizations/me`, [table])).toEqual({
       kind: "response",
       status: 403,
       body: { detail: "Not a member." },
@@ -82,18 +98,18 @@ describe("route", () => {
     // 501 rather than 404, because a 404 is a real gateway answer that some
     // components handle gracefully, which would hide the missing path. And
     // never `network`: that is what put a failing request on every story.
-    const routed = route("/v1/does/not/exist", [{ "/v1/other": {} }])
+    const routed = route(`${API_ROOT}/does/not/exist`, [{ [`${API_ROOT}/other`]: {} }])
     expect(routed.kind).toBe("response")
     if (routed.kind !== "response") return
     expect(routed.status).toBe(501)
-    expect(routed.body).toMatchObject({ detail: expect.stringContaining("/v1/does/not/exist") })
+    expect(routed.body).toMatchObject({ detail: expect.stringContaining(`${API_ROOT}/does/not/exist`) })
   })
 
   it("takes the first table carrying the path when several are mounted", () => {
     // An autodocs page mounts several stories at once.
-    const first: ApiMocks = { "/v1/usage": { total: 1 } }
-    const second: ApiMocks = { "/v1/usage": { total: 2 } }
-    expect(route("/v1/usage", [first, second])).toEqual({
+    const first: ApiMocks = { [`${API_ROOT}/usage`]: { total: 1 } }
+    const second: ApiMocks = { [`${API_ROOT}/usage`]: { total: 2 } }
+    expect(route(`${API_ROOT}/usage`, [first, second])).toEqual({
       kind: "response",
       status: 200,
       body: { total: 1 },

--- a/web/.storybook/apiRouting.ts
+++ b/web/.storybook/apiRouting.ts
@@ -1,3 +1,4 @@
+import { API_ROOT } from "@/shared/api/client"
 import { organizationContext } from "@/tests/fixtures"
 
 /**
@@ -10,8 +11,17 @@ import { organizationContext } from "@/tests/fixtures"
  * path. Nothing here has a side effect.
  */
 
-/** The gateway's prefix. Everything else belongs to Storybook itself. */
-const GATEWAY_PREFIX = "/v1/"
+/**
+ * The gateway's prefix. Everything else belongs to Storybook itself.
+ *
+ * Derived from `API_ROOT` rather than spelled again: a second literal is how
+ * this broke. The API moved to `/api/v1` and the mock kept matching `/v1/`, so
+ * every story's request missed the mock and went to the network, where the
+ * static catalog answers 404. The constant's own comment promises that moving
+ * the API is "a change here and nowhere else", which only holds if nothing
+ * else writes the path down.
+ */
+const GATEWAY_PREFIX = `${API_ROOT}/`
 
 export interface MockFailure {
   $status: number
@@ -44,7 +54,7 @@ function isMockFailure(value: unknown): value is MockFailure {
  * needs belongs in that component's story, where a reader can see it.
  */
 export const BASELINE: ApiMocks = {
-  "/v1/organizations/me": organizationContext(),
+  [`${API_ROOT}/organizations/me`]: organizationContext(),
 }
 
 /**
@@ -52,8 +62,8 @@ export const BASELINE: ApiMocks = {
  *
  * `apiFetch` passes a relative string, which is why this used to return the
  * three cases as they came. It normalizes now because `route` keys on the
- * leading `/v1/`, and a `Request` carries an absolute URL: left alone, the same
- * path would be mocked as a string and reach the network as a `Request`.
+ * leading `API_ROOT`, and a `Request` carries an absolute URL: left alone, the
+ * same path would be mocked as a string and reach the network as a `Request`.
  */
 export function pathOf(input: RequestInfo | URL): string {
   const raw =

--- a/web/.storybook/appContext.tsx
+++ b/web/.storybook/appContext.tsx
@@ -33,7 +33,7 @@ export const withAppContext: Decorator = (Story, context) => {
     <DeploymentProvider value={bootstrap(overrides)}>
       {/* Inside the deployment, and inside the query client `apiMock` provides:
           it seeds itself from `useOrganizationContext()`, so a story that cares
-          which workspace is selected mocks `${API_ROOT}/organization/context`. */}
+          which workspace is selected mocks {API_ROOT}/organizations/me. */}
       <SelectedWorkspaceProvider>
         <Story />
       </SelectedWorkspaceProvider>

--- a/web/.storybook/appContext.tsx
+++ b/web/.storybook/appContext.tsx
@@ -33,7 +33,7 @@ export const withAppContext: Decorator = (Story, context) => {
     <DeploymentProvider value={bootstrap(overrides)}>
       {/* Inside the deployment, and inside the query client `apiMock` provides:
           it seeds itself from `useOrganizationContext()`, so a story that cares
-          which workspace is selected mocks /v1/organization/context. */}
+          which workspace is selected mocks `${API_ROOT}/organization/context`. */}
       <SelectedWorkspaceProvider>
         <Story />
       </SelectedWorkspaceProvider>

--- a/web/.storybook/smoke.mjs
+++ b/web/.storybook/smoke.mjs
@@ -92,7 +92,7 @@ async function drain() {
       // whole "Failed to load resource" family, which is why it reported the
       // catalog clean while every story 404d on `/v1/organizations/me`: the
       // decorators mount a provider that queries the organization, and nothing
-      // answered it. Now that `apiMock` owns every `/v1/` path, a load failure
+      // answered it. Now that `apiMock` owns every path under the API root, a load failure
       // is a real finding. The abort is still this probe's own fault, since it
       // reuses one page across hundreds of rapid navigations.
       if (/net::ERR_ABORTED/.test(text)) return


### PR DESCRIPTION
## Description

Every story in the catalog has been reaching the network and 404ing since #1026, and nothing reported it.

#1026 moved the API to `/api/v1`. It updated every story's own mock table, but `.storybook/apiRouting.ts` held two more copies of the old path: `GATEWAY_PREFIX` matched `/v1/`, so no gateway request was recognized as one, and `BASELINE` keyed the organization context at `/v1/organizations/me`, which every story needs because `SelectedWorkspaceProvider` wraps all of them. A request that misses the mock goes to the network, and the static catalog answers 404.

Both now derive from `API_ROOT`. Its own comment promises that moving the API is "a change here and nowhere else", which only holds if nothing else writes the path down.

**Why the per-PR gate did not catch it.** A dead mock still builds and still paints, so `Otari Design System` stays green: the catalog compiles and every story renders something. Only the console-clean sweep asks whether a story rendered *without errors*, and that runs on main.

**The tests could not have caught it either, which is the part worth fixing properly.** All seven routing cases spelled `/v1/` themselves, so they were checking the mock against the same stale literal the mock had. The suite was self-consistent with the bug and would have gone on passing forever. They build their paths from `API_ROOT` now, and one added case pins both halves of the contract: a request at the current root is intercepted, and one at the old prefix is not. Reverting `GATEWAY_PREFIX` to `"/v1/"` fails eight of the ten.

The mock's usage docs in `apiMock.tsx` and one comment in `appContext.tsx` taught the old key as well, which is how the next story written would have inherited it.

This is a regression from #1026, not a fault in the design system work above it.

## How to test it locally

    pnpm --dir web run storybook:build
    python3 -m http.server 6006 --directory web/storybook-static &
    pnpm --dir web exec node .storybook/smoke.mjs

Measured on a local build, before and after this change:

| | renders | result |
| --- | --- | --- |
| before | 387 stories x 2 themes = 774 | **771 failing**: 757 "console errors", 14 timeouts |
| after | the same 774 | **`ALL RENDERED CLEAN`** |

The failures before were all the same 404, either reported as a console error or as a 20s timeout where the component waited on the request.

`pnpm --dir web exec vitest run .storybook` covers the routing unit, ten cases.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Found while working the dashboard series; it is a regression from #1026 rather than an issue anybody had filed, and it is small enough to stand on its own.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). `.storybook/apiRouting.test.ts`: every case now derives its path from `API_ROOT`, plus one that pins the old prefix as *not* the gateway's. Verified by reverting the fix and watching eight of ten fail.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` passes. The dashboard's own three are the relevant ones here and all pass: `pnpm --dir web run lint`, `run typecheck`, `test`.
- [x] Documentation was updated where necessary. The mock's usage examples and one decorator comment named the old path.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API contract change; this follows one.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The two counts in the table are from running the sweep against a local static build before and after the change, not inferred from the rule. The second stale copy (`BASELINE`) was found by the new test rather than by reading: with only `GATEWAY_PREFIX` fixed, the organization-context case failed with a 501.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
