### PR TITLE
feat(core): accept several bootstrap modules in OTARI_BOOTSTRAP

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,6 +158,8 @@ def register(container: Container) -> None:
 
 With nothing configured nothing is imported, the defaults stand, and Otari boots standalone. A selector that is set but cannot be loaded fails startup rather than quietly falling back, because a build nobody chose is worse than a gateway that will not start.
 
+Several independent extensions (say, a budget-alerts plugin and a custom identity adapter from different authors) coexist without one wrapping the other: `OTARI_BOOTSTRAP` accepts a comma-separated list of selectors, applied in that order after the core defaults, and a later bind wins. This stays inside the no-auto-discovery rule above, because the list is explicit and ordered: the whole wiring is still readable from one config value, and a blank entry in it fails startup the way a blank selector does.
+
 A contributed router is the additive half of the seam, and it is gated rather than swapped: Otari mounts it behind `require_capability(...)`, which resolves `EntitlementPort` and answers a request for an unentitled capability with the same 404 a path nothing serves gets. That gate is the server-side half of the entitlement axis; hiding a nav item in the dashboard is not authorization.
 
 Entitlement is not authentication either, and the mount point adds none. A capability names no caller, so on an entitled deployment a contributed route is reachable by anyone unless the router says otherwise. A contribution declares the credential each of its routes needs on the route, the way Otari's own routers do; there is no router-level default to mount, because the right answer differs per route, a contributed route may be deliberately public, and the header check resolves a database session a hybrid gateway does not have.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,6 +309,21 @@ usage-report timeout and retries, and first-chunk fallback timeout. See
 inside the gateway process. The callable can rebind extension ports and
 contribute capability-gated routers. Most deployments should leave it unset.
 
+Several independent extensions coexist by listing their selectors in that one
+value, comma-separated, in the order they should apply:
+
+```bash
+OTARI_BOOTSTRAP="budget_alerts.bootstrap:register,acme_sso.bootstrap:register"
+```
+
+Each is loaded and called in turn after the core adapters are bound, and a
+later bind of the same port replaces an earlier one, so the whole wiring stays
+explicit and readable from this one value; nothing is discovered from installed
+packages. A blank entry, a trailing comma included, refuses to start rather
+than silently dropping an extension, and so does any selector that cannot be
+loaded. The startup log names each selector with what it rebound and
+contributed.
+
 This is executable code, not a feature flag. Install the module in the gateway
 environment, pin it to a compatible Otari release, and authenticate every
 contributed route. See [Architecture](../ARCHITECTURE.md) for the extension

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -18,6 +18,10 @@ An overlay rebinds ports without editing any Otari source file, by pointing
 ``OTARI_BOOTSTRAP`` at a ``module:callable`` selector. The callable receives
 this container after the core defaults are bound, and may rebind any port and
 contribute routers of its own. Unset, the defaults stand.
+
+Several independent extensions coexist by listing their selectors in that one
+value, comma-separated, in the order they are applied; a later bind wins, and
+the whole wiring stays readable from a single config value.
 """
 
 import importlib
@@ -249,12 +253,13 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
     """Build the composition-root container for this deployment.
 
     Binds the core adapters, then, if a selector is given, lets the bootstrap it
-    names rebind ports and contribute routers. With no selector the core
-    defaults stand and Otari boots standalone.
+    names rebind ports and contribute routers. A comma-separated list of
+    selectors is applied in order, each seeing the bindings the previous ones
+    left. With no selector the core defaults stand and Otari boots standalone.
 
     Raises:
