### PR TITLE
feat(dashboard): add ListDetail, the list-and-detail page frame

### DIFF
--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -90,6 +90,7 @@ for a component, not for those.
 | `indicators/Dot` · `/Badge` · `/DismissChip` · `/Kbd` · `/Avatar` | one each |
 | `indicators/Chip` | `Chip`, and the `ChipTone` type |
 | `layout/Divider` | `Divider` |
+| `layout/ListDetail` | `ListDetail`, `ListDetailRow`. See [layout.md](layout.md) |
 | `content/Markdown` | `Markdown` |
 | `ProductMark` | `ProductMark`. At the top level: it belongs to no topic |
 | `@/shared/components/access/EntitlementGate` · `/UnavailableHere` · `/MissingGatewayAddressNotice` | one each |

--- a/web/design/layout.md
+++ b/web/design/layout.md
@@ -41,6 +41,7 @@ constants for these; `Section` is the one place the pair is named.
 | `SettingRow` | `label`, `configKey?`, `help?`, `control`, `nested?`, `error?` | One setting inside a group |
 | `KpiStrip` + `KpiCell` | see [metrics.md](metrics.md) | The metrics band |
 | `TableScrollFrame` | `className`, children | Around a wide table |
+| `ListDetail` + `ListDetailRow` | `listLabel`, `listAction?`, `list`, `empty?`, `onEmptyPress?`, `detail`, `detailLabel?`, `isDetailShown`, `onShowList`, `backLabel?` | A set of records where reading one is most of the work |
 
 **`PageIntro` renders its own `<h1 className="text-display">`**, so never put a
 heading inside it and never spell `text-display` on a page yourself. The sentence
@@ -101,6 +102,36 @@ No Save anywhere on that one: a text field commits on blur and on Enter, a
 select on change. Reach for it when the settings are independent of one another,
 so no single button could say what it is about to write.
 `features/tools/ToolsGuardrailsPage` is the worked example.
+
+A list-and-detail page, which is the shape for a set of records where reading
+one is most of the work:
+
+```
+PageIntro          title, sentence. No action: the create control goes in the
+                   list column, because that is the column it lengthens
+ErrorBanner        only if a read failed
+ListDetail         the two columns, at 1:1.75, partitioned by a hairline
+  ListDetailRow    one record: its name, and a line summarizing it
+```
+
+**No page reaches for this yet, and that is deliberate rather than an
+oversight.** DESIGN.md's "What is deliberately not here" declines a primitive
+with no consumer, and this is the standing exception: the frame was asked for as
+a reusable shape rather than for one screen, so it ships with its stories and its
+test and waits for the first page that suits it. Routing's policies were the
+candidate and stayed a `DataTable`, because a flat set of policies has no
+grouping or hierarchy for a detail column to earn. Reach for this when a record
+has more to read than a row can hold.
+
+The frame does not bleed: it is one framed object inside the page column, the
+way a `bounded` settings group is, rather than rules running to the scroll
+area's edges. Every fact a table would have put in a lane goes in the detail
+column, since the list column holds a name and a line, and so do the controls
+that act on the open record. **Nothing is edited in either column**: a record is
+created and changed in a `FormDialog` over the page, which is the one create
+surface (see [feedback.md](feedback.md)). **Below `md` one column shows at a
+time**, and which one is a prop: two columns at 390px give neither a readable
+measure, and stacking them puts every record above the one being read.
 
 **A save that worked says nothing.** The control disables while the write is in
 flight and that is the whole acknowledgement: a confirmation mark on every row

