### PR TITLE
feat(dashboard): move the domain claim form into FormDialog

### DIFF
--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -475,7 +475,7 @@ test.describe("the domain dialog", () => {
     await page.getByRole("button", { name: "Claim domain" }).first().click()
     const dialog = page.getByRole("dialog", { name: "New domain" })
     await expect(dialog.getByLabel(/^Domain/)).toBeVisible()
-    await captureScreenshot(page, "domains-claim-dialog")
+    await captureScreenshot(page, "organization-domains-claim-dialog")
   })
 })
 

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -464,6 +464,21 @@ test.describe("the provider dialog", () => {
   })
 })
 
+test.describe("the domain dialog", () => {
+  // The suite's only `sm` dialog, which is the width nothing else here covers.
+  test("the claim dialog", async ({ page }) => {
+    await login(page)
+    await gotoRoute(page, "/organization/domains")
+    await expect(
+      page.getByRole("heading", { name: /email domains/i }).first(),
+    ).toBeVisible()
+    await page.getByRole("button", { name: "Claim domain" }).first().click()
+    const dialog = page.getByRole("dialog", { name: "New domain" })
+    await expect(dialog.getByLabel(/^Domain/)).toBeVisible()
+    await captureScreenshot(page, "domains-claim-dialog")
+  })
+})
+
 // No capture for the organization provider-key dialog. Its page is gated on the
 // `organization_providers` surface, which only a hosted deployment publishes
 // (bootstrap.py's HOSTED_SURFACES), and this suite boots a standalone gateway,

--- a/web/src/features/organization/OrganizationDomainsPage.test.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.test.tsx
@@ -220,6 +220,40 @@ describe("OrganizationDomainsPage", () => {
     })
   })
 