-        BootstrapError: If the selector is present but blank, or names a
-            bootstrap that cannot be loaded.
+        BootstrapError: If the selector is present but blank, has a blank entry,
+            or names a bootstrap that cannot be loaded.
 
     """
     container = Container()
@@ -300,28 +305,66 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
         msg = "OTARI_BOOTSTRAP is set but blank; unset it to run without a bootstrap"
         raise BootstrapError(msg)
 
-    defaults = dict(container.bindings())
-    outcome = _load_register(bootstrap_selector)(container)
+    # Applied in order, each seeing what the previous ones bound; any failure
+    # along the way fails startup rather than serving the selectors before it.
+    container.summary = "; ".join(
+        _apply_bootstrap(container, selector) for selector in _split_selectors(bootstrap_selector)
+    )
+    logger.info("Composition root: %s", container.summary)
+    return container
+
+
+def _split_selectors(bootstrap_selector: str) -> list[str]:
+    """Split a comma-separated ``OTARI_BOOTSTRAP`` value into stripped selectors.
+
+    Raises:
+        BootstrapError: If an entry is blank, a trailing comma included. A
+            dropped entry is a build nobody chose, the same as a blank value.
+
+    """
+    selectors = [selector.strip() for selector in bootstrap_selector.split(",")]
+    for position, selector in enumerate(selectors, start=1):
+        if not selector:
+            msg = f"OTARI_BOOTSTRAP entry {position} of {len(selectors)} is blank; remove the extra comma"
+            raise BootstrapError(msg)
+    return selectors
+
+
+def _apply_bootstrap(container: Container, selector: str) -> str:
+    """Load and call one bootstrap against ``container`` and return what it changed.
+
+    The summary fragment names the ports the call rebound, against a snapshot of
+    the bindings taken just before it, and the routers it contributed.
+
+    Raises:
+        BootstrapError: If the bootstrap cannot be loaded or returned an awaitable.
+
+    """
+    register = _load_register(selector)
+    before = dict(container.bindings())
+    contributed_before = len(container.router_contributions())
+    outcome = register(container)
     if inspect.isawaitable(outcome):
         # The same silent drop the ``iscoroutinefunction`` guard refuses, by the
         # route that guard cannot see: a callable *object* whose ``__call__`` is
-        # ``async def`` is not a coroutine function, so it passes every check
-        # above and its body never runs until awaited. Closing the coroutine
-        # keeps the refusal from also emitting "was never awaited" at whatever
-        # point the garbage collector gets to it.
+        # ``async def`` is not a coroutine function, so it passes every check in
+        # ``_load_register`` and its body never runs until awaited. Closing the
+        # coroutine keeps the refusal from also emitting "was never awaited" at
+        # whatever point the garbage collector gets to it.
         outcome.close()
         msg = (
-            f"Bootstrap {bootstrap_selector!r} returned an awaitable; the container is built "
+            f"Bootstrap {selector!r} returned an awaitable; the container is built "
             "synchronously, so register must run to completion when called"
         )
         raise BootstrapError(msg)
-    rebound = sorted(_port_name(port) for port, factory in container.bindings() if defaults.get(port) is not factory)
-    container.summary = f"{bootstrap_selector} rebound {', '.join(rebound) or 'no ports'}"
-    contributed = ", ".join(contribution.capability for contribution in container.router_contributions())
+    rebound = sorted(_port_name(port) for port, factory in container.bindings() if before.get(port) is not factory)
+    summary = f"{selector} rebound {', '.join(rebound) or 'no ports'}"
+    contributed = ", ".join(
+        contribution.capability for contribution in container.router_contributions()[contributed_before:]
+    )
     if contributed:
-        container.summary += f", contributed routers for {contributed}"
-    logger.info("Composition root: %s", container.summary)
-    return container
+        summary += f", contributed routers for {contributed}"
+    return summary
 
 
 def _port_name(port: PortKey[Any]) -> str:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -779,10 +779,11 @@ class GatewayConfig(BaseSettings):
     bootstrap: str | None = Field(
         default=None,
         description=(
-            "Composition-root bootstrap, as a 'module:callable' selector (OTARI_BOOTSTRAP). "
-            "Imported once at startup after the core adapters are bound, and called with the "
-            "container so an overlay can rebind ports and contribute routers. Unset means "
-            "nothing is imported. Unrelated to bootstrap_api_key."
+            "Composition-root bootstrap, as a 'module:callable' selector (OTARI_BOOTSTRAP), or a "
+            "comma-separated list of them applied in order. Each is imported once at startup after "
+            "the core adapters are bound, and called with the container so an overlay can rebind "
+            "ports and contribute routers; a later bind wins. Unset means nothing is imported. "
+            "Unrelated to bootstrap_api_key."
         ),
     )
     log_writer_strategy: str = Field(

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -200,6 +200,108 @@ def test_a_selector_with_surrounding_whitespace_still_loads(tmp_path: Path, monk
     assert "rebound no ports" in container.summary
 
 
+def test_two_selectors_are_applied_in_order_and_a_later_bind_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "first_bootstrap",
+        """
+from fastapi import APIRouter
+
+from gateway.container import RouterContribution
+from gateway.ports.billing_port import BillingPort
+from gateway.ports.entitlement_port import EntitlementPort
+
+
+class FirstBilling:
+    def __init__(self, session):
+        self.session = session
+
+
+class FirstEntitlements:
+    def __init__(self, session):
+        self.session = session
+
+
+def register(container):
+    container.bind(BillingPort, FirstBilling)
+    container.bind(EntitlementPort, FirstEntitlements)
+    container.contribute_router(RouterContribution(capability="first", router=APIRouter()))
+""",
+    )
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "second_bootstrap",
+        """
+from fastapi import APIRouter
+
+from gateway.container import RouterContribution
+from gateway.ports.billing_port import BillingPort
+
+
+class SecondBilling:
+    def __init__(self, session):
+        self.session = session
+
+
+def register(container):
+    container.bind(BillingPort, SecondBilling)
+    container.contribute_router(RouterContribution(capability="second", router=APIRouter()))
+""",
+    )
+
+    container = build_container("first_bootstrap:register, second_bootstrap:register")
+
+    # Both ran: the port only the first touched holds its adapter, the port both
+    # touched holds the later one, and the routers arrived in selector order.
+    assert type(container.resolve(BillingPort, NO_SESSION)).__name__ == "SecondBilling"
+    assert type(container.resolve(EntitlementPort, NO_SESSION)).__name__ == "FirstEntitlements"
+    assert [contribution.capability for contribution in container.router_contributions()] == ["first", "second"]
+    assert container.summary == (
+        "first_bootstrap:register rebound BillingPort, EntitlementPort, contributed routers for first; "
+        "second_bootstrap:register rebound BillingPort, contributed routers for second"
+    )
+
+
+@pytest.mark.parametrize(
+    ("selector", "message"),
+    [
+        ("guarded_bootstrap:register, ,guarded_bootstrap:register", "entry 2 of 3 is blank"),
+        ("guarded_bootstrap:register,", "entry 2 of 2 is blank"),
+        (",guarded_bootstrap:register", "entry 1 of 2 is blank"),
+    ],
+)
+def test_a_blank_entry_in_a_selector_list_refuses_to_boot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, selector: str, message: str
+) -> None:
+    # A dropped entry is refused before any selector runs, so a list with a
+    # stray comma never boots a build missing one of its extensions.
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "guarded_bootstrap",
+        "def register(container):\n    raise AssertionError('no selector may run')\n",
+    )
+
+    with pytest.raises(BootstrapError, match=message):
+        build_container(selector)
+
+
+def test_a_failing_later_selector_fails_startup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "inert_bootstrap",
+        "def register(container):\n    return None\n",
+    )
+
+    with pytest.raises(BootstrapError, match="was not found"):
+        build_container("inert_bootstrap:register,gateway_bootstrap_that_does_not_exist:register")
+
+
 @pytest.mark.parametrize(
     ("selector", "message"),
     [


### PR DESCRIPTION
## Description

Otari can be extended by pointing `OTARI_BOOTSTRAP` at a trusted module that rebinds ports and adds routes at startup. Until now that setting took exactly one module, which fits one overlay per deployment but not a deployment that installs two independent extensions from different authors: one of them had to wrap the other.

`OTARI_BOOTSTRAP` (and the `bootstrap` config field) now accepts a comma-separated list of `module:callable` selectors, applied in the order written after the core defaults are bound. A later bind wins, as it did already. A blank entry anywhere in the list, a trailing comma included, refuses to start and names the position, and a second selector that cannot be loaded fails startup rather than quietly running with only the first. The startup summary names each selector with the ports it rebound and the routers it contributed.

The list is explicit and ordered, so the whole wiring is still readable from one config value and nothing is discovered from installed packages, which keeps the no-auto-discovery rule in ARCHITECTURE.md intact. A single selector behaves exactly as before, including every error message.

This is one of the four seams needed so that budget alerts (#973) can ship as a plugin rather than in core. Refs #973.

## How to test it locally

Automated:

- `make lint`, `make typecheck`, `make test-unit`: the new cases live in `tests/unit/test_container.py` (two selectors applied in order with a later bind winning and both routers recorded, blank middle entry, trailing comma, leading comma, and a failing second selector).
- `uv run --frozen --no-dev python scripts/oss_edition_smoke.py`: boots with no bootstrap at all, confirming the plain build is untouched.

The integration suite (`make test-integration`, which includes `tests/integration/test_bootstrap_overlay.py`) was **not** run locally: the machine this was developed on has neither Docker nor a PostgreSQL server, so Testcontainers cannot start. CI runs it on this PR.

By hand, from a checkout:

```bash
mkdir -p /tmp/boot && cat > /tmp/boot/one.py <<'EOF'
from gateway.ports.billing_port import BillingPort
class OneBilling:
    def __init__(self, session): ...
def register(container):
    container.bind(BillingPort, OneBilling)
EOF
cat > /tmp/boot/two.py <<'EOF'
from gateway.ports.entitlement_port import EntitlementPort
class TwoEntitlements:
    def __init__(self, session): ...
def register(container):
    container.bind(EntitlementPort, TwoEntitlements)
EOF
PYTHONPATH=/tmp/boot OTARI_BOOTSTRAP="one:register, two:register" uv run otari serve
```

The startup log reads `Composition root: one:register rebound BillingPort; two:register rebound EntitlementPort`. Then try `OTARI_BOOTSTRAP="one:register,"`: the gateway refuses to start with `OTARI_BOOTSTRAP entry 2 of 2 is blank; remove the extra comma`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #1060
Refs #973

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make test-unit` and the smoke gate ran locally; `make test-integration` could not (no Docker or PostgreSQL on the machine) and is left to CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Not applicable: no route or schema changed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any additional AI details you'd like to share:** Implementation, tests, docs and this description were written by the agent following the repo's `pr-cycle`, `backend-standards` and `review` skills. A human requested the change and set its scope.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
