### PR TITLE
feat(dashboard): let a routing policy be created for several users at once

### DIFF
--- a/web/src/features/routing/PolicyForm.stories.tsx
+++ b/web/src/features/routing/PolicyForm.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import type { PolicySpec } from "@/client"
 import { API_ROOT } from "@/shared/api/client"
+import { organizationMember, user } from "@/tests/fixtures"
+
 import { PolicyForm } from "./PolicyForm"
 
 /**
@@ -42,6 +44,25 @@ const GUARDRAILS_ON = {
   fields: [{ key: "guardrails_url", value: "https://guardrails.internal" }],
 }
 
+/** Who the scope picker can name, and what the roster calls them.
+ *
+ *  Both halves of the labeling, so the scoped tab shows the real thing: one
+ *  owner id the organization has a person behind, and one it does not.
+ */
+const OWNERS = [user({ user_id: "u-ana" }), user({ user_id: "release-bot" })]
+
+const ROSTER = {
+  data: [
+    organizationMember({
+      user_id: "u-ana",
+      attribution_user_id: "u-ana",
+      full_name: "Ana Ruiz",
+      role: "member",
+    }),
+  ],
+  count: 1,
+}
+
 const meta = {
   title: "Features/Routing/PolicyForm",
   component: PolicyForm,
@@ -50,9 +71,11 @@ const meta = {
     api: {
       [`${API_ROOT}/models/discoverable`]: CATALOG,
       [`${API_ROOT}/tool-settings`]: GUARDRAILS_ON,
-      // `ScopePicker` asks for the roster on every render, so without this the
-      // mock answers its deliberate 501 rather than the network's 404.
-      [`${API_ROOT}/users`]: [],
+      // The scope picker's two reads, which the form makes while it is open, so
+      // without these the mock answers its deliberate 501 rather than the
+      // network's 404.
+      [`${API_ROOT}/users`]: OWNERS,
+      [`${API_ROOT}/organizations/me/members`]: ROSTER,
     },
   },
   args: {
@@ -127,7 +150,8 @@ export const WithoutGuardrailsService: Story = {
     api: {
       [`${API_ROOT}/models/discoverable`]: CATALOG,
       [`${API_ROOT}/tool-settings`]: { fields: [] },
-      [`${API_ROOT}/users`]: [],
+      [`${API_ROOT}/users`]: OWNERS,
+      [`${API_ROOT}/organizations/me/members`]: ROSTER,
     },
   },
 }

--- a/web/src/features/routing/PolicyForm.tsx
+++ b/web/src/features/routing/PolicyForm.tsx
@@ -107,10 +107,16 @@ function ScopePicker({
   userIds,
   users,
   onChange,
+  isSettled,
 }: {
   userIds: string[] | null
   users: User[]
   onChange: (userIds: string[] | null) => void
+  /**
+   * Whether a write under this name has already landed, which freezes the
+   * scope. See the branch below for why it cannot be changed after that.
+   */
+  isSettled: boolean
 }) {
   const isScoped = userIds !== null
 
@@ -120,34 +126,54 @@ function ScopePicker({
         label="Applies to"
         description="A global policy resolves for every caller. A scoped one resolves only for the people named, and takes precedence over a global policy of the same name."
       />
-      <TabRow>
-        {/* Each tab acts only on a change of state: pressing the one already
-            active would otherwise throw away the people chosen under it. */}
-        <Tab
-          isActive={!isScoped}
-          onPress={() => {
-            if (isScoped) onChange(null)
-          }}
-        >
-          Every caller
-        </Tab>
-        <Tab
-          isActive={isScoped}
-          onPress={() => {
-            if (!isScoped) onChange([])
-          }}
-        >
-          Specific users
-        </Tab>
-      </TabRow>
-      {userIds === null ? null : (
-        <UserMultiSelect
-          label="Users"
-          value={userIds}
-          onChange={onChange}
-          users={users}
-          description="One policy is written per person, each resolving only for them."
-        />
+      {isSettled ? (
+        // Withheld, not disabled: there is no write that takes a policy back,
+        // so a control offering to change who this applies to would be
+        // offering something this form cannot do. Taking a person out of the
+        // selection would leave the policy already written for them in place,
+        // and choosing every caller would leave it in place AND outranking the
+        // global one for exactly that person, which is the precedence rule
+        // stated above. Stated rather than greyed out, because a disabled
+        // control with no reason beside it teaches nothing.
+        <p className="text-caption">
+          Some policies under this name have already been created, and this form
+          cannot take one back, so who it applies to is fixed now. Create policy
+          writes the ones still missing. To remove one you did not mean to
+          create, close this and delete it from the list.
+        </p>
+      ) : (
+        <>
+          <TabRow>
+            {/* Each tab acts only on a change of state: pressing the one
+                already active would otherwise throw away the people chosen
+                under it. */}
+            <Tab
+              isActive={!isScoped}
+              onPress={() => {
+                if (isScoped) onChange(null)
+              }}
+            >
+              Every caller
+            </Tab>
+            <Tab
+              isActive={isScoped}
+              onPress={() => {
+                if (!isScoped) onChange([])
+              }}
+            >
+              Specific users
+            </Tab>
+          </TabRow>
+          {userIds === null ? null : (
+            <UserMultiSelect
+              label="Users"
+              value={userIds}
+              onChange={onChange}
+              users={users}
+              description="One policy is written per person, each resolving only for them."
+            />
+          )}
+        </>
       )}
     </div>
   )
@@ -775,6 +801,12 @@ export function PolicyForm({
           userIds={userIds}
           users={users.data ?? []}
           onChange={setUserIds}
+          // Any landed write settles it, whatever payload it went under. Not
+          // keyed on the current name and spec the way `done` is: a policy
+          // written for somebody stays written when the name changes, so a key
+          // match would release the scope and let them be dropped from the
+          // selection while their row lived on.
+          isSettled={written.userIds.length > 0}
         />
       )}
 

--- a/web/src/features/routing/PolicyForm.tsx
+++ b/web/src/features/routing/PolicyForm.tsx
@@ -10,15 +10,18 @@
 import { Link } from "@tanstack/react-router"
 import { type RefObject, useMemo, useRef, useState } from "react"
 
-import type { PolicyGuardrail, PolicySpec } from "@/client"
+import type { PolicyGuardrail, PolicySpec, User } from "@/client"
 import { Button } from "@/design-system/actions/Button"
+import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import { FieldAction } from "@/design-system/forms/FieldAction"
 import { ControlField } from "@/design-system/forms/FieldMessages"
 import { Tab, TabRow } from "@/design-system/navigation/TabRow"
 import { ModelComboBox } from "@/features/models/ModelComboBox"
-import { UserComboBox } from "@/features/users/UserComboBox"
+import { useMemberAttributionLabels } from "@/features/organization/attribution"
+import { UserMultiSelect } from "@/features/users/UserMultiSelect"
+import { userOptionText } from "@/features/users/userOptions"
 import {
   useCreateAlias,
   useCreateOrganizationAlias,
@@ -91,65 +94,102 @@ function conditionsOf(
     }))
 }
 
-/** Who a policy applies to. Same control and wording as the alias scope picker,
- *  because it is the same decision. */
+/** Who a policy applies to. Same control and wording as assigning a budget,
+ *  because naming the people something applies to is the same decision.
+ *
+ *  Three states, not two. `null` is every caller, which is one policy with no
+ *  scope. A list is the scoped case, and because a policy's key is its name
+ *  plus its user, each person in it is a row of their own. An empty list is
+ *  therefore scoped with nobody chosen yet, which is not "every caller" and is
+ *  not something the form will submit.
+ */
 function ScopePicker({
-  userId,
+  userIds,
+  users,
   onChange,
-  enabled,
 }: {
-  userId: string | null
-  onChange: (userId: string | null) => void
-  /**
-   * Whether the dialog holding this is open.
-   *
-   * This picker renders inside the modal, which is `null` while closed, so the
-   * roster never fetches with the dialog shut whatever this says. What the gate
-   * buys is the exit: the subtree lives for the ~100ms fade, and a refetch
-   * landing in it would be work for a form already leaving.
-   */
-  enabled: boolean
+  userIds: string[] | null
+  users: User[]
+  onChange: (userIds: string[] | null) => void
 }) {
-  const users = useUsers(enabled)
-  const scoped = userId !== null
-
-  const modeButton = (value: boolean, label: string) => (
-    <Tab
-      key={label}
-      isActive={scoped === value}
-      onPress={() => onChange(value ? "" : null)}
-    >
-      {label}
-    </Tab>
-  )
+  const isScoped = userIds !== null
 
   return (
     <div className="flex flex-col gap-3">
       <ControlField
         label="Applies to"
-        description="A global policy resolves for every caller. A user-scoped one resolves only for that user, and takes precedence over a global policy of the same name."
+        description="A global policy resolves for every caller. A scoped one resolves only for the people named, and takes precedence over a global policy of the same name."
       />
       <TabRow>
-        {modeButton(false, "Every caller")}
-        {modeButton(true, "One user")}
+        {/* Each tab acts only on a change of state: pressing the one already
+            active would otherwise throw away the people chosen under it. */}
+        <Tab
+          isActive={!isScoped}
+          onPress={() => {
+            if (isScoped) onChange(null)
+          }}
+        >
+          Every caller
+        </Tab>
+        <Tab
+          isActive={isScoped}
+          onPress={() => {
+            if (!isScoped) onChange([])
+          }}
+        >
+          Specific users
+        </Tab>
       </TabRow>
-      {scoped ? (
-        <UserComboBox
-          label="User"
-          value={userId ?? ""}
+      {userIds === null ? null : (
+        <UserMultiSelect
+          label="Users"
+          value={userIds}
           onChange={onChange}
-          users={users.data ?? []}
-          placeholder="Pick a user…"
-          description="Only this user resolves the policy."
-          unknownHint={
-            <span className="text-danger">
-              No such user. Pick an existing one.
-            </span>
-          }
+          users={users}
+          description="One policy is written per person, each resolving only for them."
         />
-      ) : null}
+      )}
     </div>
   )
+}
+
+/** What to call a user id in prose, matching what the picker shows.
+ *
+ *  Through the same helper both pickers label their rows with, so somebody who
+ *  reads as a name on a chip is named that way in the account of a save rather
+ *  than appearing there as the UUID the request plane bills.
+ */
+function useUserLabel(users: User[]): (userId: string) => string {
+  const memberLabels = useMemberAttributionLabels()
+  const byId = new Map(users.map((entry) => [entry.user_id, entry]))
+  return (userId) => {
+    const user = byId.get(userId)
+    return user === undefined
+      ? userId
+      : userOptionText(user, memberLabels).label
+  }
+}
+
+/** The account of a save that wrote some of its scopes and not the others.
+ *
+ *  Both halves by name, because "it failed" over a part-written save leaves the
+ *  operator to work out which rows exist by reading the table. The ones that
+ *  landed are remembered, so the retry the last sentence promises is real
+ *  rather than a second pass over everything.
+ */
+function partialScopeReport(
+  written: string[],
+  failed: { userId: string; reason: string }[],
+  labelFor: (userId: string) => string,
+): string {
+  const created =
+    written.length > 0
+      ? `Created for ${written.map(labelFor).join(", ")}. `
+      : ""
+  const missing = failed
+    .map((entry) => `${labelFor(entry.userId)} (${entry.reason})`)
+    .join(", ")
+  return `${created}Not created for ${missing}. Submitting again retries only the ones still missing.`
 }
 
 const MODE_VALUES = ["block", "monitor"] as const
@@ -244,8 +284,48 @@ export function PolicyForm({
   // gate it would fetch for every render of the page behind a closed dialog.
   const guardrails_ = useGuardrailsConfigured(isOpen)
 
+  // Where a user scope can be written at all: `/users` is a deployment-wide
+  // operator route, so asking for it as a tenant admin buys a 403 for a picker
+  // this form does not offer them, and an edit cannot move a scope so it does
+  // not offer one either.
+  const canScope = !editing && !tenantScoped
+  // Read here rather than inside the picker, because the account of a
+  // part-written save names the same people the chips do and so needs the same
+  // roster, and two reads on one key would be two gates that have to agree.
+  //
+  // `isOpen` is load-bearing at this level and was not one level down. Inside
+  // the picker the read sat within the modal, which is `null` while closed, so
+  // nothing could fetch with the dialog shut whatever the gate said and it only
+  // bought the ~100ms exit fade. Out here the form is mounted whether or not the
+  // dialog is, so this gate is the whole of what keeps a closed form from
+  // asking for the roster.
+  const users = useUsers(isOpen && canScope)
+  const labelForUser = useUserLabel(users.data ?? [])
+
   const [name, setName] = useState(existing?.name ?? "")
-  const [userId, setUserId] = useState<string | null>(existing?.user_id ?? null)
+  // An existing row carries one scope, since it is one row; the list shape is
+  // what create writes N of.
+  const [userIds, setUserIds] = useState<string[] | null>(
+    existing?.user_id == null ? null : [existing.user_id],
+  )
+  // The scopes this dialog has already written, so a retry after a part-written
+  // save does not create again what exists. Kept per dialog rather than per
+  // press: the dialog stays open on a partial failure, and the whole point is
+  // that the next press picks up where the last one stopped.
+  //
+  // Carried with the payload they were written under, because that is what
+  // makes skipping them safe: editing the name or the spec after a partial
+  // failure means those ids hold a *different* policy, and skipping them then
+  // would leave the corrected one unwritten for exactly the people it already
+  // reached.
+  const [written, setWritten] = useState<{ key: string; userIds: string[] }>({
+    key: "",
+    userIds: [],
+  })
+  const [partialFailure, setPartialFailure] = useState<Error | undefined>(
+    undefined,
+  )
+  const [isWritingScopes, setIsWritingScopes] = useState(false)
   const [target, setTarget] = useState(
     existing ? defaultTargetOf(existing.spec) : initialTarget,
   )
@@ -317,7 +397,10 @@ export function PolicyForm({
     !editingAlias &&
     name.trim() !== "" &&
     name.trim() !== previousName
-  const scopeReady = userId === null || userId.trim() !== ""
+  // No scope at all, or at least one person under it. The empty list is the
+  // state this refuses: "scoped, nobody chosen" would submit as a global policy
+  // and quietly mean the opposite of what the tab says.
+  const scopeReady = userIds === null || userIds.length > 0
   const conditionsReady = conditions.every(
     (c) => c.target.trim() !== "" && c.threshold > 0 && c.threshold < 100,
   )
@@ -421,7 +504,7 @@ export function PolicyForm({
   // where a stray Escape can land ten minutes into building a fallback chain.
   const draft = JSON.stringify({
     name,
-    userId,
+    userIds,
     target,
     chain,
     conditions,
@@ -448,11 +531,51 @@ export function PolicyForm({
     save.isPending ||
     saveAlias.isPending ||
     saveOrgPolicy.isPending ||
-    saveOrgAlias.isPending
+    saveOrgAlias.isPending ||
+    // Its own flag as well as the mutation's: between two of N writes the
+    // mutation is idle, and a submit that re-armed itself in that gap would
+    // start a second run over the same list.
+    isWritingScopes
+
+  /** Write one policy per chosen scope, one at a time, and report what landed.
+   *
+   *  There is no batch endpoint and no transaction over N rows, so a refusal
+   *  partway leaves the earlier rows in place. The honest thing is to keep the
+   *  dialog open, name both halves, and remember the ids that succeeded so the
+   *  next press writes only what is missing. Every scope is attempted rather
+   *  than stopping at the first refusal, so one person's conflict does not
+   *  read as everyone after them having failed too.
+   */
+  const writeUserScopes = async (scopes: string[]) => {
+    const key = JSON.stringify([name.trim(), spec])
+    setIsWritingScopes(true)
+    const done = written.key === key ? [...written.userIds] : []
+    const failed: { userId: string; reason: string }[] = []
+    for (const scope of scopes) {
+      if (done.includes(scope)) continue
+      try {
+        await save.mutateAsync({ name: name.trim(), spec, user_id: scope })
+        done.push(scope)
+      } catch (caught) {
+        failed.push({ userId: scope, reason: errorMessage(caught) })
+      }
+    }
+    setWritten({ key, userIds: done })
+    setIsWritingScopes(false)
+    if (failed.length === 0) {
+      onClose()
+      return
+    }
+    setPartialFailure(new Error(partialScopeReport(done, failed, labelForUser)))
+  }
 
   const submit = () => {
     if (!canSubmit || outgrewAlias) return
-    const scope = userId === null ? null : userId.trim()
+    // Cleared on every path, not only the one that sets it: left standing it
+    // would outrank a fresh refusal from any of the four mutations below and
+    // report the last attempt's scopes over this one's failure.
+    setPartialFailure(undefined)
+    const scope = userIds === null ? null : (userIds[0] ?? null)
     if (editingAlias) {
       if (workspaceId !== null) {
         saveOrgAlias.mutate(
@@ -481,6 +604,12 @@ export function PolicyForm({
         },
         { onSuccess: onClose },
       )
+      return
+    }
+    // Only on create: an edit is one row, whose scope is half its key and so
+    // cannot move, and a rename has to travel on that one write.
+    if (!editing && userIds !== null) {
+      void writeUserScopes(userIds)
       return
     }
     save.mutate(
@@ -539,7 +668,12 @@ export function PolicyForm({
       // All four writers, not two: an organization-scoped save fails through its
       // own mutation, and with those two missing the refusal was swallowed and
       // the panel just sat there.
+      //
+      // The part-written account goes first, and it is the same surface rather
+      // than a second one: over N scopes `save.error` holds only the last
+      // refusal, which says nothing about the rows that did land.
       error={
+        partialFailure ??
         save.error ??
         saveAlias.error ??
         saveOrgPolicy.error ??
@@ -637,7 +771,11 @@ export function PolicyForm({
           This applies to everyone in the selected workspace.
         </p>
       ) : (
-        <ScopePicker userId={userId} onChange={setUserId} enabled={isOpen} />
+        <ScopePicker
+          userIds={userIds}
+          users={users.data ?? []}
+          onChange={setUserIds}
+        />
       )}
 
       {/* Conditional tier-down */}

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import type {
   OrganizationContext,
+  OrganizationMember,
   PolicySpec,
   RoutingPolicyResponse,
 } from "@/client"
@@ -13,7 +14,11 @@ import { RoutingPage } from "@/features/routing/RoutingPage"
 import { API_ROOT } from "@/shared/api/client"
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
-import { bootstrap, organizationContext } from "@/tests/fixtures"
+import {
+  bootstrap,
+  organizationContext,
+  organizationMember,
+} from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
 const policy = (
@@ -70,6 +75,21 @@ const POLICIES: RoutingPolicyResponse[] = [
 
 const USERS = [
   { user_id: "alice", alias: "alice", spend: 0, is_blocked: false },
+  { user_id: "u-bob", alias: "bob", spend: 0, is_blocked: false },
+  { user_id: "u-carol", alias: "carol", spend: 0, is_blocked: false },
+]
+
+// One of the three has a roster row behind them, so the same list exercises both
+// halves of the picker's labeling: a person the organization can name, and an
+// owner id nobody named, whose id is its name.
+const MEMBERS = [
+  organizationMember({
+    organization_member_id: "55555555-5555-5555-5555-555555555555",
+    user_id: "u-bob",
+    attribution_user_id: "u-bob",
+    full_name: "Bob Builder",
+    role: "member",
+  }),
 ]
 
 function jsonResponse(body: unknown): Response {
@@ -107,12 +127,19 @@ function mockApi(
     deleteBody?: { status: number; detail: string }
     // The same for a save, which is the path the form's own banner reports.
     saveBody?: { status: number; detail: string }
+    // The organization roster, which is what names a person behind an owner id.
+    members?: OrganizationMember[]
+    // Owner ids whose *first* policy write is refused. N scopes are N writes, so
+    // the retry has to be able to succeed for the one that failed while leaving
+    // the ones that landed alone.
+    refuseFirstWriteFor?: string[]
   } = {},
 ) {
   let list = [...policies]
   let aliasList = [...aliases]
   let memberList = [...(opts.memberPolicies ?? [])]
   let memberAliasList = [...(opts.memberAliases ?? [])]
+  const refuseOnce = new Set(opts.refuseFirstWriteFor ?? [])
   const calls: { url: string; method: string; body: unknown }[] = []
   const spy = vi
     .spyOn(globalThis, "fetch")
@@ -168,10 +195,12 @@ function mockApi(
       if (url.endsWith(`${API_ROOT}/organizations/me`)) {
         return jsonResponse(opts.context ?? organizationContext())
       }
-      // The user picker's roster read. Empty here: these tests are about
-      // policies, and every owner in `USERS` is a plain id rather than a member.
+      // The user picker's roster read, which names the person behind an owner
+      // id. Paged, like the real endpoint: `fetchAllPaged` reads `data`, so a
+      // bare array here throws rather than answering an empty roster.
       if (url.includes(`${API_ROOT}/organizations/me/members`)) {
-        return jsonResponse({ data: [], count: 0 })
+        const members = opts.members ?? []
+        return jsonResponse({ data: members, count: members.length })
       }
       if (url.includes(`${API_ROOT}/routing/policies/explain`)) {
         return jsonResponse({
@@ -227,6 +256,14 @@ function mockApi(
       }
       if (url.includes(`${API_ROOT}/routing/policies`)) {
         if (method === "POST") {
+          const scope = (body.user_id ?? null) as string | null
+          if (scope !== null && refuseOnce.has(scope)) {
+            refuseOnce.delete(scope)
+            return new Response(
+              JSON.stringify({ detail: `No room for ${scope}` }),
+              { status: 409, headers: { "Content-Type": "application/json" } },
+            )
+          }
           if (opts.saveBody) {
             // Not `jsonResponse`, which is a 200 by construction.
             return new Response(
@@ -376,6 +413,78 @@ const createTrigger = async () => {
   return within(header).findByRole("button", { name: "Create policy" })
 }
 
+type TestUser = ReturnType<typeof userEvent.setup>
+
+/** The two fields every policy needs, with the model popover dismissed after.
+ *
+ *  An open React Aria popover aria-hides the submit button, so leaving it up
+ *  makes every later query in the dialog miss.
+ */
+async function nameAndServe(
+  user: TestUser,
+  name: string,
+  target = "openai:gpt-5-nano",
+) {
+  await user.type(screen.getByRole("textbox", { name: /policy name/i }), name)
+  await user.type(screen.getByRole("combobox", { name: /^serves$/i }), target)
+  await user.keyboard("{Escape}")
+}
+
+/** Switch to the scoped tab and choose people, the way an operator does.
+ *
+ *  Each query is typed rather than the list being opened cold: the picker's
+ *  menu triggers on input, and it matches the owner id as well as the label, so
+ *  "bob" reaches a person the roster calls something else entirely.
+ */
+async function pickUsers(user: TestUser, queries: string[]) {
+  const dialog = within(screen.getByRole("dialog"))
+  await user.click(dialog.getByRole("button", { name: "Specific users" }))
+  for (const query of queries) {
+    // Named by the field's own label: the multi-select primitive labels its
+    // search box that way rather than carrying an `aria-label` of its own.
+    const search = dialog.getByLabelText("Users")
+    // Cleared between queries, because the primitive keeps the query after a
+    // pick on purpose (see `MultiSelect`: clearing it would refill the list
+    // under the pointer). Typing the next name onto the last one matches
+    // nobody.
+    await user.clear(search)
+    await user.type(search, query)
+    await user.click(await screen.findByRole("option"))
+  }
+  await user.keyboard("{Escape}")
+}
+
+async function submitDialog(user: TestUser, label = "Create policy") {
+  await user.click(
+    within(screen.getByRole("dialog")).getByRole("button", { name: label }),
+  )
+}
+
+/** The bodies of the deployment-wide policy writes, in the order they were sent.
+ *
+ *  Matched on the exact path, not a prefix: `/routing/policies/explain` is a
+ *  POST too, and counting one of those as a write would put a phantom row in
+ *  every assertion about how many writes a submit made.
+ */
+function policyWrites(
+  calls: { url: string; method: string; body: unknown }[],
+): { name: string; spec: PolicySpec; user_id?: string | null }[] {
+  return calls
+    .filter(
+      (call) =>
+        call.method === "POST" &&
+        call.url.endsWith(`${API_ROOT}/routing/policies`),
+    )
+    .map(
+      (call) =>
+        call.body as {
+          name: string
+          spec: PolicySpec
+          user_id?: string | null
+        },
+    )
+}
+
 describe("RoutingPage", () => {
   it("lists policies with what they serve and where they come from", async () => {
     mockApi()
@@ -522,6 +631,161 @@ describe("RoutingPage", () => {
     // The fallthrough is explicit and last, which is what the schema requires.
     expect(body.spec.select).toEqual([{ default: "openai:gpt-5-nano" }])
     expect(body.spec.on_failure).toBeUndefined()
+  })
+
+  it("writes exactly one unscoped policy for every caller", async () => {
+    // The default tab, asserted rather than assumed: "every caller" and "scoped
+    // but nobody chosen" are two states, and only this one is one write.
+    const { calls } = mockApi([], null, [], { members: MEMBERS })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await submitDialog(user)
+
+    const writes = policyWrites(calls)
+    expect(writes).toHaveLength(1)
+    expect(writes[0].user_id ?? null).toBeNull()
+  })
+
+  it("writes one policy per chosen user, each carrying its own scope", async () => {
+    // A policy's key is its name plus its user, so N people are N rows of the
+    // same name and spec. There is no batch endpoint; this is the whole design.
+    const { calls } = mockApi([], null, [], { members: MEMBERS })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await pickUsers(user, ["bob", "carol"])
+    await submitDialog(user)
+
+    const writes = policyWrites(calls)
+    expect(writes).toHaveLength(2)
+    expect(writes.map((write) => write.user_id)).toEqual(["u-bob", "u-carol"])
+    // Same name and same spec on each: only the scope differs.
+    expect(new Set(writes.map((write) => write.name))).toEqual(
+      new Set(["cheap"]),
+    )
+    for (const write of writes) {
+      expect(write.spec.select).toEqual([{ default: "openai:gpt-5-nano" }])
+    }
+  })
+
+  it("shows the chosen people by name above the input, not as bare owner ids", async () => {
+    mockApi([], null, [], { members: MEMBERS })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await pickUsers(user, ["bob"])
+
+    const dialog = within(screen.getByRole("dialog"))
+    // The roster names this one, so the chip says the person rather than the id
+    // the request plane bills to.
+    expect(
+      dialog.getByRole("button", { name: "Remove Bob Builder" }),
+    ).toBeInTheDocument()
+  })
+
+  it("will not submit a scoped policy with nobody chosen", async () => {
+    const { calls } = mockApi([], null, [], { members: MEMBERS })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    const dialog = within(screen.getByRole("dialog"))
+    await user.click(dialog.getByRole("button", { name: "Specific users" }))
+
+    expect(dialog.getByRole("button", { name: "Create policy" })).toBeDisabled()
+    await submitDialog(user)
+    expect(policyWrites(calls)).toHaveLength(0)
+  })
+
+  it("keeps the dialog open on a part-written save, naming who landed and who did not", async () => {
+    // Three writes with no transaction over them, so a refusal partway leaves
+    // the earlier rows in place. Saying "it failed" would leave the operator to
+    // work out which of the three exist by reading the table. The refusal is in
+    // the middle, so this also pins that the writes after it are still
+    // attempted rather than one conflict standing in for everyone behind it.
+    const { calls } = mockApi([], null, [], {
+      members: MEMBERS,
+      refuseFirstWriteFor: ["u-carol"],
+    })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await pickUsers(user, ["bob", "carol", "alice"])
+    await submitDialog(user)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("Created for Bob Builder, alice (alice).")
+    // By its id, since nobody named this one, and with the refusal's own reason
+    // rather than a swallowed "something went wrong".
+    expect(alert).toHaveTextContent("Not created for u-carol (carol)")
+    expect(alert).toHaveTextContent("No room for u-carol")
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+
+    // Pressing again rewrites nothing that already landed.
+    await submitDialog(user)
+    const scopes = policyWrites(calls).map((write) => write.user_id)
+    expect(scopes).toEqual(["u-bob", "u-carol", "alice", "u-carol"])
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("writes every scope again when the payload changed after a part-written save", async () => {
+    // The ids that landed are remembered against the payload they landed under,
+    // so correcting the name first is not the same policy: skipping them then
+    // would leave the corrected one unwritten for exactly the people the old
+    // one already reached.
+    const { calls } = mockApi([], null, [], {
+      members: MEMBERS,
+      refuseFirstWriteFor: ["u-carol"],
+    })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await pickUsers(user, ["bob", "carol"])
+    await submitDialog(user)
+    expect(await screen.findByRole("alert")).toBeInTheDocument()
+
+    await user.type(screen.getByRole("textbox", { name: /policy name/i }), "er")
+    await submitDialog(user)
+
+    const writes = policyWrites(calls)
+    expect(writes.map((write) => [write.name, write.user_id])).toEqual([
+      ["cheap", "u-bob"],
+      ["cheap", "u-carol"],
+      ["cheaper", "u-bob"],
+      ["cheaper", "u-carol"],
+    ])
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("lists a row per user for a policy written to several of them", async () => {
+    mockApi(
+      [
+        policy("cheap", CHAIN, { user_id: "u-bob" }),
+        policy("cheap", CHAIN, { user_id: "u-carol" }),
+      ],
+      null,
+      [],
+      { members: MEMBERS },
+    )
+    renderPage(<RoutingPage />)
+
+    // Two rows under one name: the scope is half the row's identity, so they do
+    // not collapse into one.
+    expect(
+      await screen.findAllByRole("rowheader", { name: "cheap" }),
+    ).toHaveLength(2)
   })
 
   it("keeps the failure chain and guardrails out of the way until asked for", async () => {
@@ -1904,7 +2168,9 @@ describe("RoutingPage for an organization admin", () => {
     expect(
       await screen.findByText(/applies to everyone in the selected workspace/i),
     ).toBeInTheDocument()
-    expect(screen.queryByText("For one user")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Specific users" }),
+    ).not.toBeInTheDocument()
   })
 
   it("deletes through the tenant-scoped router, naming the workspace", async () => {

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -738,6 +738,42 @@ describe("RoutingPage", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
+  it("fixes who a policy applies to once a write for somebody has landed", async () => {
+    // Nothing here can take a policy back, so a scope that can still be edited
+    // after a partial write is a way to end up with rows the operator did not
+    // ask for: drop a written person from the selection and their policy lives
+    // on unmentioned, or switch to every caller and it lives on ALSO outranking
+    // the global one for exactly them, which is the precedence the field's own
+    // description promises. The controls are withheld instead, and say why.
+    mockApi([], null, [], {
+      members: MEMBERS,
+      refuseFirstWriteFor: ["u-carol"],
+    })
+    const user = userEvent.setup()
+    renderPage(<RoutingPage />)
+
+    await user.click(await createTrigger())
+    await nameAndServe(user, "cheap")
+    await pickUsers(user, ["bob", "carol"])
+    await submitDialog(user)
+    await screen.findByRole("alert")
+
+    const dialog = within(screen.getByRole("dialog"))
+    // Neither tab, and no picker: the selection is settled.
+    expect(
+      dialog.queryByRole("button", { name: "Specific users" }),
+    ).not.toBeInTheDocument()
+    expect(
+      dialog.queryByRole("button", { name: "Every caller" }),
+    ).not.toBeInTheDocument()
+    expect(dialog.queryByLabelText("Users")).not.toBeInTheDocument()
+    // And the reason, since a control that vanishes without one teaches
+    // nothing. The route back out is naming the list, not this form.
+    expect(
+      dialog.getByText(/already been created/, { exact: false }),
+    ).toHaveTextContent("delete it from the list")
+  })
+
   it("writes every scope again when the payload changed after a part-written save", async () => {
     // The ids that landed are remembered against the payload they landed under,
     // so correcting the name first is not the same policy: skipping them then


### PR DESCRIPTION
## Description

A routing policy could be pointed at everyone, or at exactly one person. This lets an operator
point one at several people in a single go.

The "Applies to" control on the policy form keeps its two choices, but the second is now
"Specific users" rather than "One user", and choosing it gives the same chip picker the Budgets
page already uses for assigning a budget: the people chosen appear as little removable boxes
above the search field, searching matches either a person's name or the owner id they are billed
under, and everyone is listed by name rather than by a bare UUID.

Underneath, a policy is identified by its name together with the person it applies to, so one
policy name legitimately holds one row per person. Selecting three people therefore writes three
policies with the same name and the same behavior and three different scopes. That is the
existing data model, not a workaround, and nothing on the gateway side changes.

Those writes go one at a time and there is no transaction over them, so a refusal partway
through leaves the earlier ones in place. Rather than reporting "it failed" over a state that is
half saved, the dialog stays open and says which people the policy was created for and which it
was not, naming each one the way the picker does and quoting the gateway's own reason for the
refusal. Pressing the button again retries only the ones still missing.

Three things worth stating for a reviewer:

- **Chips above the input, not below.** The issue left that to a designer. Above is what
  `UserMultiSelect` already does on the Budgets page, and matching a shipped page beats a coin
  flip. The control is reused exactly as it stands, including its 24px remove target, which is
  a documented and deliberate exception to the 44px floor (see the component's own docstring and
  #947); nothing new is introduced below the floor here.
- **The `user_id: str | list[str]` in `models/routing.py` was considered and rejected.** That
  field is a condition on a `select` entry, meaning "when the caller is one of these, route to
  this target". It is not the policy's scope: a policy written that way still resolves for every
  other caller through its default, which is the opposite of "applies to these people". The form
  also refuses to edit any spec carrying such a condition, because it cannot represent one
  without dropping it on save.
- **Two scope states stay distinguishable.** "Every caller" is one write with no scope. The
  scoped tab starts with nobody chosen, which is a third state rather than a synonym for the
  first, and the form refuses to submit it. Multi-select stays create-only and operator-only:
  scope is half a policy's key so it cannot move on an edit, and the tenant-scoped writer
  refuses a user scope outright. Both of those gates are untouched.

The partial-failure account goes through `FormDialog`'s existing `error` prop, so there is no
second error surface beside it. That prop takes a caught value and renders its message, which is
enough to express "created for these two, not for this one, and here is why", so nothing had to
be added to the design-system component.

One structural change beyond the picker: **the roster read moves out of `ScopePicker` and up
into `PolicyForm`.** The form is now the one place that needs it twice, because the chips and
the account of a part-written save have to name the same people the same way, and two call sites
on one query key would mean two `enabled` flags that have to agree. Moving it up keeps the gate
the picker had, now as the argument at a single call site (`useUsers(isOpen && canScope)`, where
`isOpen` is what stops the roster refetching while the dialog is closed and mounted for its exit
animation), and regains a gate the picker never needed: a tenant admin and an edit are both
offered no picker at all, and neither now asks a deployment-wide route that would refuse the
first and tell the second nothing.

## How to test it locally

1. `make dashboard && otari serve`, sign in, and go to Routing, then Policies.
2. Press Create policy. Fill in a name and a model under Serves.
3. Under "Applies to", press "Specific users". The submit button is disabled: scoped with nobody
   chosen is not submittable.
4. Search for two people and pick them. They appear as chips above the field. Press Create
   policy, and two rows appear under the same name, one per person.
5. For the partial-failure path, create a policy for one person, then create one with the same
   name for that person plus a second one: the first write conflicts, the dialog stays open, and
   the banner names who was created and who was not. Pressing Create policy again writes only
   the one still missing.

**Checks run locally:**

- `pnpm --dir web run lint` (Biome): clean.
- `pnpm --dir web run typecheck`: clean.
- `pnpm --dir web exec vitest run src/features/routing/RoutingPage.test.tsx`: 77 passed. That is
  the 70 already on this base plus 7 new; none of the existing 70 was changed except one
  assertion whose wording moved (`For one user`, a string that had never been on screen, is now
  a `Specific users` button query that is).
- `pnpm --dir web exec vitest run src/architecture.test.ts`: 30 passed, run on its own because
  batched with many files its filesystem probes time out and report failures that are not real.

Storybook was not started or built, on the requester's instruction: an earlier run of this batch
froze the machine doing exactly that. The change to `PolicyForm.stories.tsx` is stub data in
`parameters.api` plus two fixture imports, which the typecheck covers; no story was added or
restructured.

**e2e was not executed.** `web/e2e/dashboard.spec.ts` and `web/e2e/parity.management.spec.ts`
both drive this form and need a live gateway, so neither was run here. Both were read: neither
touches the user scope on the routing form (the `Pick a user, or type a new id…` locator in each
belongs to the keys form's owner box), and no role or accessible name they do rely on has moved,
so neither spec needed a change. CI will not run them for this PR either, for the reason below.

**Nothing under `src/gateway/` changes**, so there is no OpenAPI or Postman artifact to
regenerate and nothing for `make lint`, `make typecheck` or the Python suite to say about it.
Those were not run rather than run and reported clean. No documented rule changed either:
`docs/routing.md` describes the API's data model, where a stored policy is still scoped to one
user per row, so it is still accurate as written.

## This PR is stacked, and it is not verified by CI

It is based on **#1038**, not on `main`, because that PR already carries the two things this
change builds on: the policy form moved into `FormDialog`, and the routing page reorganized as a
list and detail layout.

Three consequences, all of which need saying out loud:

1. **Almost no CI runs here.** Every real workflow in this repo declares
   `pull_request: branches: [ main ]`, so only `Lint PR title` and `check-template` will run on
   this PR. The local lint, typecheck and scoped Vitest runs listed above are the only evidence
   this change works. Two green ticks on this PR are not a verified PR.
2. **CodeRabbit skips a non-main base** (`.coderabbit.yaml` sets `base_branches: ["main"]`), so
   it is being triggered by hand with a `@coderabbitai review` comment.
3. **`protect-main` does not apply to this base**, so this PR may report `CLEAN` and look
   mergeable with no approval. It should not be merged that way.

**#1038 merges first.** It will be squash-merged, which always leaves a child branch conflicted,
so this PR then owes a rebase before it can go anywhere.

**This branch was re-ported by hand rather than rebased.** The base has since split
`RoutingPage.tsx` into `RoutingPage.tsx`, `PolicyForm.tsx` and `policyModel.ts`, so git sees
this change as edits to a file whose content moved: a rebase cannot carry it, and applying the
old diff with the path rewritten drags page-level code into the form module. The semantics were
re-applied onto the current structure with the original commit as the specification, and the
whole source change lands in `PolicyForm.tsx`, which is where every hunk of it belongs now.

**#1051 has landed**, so the conflict this section used to warn about is gone: its
`DeploymentProvider` wrapping is already in the base, and its `userOptions.ts` is what
`useUserLabel` now labels through rather than restating the picker's ordering. None of the four
files that PR owns (`UserComboBox.tsx`, `UserMultiSelect.tsx`, `userOptions.ts`,
`ComboBoxField.tsx`) is edited here; `UserMultiSelect` and `userOptions` are only imported.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2101

The issue has two asks. The first (people shown by name rather than by UUID) is PR #1051, which
says `Part of`; this one is the second (selecting several people) and completes it.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

On the third box: the dashboard's own checks were run and are listed above. The Python ones were
not, because no Python changed. On the fourth and fifth: no documented rule changed and the API
contract is untouched, so neither had anything owed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Implementation, tests and a self-review, all taken three-dot against the #1038 base rather than
against `main` so the diff is only this change. The current revision is a hand re-port of the
original commit onto that base after it was restructured, not a rebase of it.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added support for selecting multiple specific users when creating routing policies.
- Added search by user name or owner ID.
- Added partial-save reporting and retry support for failed users.
- Locked the selected scope after the first successful save.
- Kept multi-user selection unavailable for tenant admins and policy edits.

## Technical notes

- Policies continue to use one row per user.
- User roster loading moved from `ScopePicker` to `PolicyForm`.
- Added stories and tests for selection, validation, partial saves, retries, duplicate rows, and scope locking.
- No gateway or data-model changes were required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->