+  it("keeps the header trigger on screen while the dialog is open", async () => {
+    // The dialog sits over the page rather than replacing the action, so the
+    // control that opened it does not vanish from under the pointer.
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationDomainsPage />)
+
+    const trigger = await screen.findByRole("button", { name: "Claim domain" })
+    await user.click(trigger)
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(trigger).toBeVisible()
+  })
+
+  it("opens on a blank draft after a close, not on the last one typed", async () => {
+    // Reset on the way in: clearing on the way out would blank the fields
+    // while the dialog is still animating away.
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationDomainsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Claim domain" }),
+    )
+    await user.type(screen.getByLabelText(/Domain/), "acme.example")
+    // A draft this far along is dirty, so the way out is through the guard.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Claim domain" }))
+    expect(await screen.findByLabelText(/Domain/)).toHaveValue("")
+  })
+
   it("never offers a management role, because a DNS record must not mint admins", async () => {
     mockApi()
     renderPage(<OrganizationDomainsPage />)

--- a/web/src/features/organization/OrganizationDomainsPage.test.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.test.tsx
@@ -281,6 +281,18 @@ describe("OrganizationDomainsPage", () => {
     expect(
       screen.getByRole("button", { name: /They join as/ }),
     ).toHaveTextContent("Viewer")
+
+    // And the seed is per open, not per page: the ref lives below the key, so
+    // the next open starts clean. Held above it, or with the key dropped, the
+    // dialog would arrive already dirty and Escape would ask before closing an
+    // untouched form.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    await user.click(screen.getByRole("button", { name: "Claim domain" }))
+    await screen.findByRole("dialog")
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
   })
 
   it("never offers a management role, because a DNS record must not mint admins", async () => {

--- a/web/src/features/organization/OrganizationDomainsPage.test.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.test.tsx
@@ -254,6 +254,35 @@ describe("OrganizationDomainsPage", () => {
     expect(await screen.findByLabelText(/Domain/)).toHaveValue("")
   })
 
+  it("guards a changed role on the way out, with nothing typed", async () => {
+    // The role is the other thing this form owns, and it is a choice the
+    // operator cannot retype: without it in `isDirty`, closing discards it
+    // silently. Dismissed through Cancel rather than Escape because in jsdom
+    // focus lands on `<body>` after picking from the Select, so a keystroke
+    // reaches nothing.
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationDomainsPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Claim domain" }),
+    )
+    await user.click(screen.getByRole("button", { name: /They join as/ }))
+    await user.click(await screen.findByRole("option", { name: "Viewer" }))
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(
+      await screen.findByRole("button", { name: "Discard" }),
+    ).toBeInTheDocument()
+    // Still open behind the guard, so Keep editing returns to the choice
+    // rather than to an empty form.
+    await user.click(screen.getByRole("button", { name: "Keep editing" }))
+    expect(
+      screen.getByRole("button", { name: /They join as/ }),
+    ).toHaveTextContent("Viewer")
+  })
+
   it("never offers a management role, because a DNS record must not mint admins", async () => {
     mockApi()
     renderPage(<OrganizationDomainsPage />)

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -9,12 +9,13 @@ import { CopyField } from "@/design-system/actions/CopyField"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
+import { Select } from "@/design-system/forms/Select"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
-import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import {
   useCreateOrganizationDomain,
   useDeleteOrganizationDomain,
@@ -68,7 +69,13 @@ const AUTO_JOIN_ROLE_OPTIONS = [
   { value: "viewer", label: "Viewer" },
 ]
 
-function ClaimForm({ onClose }: { onClose: () => void }) {
+function ClaimForm({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
   const create = useCreateOrganizationDomain()
   const [domain, setDomain] = useState("")
   const [role, setRole] = useState("member")
@@ -79,21 +86,24 @@ function ClaimForm({ onClose }: { onClose: () => void }) {
       default_role: role === "viewer" ? "viewer" : "member",
       enabled: true,
     }
-    create.mutate(body, {
-      onSuccess: () => {
-        setDomain("")
-        onClose()
-      },
-    })
+    create.mutate(body, { onSuccess: onClose })
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      size="sm"
+      title="New domain"
+      submitLabel="Claim domain"
+      onSubmit={submit}
+      isPending={create.isPending}
+      isSubmitDisabled={domain.trim() === ""}
+      isDirty={domain.trim() !== ""}
+      error={create.error}
     >
-      <h2 className="text-title">Claim an email domain</h2>
-      <ErrorBanner error={create.error} />
       <Field
         label="Domain"
         value={domain}
@@ -103,30 +113,18 @@ function ClaimForm({ onClose }: { onClose: () => void }) {
         placeholder="example.com"
         description="The domain your colleagues' addresses end in. A whole address works too; only its domain is stored. Public providers like gmail.com can't be claimed."
       />
-      <FilterSelect
+      <Select
         label="They join as"
         value={role}
         onChange={setRole}
         options={AUTO_JOIN_ROLE_OPTIONS}
+        reserveMessage={false}
       />
       <p className="text-caption">
         Nothing happens until you publish the DNS record this creates and verify
         it. Anyone who already has an account joins on their next sign-in.
       </p>
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={domain.trim() === ""}
-          isPending={create.isPending}
-          onPress={submit}
-        >
-          Claim domain
-        </Button>
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -191,6 +189,7 @@ export function OrganizationDomainsPage() {
   const update = useUpdateOrganizationDomain()
   const remove = useDeleteOrganizationDomain()
   const [adding, setAdding] = useState(false)
+  const [openCount, setOpenCount] = useState(0)
   const [pendingDelete, setPendingDelete] = useState<OrganizationDomain>()
 
   const rows = domains.data?.data ?? []
@@ -286,8 +285,15 @@ export function OrganizationDomainsPage() {
       <PageIntro
         title="Email domains"
         action={
-          canEdit && !adding ? (
-            <Button variant="primary" onPress={() => setAdding(true)}>
+          canEdit ? (
+            <Button
+              // Visible while the dialog is open: the dialog is over the page.
+              variant="primary"
+              onPress={() => {
+                setOpenCount((count) => count + 1)
+                setAdding(true)
+              }}
+            >
               Claim domain
             </Button>
           ) : null
@@ -309,7 +315,14 @@ export function OrganizationDomainsPage() {
         </InfoBanner>
       ) : null}
 
-      {adding ? <ClaimForm onClose={() => setAdding(false)} /> : null}
+      {/* Keyed on the open count, so each open remounts a blank form. Clearing
+          the draft on close instead would blank the fields while the dialog is
+          still animating away. */}
+      <ClaimForm
+        key={openCount}
+        isOpen={adding}
+        onClose={() => setAdding(false)}
+      />
 
       {pending.map((row) => (
         <PendingProof key={row.id} row={row} />

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -1,5 +1,5 @@
 import { Button, Chip } from "@heroui/react"
-import { useState } from "react"
+import { useRef, useState } from "react"
 
 import type {
   CreateOrganizationDomainRequest,
@@ -79,6 +79,12 @@ function ClaimForm({
   const create = useCreateOrganizationDomain()
   const [domain, setDomain] = useState("")
   const [role, setRole] = useState("member")
+  // One snapshot of everything the form owns, seeded on mount: dirty means
+  // "differs from what was seeded", and a field added to the form is added here
+  // or the guard cannot see it. A predicate of the fields had already forgotten
+  // `role`, so changing who joins and pressing Escape discarded it unguarded.
+  const draft = JSON.stringify({ domain, role })
+  const seededDraft = useRef(draft)
 
   const submit = () => {
     const body: CreateOrganizationDomainRequest = {
@@ -101,7 +107,7 @@ function ClaimForm({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={domain.trim() === ""}
-      isDirty={domain.trim() !== ""}
+      isDirty={draft !== seededDraft.current}
       error={create.error}
     >
       <Field


### PR DESCRIPTION
## Description

Claiming an email domain used to append a form section under the page heading, which is one of the two creation patterns the dashboard is collapsing into one. It now opens the shared form dialog: press "Claim domain" in the heading row and a small centered dialog titled "New domain" appears, with "Claim domain" as its submit.

Two behaviors change beyond the surface. The heading button stays on screen while the dialog is open, because the dialog sits over the page rather than replacing the action, so the control never vanishes from under the pointer. And a half-typed draft is cleared when the dialog opens rather than when it closes: clearing on the way out would blank the fields while the dialog is still animating away.

The "They join as" picker moves from the toolbar filter control to the form one. The toolbar control draws a label of its own, so beside a labeled field inside a dialog it would ship two label rungs.

Part of #1031

## How to test it locally

1. `make dashboard && make dev`, sign in, and open Organization, Email domains as an owner or admin.
2. Press "Claim domain" in the heading row. The dialog opens over the page and the heading button is still there.
3. Type a domain, press Escape, and discard the unsaved changes. Press "Claim domain" again: the field is empty.
4. Claim a domain and confirm the row and its pending-proof card appear as before.

Covered automatically by `web/src/features/organization/OrganizationDomainsPage.test.tsx` (14 cases, including the two above). Both new cases were checked by removing the fix and watching them fail: dropping the remount key makes the draft survive, and hiding the trigger while the dialog is open fails the visibility case.

## PR Type

- [x] Refactor

## Relevant issues

Part of #1031

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
  Dashboard counterparts: `pnpm --dir web run lint`, `run typecheck`, and the vitest suite, all green. The Playwright behavioral projects (onboarding, seed, parity, hybrid) were run before and after this change and produce the same result: one pre-existing failure, `parity.management.spec.ts` budgets, which is unrelated to this page and fails identically on the base commit.
- [ ] Documentation was updated where necessary. No documentation covers this form's placement; the design system's dialog guidance already describes the target pattern.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API change.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 5)

**Any additional AI details you'd like to share:**

The reset-on-open behavior and the two new tests were checked by deliberately reintroducing each defect and reading the failure, rather than by the tests passing on first write.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