--- a/web/src/design-system/layout/ListDetail.stories.tsx
+++ b/web/src/design-system/layout/ListDetail.stories.tsx
@@ -1,0 +1,268 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { FiTrash2 } from "react-icons/fi"
+
+import { Button } from "../actions/Button"
+import { IconButton } from "../actions/IconButton"
+import { ListDetail, ListDetailRow } from "./ListDetail"
+
+/**
+ * A list of records beside the one that is open, at 1:1.75.
+ *
+ * Documented as a pair, like `TabRow` and `Tab`: the frame owns the two columns
+ * and the partition between them, the row owns one record and the lane its
+ * actions sit in, and neither is any use alone.
+ *
+ * Nothing here holds state. Which record is open is the page's, which is what
+ * lets one selection drive the URL, the detail column, and (below `md`) which
+ * of the two columns is the one on screen. An editor is not one of the two
+ * columns: a record is created and changed in a `FormDialog` over the page.
+ *
+ * **Narrow the canvas to see the other half of the layout.** From `md` up both
+ * columns are on screen and `isDetailShown` does nothing; below it exactly one
+ * is, and the Back control is the way between them.
+ */
+const meta = {
+  title: "Design system/Layout/ListDetail",
+  component: ListDetail,
+  args: {
+    listLabel: "Policies",
+    list: null,
+    detail: null,
+    isDetailShown: false,
+    onShowList: () => {},
+  },
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ListDetail>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const POLICIES = [
+  { name: "fast", serves: "openai:gpt-5-mini  +1 on failure" },
+  { name: "cheap", serves: "Learned · 2 candidates, openai:gpt-5 by default" },
+  { name: "balanced", serves: "Weighted · 70% / 30% across 2 models" },
+  { name: "strict", serves: "anthropic:claude-sonnet-4-5" },
+]
+
+function Facts({ serves }: { serves: string }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {[
+        ["Serves", serves],
+        ["Applies to", "Every caller"],
+        ["Source", "STORED"],
+      ].map(([label, value]) => (
+        <div key={label} className="flex min-w-0 flex-col gap-1">
+          <span className="text-overline">{label}</span>
+          <span className="text-body">{value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** A record open, which is the state the shape exists for. */
+export const Default: Story = {
+  render: () => {
+    const [open, setOpen] = useState<string | undefined>("fast")
+    const selected = POLICIES.find((policy) => policy.name === open)
+    return (
+      <ListDetail
+        listLabel="Policies"
+        backLabel="All policies"
+        detailLabel="Policy detail"
+        listAction={
+          <Button size="sm" variant="primary" onPress={() => {}}>
+            Create policy
+          </Button>
+        }
+        isDetailShown={selected !== undefined}
+        onShowList={() => setOpen(undefined)}
+        list={POLICIES.map((policy) => (
+          <ListDetailRow
+            key={policy.name}
+            label={policy.name}
+            isSelected={policy.name === open}
+            onSelect={() => setOpen(policy.name)}
+            actions={
+              <IconButton label={`Delete ${policy.name}`} onPress={() => {}}>
+                <FiTrash2 aria-hidden="true" className="size-4" />
+              </IconButton>
+            }
+          >
+            {policy.serves}
+          </ListDetailRow>
+        ))}
+        detail={
+          selected === undefined ? (
+            <div className="px-4 py-10 text-center text-caption">
+              Pick a policy to see what it serves.
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+                <h2 className="text-title">{selected.name}</h2>
+                <div className="flex gap-2">
+                  <Button size="sm" onPress={() => {}}>
+                    Edit
+                  </Button>
+                  <Button size="sm" onPress={() => {}}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+              <div className="px-4 py-4">
+                <Facts serves={selected.serves} />
+              </div>
+            </div>
+          )
+        }
+      />
+    )
+  },
+}
+
+/**
+ * Nothing open, which is where a wide viewport lands before the first click.
+ * The detail column holds what to do rather than a blank half-page.
+ */
+export const NothingOpen: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={false}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="px-4 py-10 text-center text-caption">
+          Pick a policy to see what it serves.
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * An empty list, where the only thing to do with the column is start the first
+ * record, so the column is the button. It is a real one: a whole-column press
+ * target that a keyboard cannot reach is a control that is not there.
+ */
+export const Empty: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      listAction={
+        <Button size="sm" variant="primary" onPress={() => {}}>
+          Create policy
+        </Button>
+      }
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={null}
+      empty="Create your first policy"
+      onEmptyPress={() => {}}
+      detail={
+        <div className="flex flex-col gap-2 px-4 py-5">
+          <h2 className="text-title">No policies yet</h2>
+          <p className="text-body">
+            A policy is a name your callers send as their model, and what serves
+            it.
+          </p>
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * The same empty column for a reader who cannot write: the sentence without
+ * the invitation, since pressing it would only be refused.
+ */
+export const EmptyReadOnly: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={null}
+      empty="No policies yet."
+      detail={
+        <div className="px-4 py-10 text-center text-caption">
+          Your organization&apos;s admins define these.
+        </div>
+      }
+    />
+  ),
+}
+
+/**
+ * Below `md`, where the detail column is the one on screen and the Back control
+ * is the way out of it. The frame is drawn here as it is at every width, so
+ * narrow the canvas to see the list disappear behind it.
+ */
+export const DetailShown: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      backLabel="All policies"
+      detailLabel="Policy detail"
+      isDetailShown
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={policy.name === "cheap"}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="flex flex-col gap-4 px-4 py-5">
+          <h2 className="text-title">cheap</h2>
+          <Facts serves="Learned · 2 candidates, openai:gpt-5 by default" />
+        </div>
+      }
+    />
+  ),
+}
+
+/** The open record on the dark artboard, where the selection tint is its own value. */
+export const Dark: Story = {
+  render: () => (
+    <ListDetail
+      listLabel="Policies"
+      isDetailShown={false}
+      onShowList={() => {}}
+      list={POLICIES.map((policy) => (
+        <ListDetailRow
+          key={policy.name}
+          label={policy.name}
+          isSelected={policy.name === "cheap"}
+          onSelect={() => {}}
+        >
+          {policy.serves}
+        </ListDetailRow>
+      ))}
+      detail={
+        <div className="flex flex-col gap-4 px-4 py-5">
+          <h2 className="text-title">cheap</h2>
+          <Facts serves="Learned · 2 candidates, openai:gpt-5 by default" />
+        </div>
+      }
+    />
+  ),
+  globals: { theme: "dark" },
+}

--- a/web/src/design-system/layout/ListDetail.test.tsx
+++ b/web/src/design-system/layout/ListDetail.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ListDetail, ListDetailRow } from "./ListDetail"
+
+describe("ListDetail", () => {
+  it("names both columns, so neither half is anonymous", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>Nothing open.</p>}
+        detailLabel="Policy detail"
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole("region", { name: "Policies" })).toContainElement(
+      screen.getByRole("heading", { name: "Policies" }),
+    )
+    expect(
+      screen.getByRole("region", { name: "Policy detail" }),
+    ).toHaveTextContent("Nothing open.")
+  })
+
+  it("puts the create control in the column it adds to", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        listAction={<button type="button">Create policy</button>}
+        list={null}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole("region", { name: "Policies" })).toContainElement(
+      screen.getByRole("button", { name: "Create policy" }),
+    )
+  })
+
+  it("offers the way back only while a column is hidden", async () => {
+    // The control is `md:hidden`, and jsdom applies no media query, so what is
+    // asserted here is the other half: it exists while the detail column is
+    // the one on screen and not while both are.
+    const onShowList = vi.fn()
+    const { rerender } = render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>fast</p>}
+        isDetailShown
+        onShowList={onShowList}
+        backLabel="All policies"
+      />,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "All policies" }))
+    expect(onShowList).toHaveBeenCalledOnce()
+
+    rerender(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        detail={<p>fast</p>}
+        isDetailShown={false}
+        onShowList={onShowList}
+      />,
+    )
+    expect(
+      screen.queryByRole("button", { name: /All policies|Back to the list/ }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("makes the empty column a real button, reachable by keyboard", async () => {
+    // The whole column is the target, which a div with an onClick would also
+    // manage while being unreachable without a pointer.
+    const onEmptyPress = vi.fn()
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        empty="Create your first policy"
+        onEmptyPress={onEmptyPress}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    await userEvent.tab()
+    await userEvent.keyboard("{Enter}")
+    expect(onEmptyPress).toHaveBeenCalledOnce()
+    expect(
+      screen.getByRole("button", { name: "Create your first policy" }),
+    ).toBeInTheDocument()
+  })
+
+  it("states the empty column without offering it to a reader who cannot write", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={null}
+        empty="No policies yet."
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("No policies yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("shows the list when nothing is empty about it", () => {
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={<p>fast</p>}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("fast")).toBeInTheDocument()
+  })
+})
+
+describe("ListDetailRow", () => {
+  it("presses its label to open the record, not the whole row", async () => {
+    const onSelect = vi.fn()
+    render(
+      <ListDetailRow label="fast" isSelected={false} onSelect={onSelect}>
+        openai:gpt-5-mini
+      </ListDetailRow>,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: /fast/ }))
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(screen.getByText("openai:gpt-5-mini")).toBeInTheDocument()
+  })
+
+  it("says which record is the one being shown", () => {
+    render(
+      <>
+        <ListDetailRow label="fast" isSelected onSelect={() => {}} />
+        <ListDetailRow label="cheap" isSelected={false} onSelect={() => {}} />
+      </>,
+    )
+
+    expect(screen.getByRole("button", { name: "fast" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    )
+    expect(screen.getByRole("button", { name: "cheap" })).not.toHaveAttribute(
+      "aria-current",
+    )
+  })
+
+  it("keeps a row's actions out of the press target that opens it", async () => {
+    // Nested buttons are neither valid nor operable, so the label and the
+    // actions are siblings. Pressing an action must not also open the record.
+    const onSelect = vi.fn()
+    const onDelete = vi.fn()
+    render(
+      <ListDetailRow
+        label="cheap"
+        isSelected={false}
+        onSelect={onSelect}
+        actions={
+          <button type="button" onClick={onDelete}>
+            Delete cheap
+          </button>
+        }
+      />,
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete cheap" }))
+    expect(onDelete).toHaveBeenCalledOnce()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/design-system/layout/ListDetail.tsx
+++ b/web/src/design-system/layout/ListDetail.tsx
@@ -1,0 +1,186 @@
+import type { ReactNode } from "react"
+import { FiChevronLeft } from "react-icons/fi"
+
+import { Button } from "../actions/Button"
+import { EmptyMessage } from "../feedback/EmptyMessage"
+
+/**
+ * A list of records beside the one that is open: the page shape for a set of
+ * things where reading one is most of the work.
+ *
+ * The ratio is 1:1.75 and lives here rather than at a call site, because it is
+ * the whole reason the frame exists. The left column holds a name and a line
+ * about it; the right one holds every fact a table would have spread across
+ * lanes, plus the controls that act on the record. Two columns at equal width
+ * give the reading half a page and the naming half more than it needs.
+ *
+ * **Below `md` one column shows at a time**, chosen by `isDetailShown`. Side by
+ * side at 390px gives neither column a readable measure, and stacking them puts
+ * every record above the one being read, so an operator scrolls past the list
+ * to reach what they opened. The swap is a prop rather than state in here, so
+ * the page's own selection stays the single source of what is open.
+ *
+ * Presentational: which record is selected is the caller's, and so is every
+ * row. Pair with `ListDetailRow`, which is the row this frame's list is made
+ * of, and whose separators the frame supplies.
+ */
+export function ListDetail({
+  listLabel,
+  listAction,
+  list,
+  empty,
+  onEmptyPress,
+  detail,
+  detailLabel = "Details",
+  isDetailShown,
+  onShowList,
+  backLabel = "Back to the list",
+}: {
+  /** What the left column holds, as its heading and as its region's name. */
+  listLabel: string
+  /** The control that adds a record, at the top of the column it adds to. */
+  listAction?: ReactNode
+  /** The rows, which are `ListDetailRow`s. */
+  list: ReactNode
+  /**
+   * What stands in for the rows, and so how the frame is told there are none to
+   * show: an empty list's message, or a line while the list is still loading. A
+   * node cannot be counted from in here, which is why this rather than a flag.
+   */
+  empty?: ReactNode
+  /**
+   * Makes the empty column one press target, for a list whose first record is
+   * the only thing to do with it. Omitted where the caller cannot write, so a
+   * reader who would be refused is told rather than invited.
+   */
+  onEmptyPress?: () => void
+  /** The open record, or what stands in for it while none is. */
+  detail: ReactNode
+  /**
+   * Names the detail column's region, which holds whatever the caller puts in
+   * it and so has no heading of its own to be named by.
+   */
+  detailLabel?: string
+  /** Below `md`: whether the detail column is the one on screen. */
+  isDetailShown: boolean
+  /** Below `md`: the way back, since only one column is reachable at a time. */
+  onShowList: () => void
+  /** Names the list on that control, where "the list" is not what to call it. */
+  backLabel?: string
+}) {
+  const rows =
+    empty === undefined ? (
+      // The frame divides its children, so a row draws no rule of its own and
+      // the last one leaves none hanging over the space below it.
+      <div className="flex flex-1 flex-col divide-y divide-border-subtle">
+        {list}
+      </div>
+    ) : onEmptyPress === undefined ? (
+      <EmptyMessage>{empty}</EmptyMessage>
+    ) : (
+      <button
+        type="button"
+        onClick={onEmptyPress}
+        className="flex flex-1 flex-col justify-center transition-colors hover:bg-surface-alt motion-reduce:transition-none"
+      >
+        <EmptyMessage>{empty}</EmptyMessage>
+      </button>
+    )
+
+  return (
+    <div className="grid border border-border md:grid-cols-[1fr_1.75fr]">
+      {/* Both halves are regions, so a reader can move between them rather
+          than through one to reach the other. */}
+      <section
+        aria-label={listLabel}
+        className={`min-w-0 flex-col ${isDetailShown ? "hidden md:flex" : "flex"}`}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
+          <h2 className="text-overline">{listLabel}</h2>
+          {listAction}
+        </div>
+        {rows}
+      </section>
+      <section
+        aria-label={detailLabel}
+        className={`min-w-0 flex-col border-border md:border-l ${
+          isDetailShown ? "flex" : "hidden md:flex"
+        }`}
+      >
+        {isDetailShown ? (
+          // Only where a column is hidden. From `md` up the list is right
+          // there, and a Back control beside it would point at what it is
+          // sitting next to.
+          <div className="border-b border-border px-2 py-1 md:hidden">
+            <Button className="min-h-11" onPress={onShowList}>
+              <FiChevronLeft aria-hidden="true" className="size-4" />
+              {backLabel}
+            </Button>
+          </div>
+        ) : null}
+        <div className="flex min-w-0 flex-1 flex-col">{detail}</div>
+      </section>
+    </div>
+  )
+}
+
+/**
+ * One record in a `ListDetail`'s list: its name, a line about it, and the
+ * actions that belong to the list rather than to the record.
+ *
+ * The row is not itself the press target. Its label is, and the actions sit
+ * beside it, because a button inside a button is neither valid nor operable.
+ *
+ * **The action lane is there whether or not a row has actions**, so the
+ * trailing controls form a vertical lane down the list instead of landing
+ * wherever their row's label ends. Its width is the touch floor, which is also
+ * the width of the one control it is sized for.
+ *
+ * `aria-current` rather than `aria-pressed`: this is the record being shown out
+ * of a set, not a control that stays down. The selected row wears the accent as
+ * a tint, which is the accent spent on selection the way an active nav row
+ * spends it, and keeps the page's ink: the accent's own ink is under AA on its
+ * tint.
+ */
+export function ListDetailRow({
+  label,
+  isSelected,
+  onSelect,
+  actions,
+  children,
+}: {
+  /** The record's name, in the lane every row shares. */
+  label: ReactNode
+  isSelected: boolean
+  onSelect: () => void
+  /**
+   * Controls acting on this record from the list, always visible: a touch
+   * device has no hover, so a control revealed by one does not exist there.
+   */
+  actions?: ReactNode
+  /** A second line under the label: what this record is, in a few words. */
+  children?: ReactNode
+}) {
+  return (
+    <div
+      className={`flex items-stretch ${isSelected ? "bg-primary-subtle" : ""}`}
+    >
+      <button
+        type="button"
+        aria-current={isSelected ? "true" : undefined}
+        onClick={onSelect}
+        className={`flex min-h-11 min-w-0 flex-1 flex-col justify-center gap-0.5 px-4 py-2 text-left transition-colors motion-reduce:transition-none ${
+          isSelected ? "" : "hover:bg-surface-alt"
+        }`}
+      >
+        <span className="truncate text-body">{label}</span>
+        {children === undefined ? null : (
+          <span className="truncate text-caption">{children}</span>
+        )}
+      </button>
+      <div className="flex min-w-11 shrink-0 items-center justify-end pr-2">
+        {actions}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Adds a reusable page frame to the design system: a list of records on the left, the one that is
open on the right, at a 1:1.75 ratio, divided by a hairline. Below the tablet breakpoint one
column shows at a time, with a way back to the list, because two columns on a phone give neither
one a readable width and stacking them buries the record you opened under the whole list.

The ratio, the divider and the column swap live in the component rather than at each call site,
so the next screen that wants this shape does not have to work any of it out again.

**Nothing uses it yet, and that is a deliberate exception worth naming.** The design system's own
rules decline a component with no consumer, on the grounds that it is an API to maintain and a
claim about the product that is not true. This one ships ahead of its first consumer because it
was asked for as a reusable shape rather than for one screen. The routing policies page was the
candidate and stays a table: a flat list of policies has no grouping or hierarchy for a detail
column to earn, so a table fits it better. `layout.md` records that reasoning next to the
component, so the next reader finds the decision rather than re-opening it.

It is presentational and holds no state of its own. Which record is open, and which column shows
on a phone, are both passed in, which is what lets a page keep one source of truth for what the
reader has selected.

## How to test it locally

1. `pnpm --dir web run storybook`, then `Design system → Layout → ListDetail`. The stories cover
   the two-column frame, a selected row, per-row actions, the empty column with and without a
   press target, and the phone view where one column shows at a time.
2. Resize below 768px in the two-column story: the list is what shows, opening a record swaps to
   it, and the back control returns. The back control and the row actions are at least 44px tall
   on a phone, since they are the only way through the page there.
3. Switch the catalog between light and dark: the selected row and the divider are both token
   driven, so neither needs a per-theme rule.

Automated coverage: `ListDetail.test.tsx` beside the component, plus the design-system layer gate
in `src/architecture.test.ts` (this layer may import nothing else under `src/`) and the token
gates in `src/styles/foundation.test.ts` (no raw hex, no numbered palette class, no `bg-white`).

Checks run locally: `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, Vitest over
`src/design-system/layout` and `src/styles` (3543 passing) and `src/architecture.test.ts`
(30 passing, run on its own because its probe files race another suite's tree walk). The full
suite and the catalog build are left to CI. Nothing under `src/gateway/` changes, so there is no
OpenAPI or Postman artifact to regenerate.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of mozilla-ai/otari-ai#2109. That issue asked for the routing policies page to be
reorganized into two columns. The page reorganization was reverted by decision after review, on
the grounds above, and the issue stays open pending a call on the page itself. This PR keeps the
one durable piece of that work.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`ListDetail.test.tsx`, plus the layer and token gates).
- [x] I ran the Definition of Done checks locally (the `web/` equivalents: `pnpm --dir web run lint`, `run typecheck`, and scoped Vitest; `make lint` and the Python suites cover no part of this change).
- [x] Documentation was updated where necessary (`web/design/DESIGN.md`, `web/design/layout.md`).
- [ ] If the API contract changed, I regenerated the OpenAPI spec (no API change).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:** The component was written for the routing page
reorganization, reviewed, then separated from it when that page was kept as a table.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
