### PR TITLE
feat(core): let a bootstrap contribute lifespan background tasks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,6 +154,7 @@ An overlay (or your own deployment) rebinds ports to its own adapters **without 
 def register(container: Container) -> None:
     container.bind(BillingPort, _wallet_billing_adapter)
     container.contribute_router(RouterContribution(capability="billing", router=wallet_router))
+    container.contribute_background_task(BackgroundTaskContribution(name="budget alerts", start=run_alert_evaluator))
 ```
 
 With nothing configured nothing is imported, the defaults stand, and Otari boots standalone. A selector that is set but cannot be loaded fails startup rather than quietly falling back, because a build nobody chose is worse than a gateway that will not start.
@@ -161,6 +162,8 @@ With nothing configured nothing is imported, the defaults stand, and Otari boots
 A contributed router is the additive half of the seam, and it is gated rather than swapped: Otari mounts it behind `require_capability(...)`, which resolves `EntitlementPort` and answers a request for an unentitled capability with the same 404 a path nothing serves gets. That gate is the server-side half of the entitlement axis; hiding a nav item in the dashboard is not authorization.
 
 Entitlement is not authentication either, and the mount point adds none. A capability names no caller, so on an entitled deployment a contributed route is reachable by anyone unless the router says otherwise. A contribution declares the credential each of its routes needs on the route, the way Otari's own routers do; there is no router-level default to mount, because the right answer differs per route, a contributed route may be deliberately public, and the header check resolves a database session a hybrid gateway does not have.
+
+A contributed background task is the additive seam for a periodic worker (an alert evaluator, a sync job, a purge), which would otherwise need a line in the lifespan's hand-kept refresher list. `start` is a coroutine function that receives the `GatewayConfig`; the lifespan schedules it after Otari's own refreshers, in every mode, and stops it under the same shared cancellation bound, so a task that ignores cancellation is abandoned rather than allowed to hang shutdown, and one that dies is logged under its `name` and never takes the process down. Names are unique per container, and the startup summary lists them beside the contributed routers.
 
 > **Where this lives in the tree.** The composition root is `src/gateway/container.py`; it is built once per app in `create_app` (`src/gateway/main.py`) and attached to `app.state` beside the other shared resources, so two apps in one process never share one. Ports are resolved from it through dependencies in `src/gateway/api/deps.py`, which is also where the rest of composition is still hand-wired: the container took over the ports, not every dependency, and a plain single-implementation service stays wired directly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,10 +306,33 @@ usage-report timeout and retries, and first-chunk fallback timeout. See
 ## Extending Otari with a bootstrap module
 
 `bootstrap` or `OTARI_BOOTSTRAP` names a trusted `module:callable` loaded
-inside the gateway process. The callable can rebind extension ports and
-contribute capability-gated routers. Most deployments should leave it unset.
+inside the gateway process. The callable can rebind extension ports,
+contribute capability-gated routers, and contribute background tasks. Most
+deployments should leave it unset.
 
 This is executable code, not a feature flag. Install the module in the gateway
 environment, pin it to a compatible Otari release, and authenticate every
 contributed route. See [Architecture](../ARCHITECTURE.md) for the extension
 boundary.
+
+A background task is a coroutine function that receives the gateway config.
+Otari starts it beside its own periodic refreshers, in every mode, and cancels
+it at shutdown under the same bounded wait, so a task that never yields cannot
+hold the process open:
+
+```python
+from gateway.container import BackgroundTaskContribution, Container
+
+
+async def run_alert_evaluator(config) -> None:
+    while True:
+        ...
+        await asyncio.sleep(60)
+
+
+def register(container: Container) -> None:
+    container.contribute_background_task(BackgroundTaskContribution(name="budget alerts", start=run_alert_evaluator))
+```
+
+Names are unique per container; a second task registered under a taken name
+fails startup.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,8 @@ it at shutdown under the same bounded wait, so a task that never yields cannot
 hold the process open:
 
 ```python
+import asyncio
+
 from gateway.container import BackgroundTaskContribution, Container
 
 

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -11,8 +11,9 @@ artifacts. [ARCHITECTURE.md](../../ARCHITECTURE.md) owns the extension boundary.
 ## Ports and composition
 
 Domain protocols live in `ports/`, core implementations in `adapters/`, and
-bindings in `container.py`. `OTARI_BOOTSTRAP=module:callable` may rebind a port
-or contribute a capability-gated router after core bindings are installed.
+bindings in `container.py`. `OTARI_BOOTSTRAP=module:callable` may rebind a port,
+contribute a capability-gated router, or contribute a lifespan background task
+after core bindings are installed.
 
 Add a port only when a real second implementation exists. Core never imports an
 overlay. Dependencies request protocols from the container and never name an

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -17,14 +17,15 @@ claim a swap point that does not exist.
 An overlay rebinds ports without editing any Otari source file, by pointing
 ``OTARI_BOOTSTRAP`` at a ``module:callable`` selector. The callable receives
 this container after the core defaults are bound, and may rebind any port and
-contribute routers of its own. Unset, the defaults stand.
+contribute routers and lifespan background tasks of its own. Unset, the
+defaults stand.
 """
 
 import importlib
 import inspect
-from collections.abc import Callable, ItemsView
+from collections.abc import Callable, Coroutine, ItemsView
 from dataclasses import dataclass
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from fastapi import APIRouter
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,6 +43,9 @@ from gateway.ports.growth_signal_port import GrowthSignalPort
 from gateway.ports.identity_provider_port import IdentityProviderPort
 from gateway.ports.model_provider_port import ModelProviderPort
 from gateway.ports.telemetry_storage_port import TelemetryStoragePort
+
+if TYPE_CHECKING:
+    from gateway.core.config import GatewayConfig
 
 T = TypeVar("T")
 
@@ -90,6 +94,25 @@ class RouterContribution:
     router: APIRouter
 
 
+@dataclass(frozen=True)
+class BackgroundTaskContribution:
+    """One periodic worker an overlay runs for the life of the process.
+
+    The lifespan (``gateway.main``) schedules ``start(config)`` as a task after
+    Otari's own refreshers, in every mode, and stops it under the same shared
+    cancellation bound, so a contributed task that ignores cancellation cannot
+    hang shutdown. ``name`` labels the task in the startup summary and in the
+    shutdown log, and is unique per container.
+
+    ``start`` is a coroutine function, not the coroutine itself: a coroutine
+    object built at register time in a container that never runs (as the test
+    suite builds) would only leak a "never awaited" warning.
+    """
+
+    name: str
+    start: Callable[["GatewayConfig"], Coroutine[Any, Any, None]]
+
+
 class ContainerError(Exception):
     """Base error for composition-root wiring failures."""
 
@@ -107,6 +130,14 @@ class BootstrapError(ContainerError):
     """Raised when the bootstrap module ``OTARI_BOOTSTRAP`` names cannot be loaded."""
 
 
+class DuplicateBackgroundTaskError(ContainerError):
+    """Raised when a second background task is contributed under a name already taken."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"A background task named {name!r} is already contributed")
+        self.name = name
+
+
 class Container:
     """A registry mapping each port to the adapter that satisfies it.
 
@@ -119,6 +150,7 @@ class Container:
     def __init__(self) -> None:
         self._factories: dict[Any, PortFactory[Any]] = {}
         self._router_contributions: list[RouterContribution] = []
+        self._background_task_contributions: dict[str, BackgroundTaskContribution] = {}
         # One line naming what this container was built from, logged by
         # build_container and asserted on by tests.
         self.summary = "unbuilt"
@@ -159,6 +191,24 @@ class Container:
     def router_contributions(self) -> tuple[RouterContribution, ...]:
         """Return the recorded router contributions, in contribution order."""
         return tuple(self._router_contributions)
+
+    def contribute_background_task(self, contribution: BackgroundTaskContribution) -> None:
+        """Record a background task the lifespan runs beside Otari's own refreshers.
+
+        Raises:
+            DuplicateBackgroundTaskError: If a task of the same name is already
+                contributed. Two tasks sharing a name would be indistinguishable
+                in the shutdown log, and a bootstrap registering the same worker
+                twice is a mistake worth refusing at startup.
+
+        """
+        if contribution.name in self._background_task_contributions:
+            raise DuplicateBackgroundTaskError(contribution.name)
+        self._background_task_contributions[contribution.name] = contribution
+
+    def background_task_contributions(self) -> tuple[BackgroundTaskContribution, ...]:
+        """Return the recorded background task contributions, in contribution order."""
+        return tuple(self._background_task_contributions.values())
 
 
 def _billing_adapter(session: AsyncSession | None) -> BillingPort:
@@ -249,8 +299,8 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
     """Build the composition-root container for this deployment.
 
     Binds the core adapters, then, if a selector is given, lets the bootstrap it
-    names rebind ports and contribute routers. With no selector the core
-    defaults stand and Otari boots standalone.
+    names rebind ports and contribute routers and background tasks. With no
+    selector the core defaults stand and Otari boots standalone.
 
     Raises:
         BootstrapError: If the selector is present but blank, or names a
@@ -320,6 +370,9 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
     contributed = ", ".join(contribution.capability for contribution in container.router_contributions())
     if contributed:
         container.summary += f", contributed routers for {contributed}"
+    contributed_tasks = ", ".join(contribution.name for contribution in container.background_task_contributions())
+    if contributed_tasks:
+        container.summary += f", contributed background tasks {contributed_tasks}"
     logger.info("Composition root: %s", container.summary)
     return container
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
-from gateway.container import build_container
+from gateway.container import Container, build_container
 from gateway.core.config import API_KEY_HEADER, API_ROOT, GATEWAY_TOKEN_HEADER, X_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, dispose_db, init_db
 from gateway.dashboard import DASHBOARD_PACKAGE_PATH, get_dashboard_build_id, get_dashboard_dir
@@ -332,6 +332,7 @@ def _create_lifespan() -> Callable[[FastAPI], Any]:
         # From the app, not a closure: app.state.config is what get_config hands
         # every request, so startup reads the same object.
         config: GatewayConfig = app.state.config
+        container: Container = app.state.container
         configure_default_pricing(config.default_pricing)
         # Bound method, not a snapshot: it reads config.providers on every call, so
         # a provider added or re-typed in the dashboard is priced under the
@@ -465,8 +466,16 @@ def _create_lifespan() -> Callable[[FastAPI], Any]:
 
         # Start the writer inside the try so a failure here still runs the cleanup
         # below; the refresher tasks are already created and would otherwise leak.
+        contributed_tasks: list[tuple[asyncio.Task[None], str]] = []
         log_writer_started = False
         try:
+            # A bootstrap's own workers, after Otari's and in every mode, since
+            # a plugin may extend the data plane as much as the control plane.
+            # Inside the try for the same reason as the writer: a start that
+            # raises must still cancel every task created before it.
+            for contribution in container.background_task_contributions():
+                task = asyncio.create_task(contribution.start(config))
+                contributed_tasks.append((task, f"contributed {contribution.name}"))
             await log_writer.start()
             log_writer_started = True
             app.state.log_writer = log_writer
@@ -483,7 +492,7 @@ def _create_lifespan() -> Callable[[FastAPI], Any]:
                 (catalog_refresher, "models.dev catalog"),
                 (reservation_sweeper, "budget reservation sweep"),
             ]
-            await _stop_refreshers([(task, name) for task, name in refreshers if task is not None])
+            await _stop_refreshers([(task, name) for task, name in refreshers if task is not None] + contributed_tasks)
             if alias_refresher is not None:
                 reset_alias_cache()
             if policy_refresher is not None:

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -22,8 +22,11 @@ from gateway.adapters.identity_provider_adapter import RosterIdentityProviderAda
 from gateway.adapters.model_provider_adapter import SelfHostedModelProviderAdapter
 from gateway.adapters.telemetry_storage_adapter import DatabaseTelemetryStorageAdapter
 from gateway.container import (
+    BackgroundTaskContribution,
     BootstrapError,
     Container,
+    ContainerError,
+    DuplicateBackgroundTaskError,
     PortNotBoundError,
     RouterContribution,
     build_container,
@@ -96,6 +99,7 @@ def test_no_selector_contributes_no_routers_and_says_so() -> None:
     container = build_container()
 
     assert container.router_contributions() == ()
+    assert container.background_task_contributions() == ()
     assert container.summary.startswith("no bootstrap, core defaults for ")
     for port in (
         BillingPort,
@@ -300,3 +304,71 @@ def test_router_contributions_keep_their_order() -> None:
     container.contribute_router(second)
 
     assert container.router_contributions() == (first, second)
+
+
+async def _never_runs(_config: object) -> None:
+    raise AssertionError("the container records a task; only the lifespan starts one")
+
+
+def test_background_task_contributions_keep_their_order() -> None:
+    container = Container()
+    first = BackgroundTaskContribution(name="one", start=_never_runs)
+    second = BackgroundTaskContribution(name="two", start=_never_runs)
+
+    container.contribute_background_task(first)
+    container.contribute_background_task(second)
+
+    assert container.background_task_contributions() == (first, second)
+
+
+def test_a_duplicate_background_task_name_is_refused_and_the_first_stands() -> None:
+    container = Container()
+    first = BackgroundTaskContribution(name="sync", start=_never_runs)
+    container.contribute_background_task(first)
+
+    with pytest.raises(DuplicateBackgroundTaskError, match="'sync' is already contributed") as caught:
+        container.contribute_background_task(BackgroundTaskContribution(name="sync", start=_never_runs))
+
+    assert isinstance(caught.value, ContainerError)
+    assert caught.value.name == "sync"
+    assert container.background_task_contributions() == (first,)
+
+
+def test_bootstrap_summary_names_the_contributed_background_tasks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "tasks_bootstrap",
+        """
+from fastapi import APIRouter
+
+from gateway.container import BackgroundTaskContribution, Container, RouterContribution
+
+
+async def evaluate(config) -> None:
+    pass
+
+
+async def purge(config) -> None:
+    pass
+
+
+def register(container: Container) -> None:
+    container.contribute_router(RouterContribution(capability="alerts", router=APIRouter()))
+    container.contribute_background_task(BackgroundTaskContribution(name="budget alerts", start=evaluate))
+    container.contribute_background_task(BackgroundTaskContribution(name="purge", start=purge))
+""",
+    )
+
+    container = build_container("tasks_bootstrap:register")
+
+    assert [contribution.name for contribution in container.background_task_contributions()] == [
+        "budget alerts",
+        "purge",
+    ]
+    assert container.summary == (
+        "tasks_bootstrap:register rebound no ports, contributed routers for alerts, "
+        "contributed background tasks budget alerts, purge"
+    )

--- a/tests/unit/test_gateway_lifespan_shutdown.py
+++ b/tests/unit/test_gateway_lifespan_shutdown.py
@@ -19,12 +19,15 @@ land and is not reproducible on demand.
 """
 
 import asyncio
+import logging
 from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 
+from gateway.container import BackgroundTaskContribution, Container
 from gateway.core.config import GatewayConfig
+from gateway.log_config import logger as gateway_logger
 from gateway.main import _REFRESHER_STOP_TIMEOUT_SECONDS, _create_lifespan, _stop_refresher, _stop_refreshers
 
 
@@ -147,11 +150,124 @@ async def test_lifespan_shutdown_completes_despite_a_stuck_refresher(
         master_key="sk-test-master",
     )
     lifespan = _create_lifespan()
-    app = FastAPI()
-    app.state.config = config
+    app = _app_for(config)
 
     # No asyncio.timeout wrapper: if shutdown regresses this hangs, and the
     # suite-wide pytest timeout reports it. A short bound here would be
     # indistinguishable from the fix under test.
     async with lifespan(app):
         pass
+
+
+def _standalone_config(tmp_path: Path) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=f"sqlite:///{tmp_path / 'lifespan.db'}",
+        master_key="sk-test-master",
+    )
+
+
+def _hybrid_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GatewayConfig:
+    """A gateway attached to a control plane, so the lifespan skips init_db and the core refreshers."""
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw-test-token")
+    return GatewayConfig(
+        mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'lifespan.db'}",
+        platform={"base_url": "http://platform.test"},
+    )
+
+
+def _app_for(config: GatewayConfig, *contributions: BackgroundTaskContribution) -> FastAPI:
+    """A bare app carrying what the lifespan reads off ``app.state``, as ``create_app`` attaches it."""
+    app = FastAPI()
+    app.state.config = config
+    container = Container()
+    for contribution in contributions:
+        container.contribute_background_task(contribution)
+    app.state.container = container
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["standalone", "hybrid"])
+async def test_a_contributed_task_is_started_with_the_config_and_cancelled_at_shutdown(
+    mode: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In both modes: hybrid skips the core refreshers, and a plugin may extend the data plane too."""
+    config = _standalone_config(tmp_path) if mode == "standalone" else _hybrid_config(tmp_path, monkeypatch)
+    seen: list[tuple[GatewayConfig, asyncio.Task[None]]] = []
+
+    async def records(received: GatewayConfig) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        seen.append((received, task))
+        await asyncio.sleep(3600)
+
+    lifespan = _create_lifespan()
+    app = _app_for(config, BackgroundTaskContribution(name="probe", start=records))
+
+    async with lifespan(app):
+        await asyncio.sleep(0)  # let the contributed task reach its first await
+        assert len(seen) == 1
+        assert seen[0][0] is config
+        assert not seen[0][1].done()
+
+    assert seen[0][1].cancelled()
+
+
+@pytest.mark.asyncio
+async def test_a_contributed_task_that_ignores_cancellation_is_abandoned_under_the_shared_bound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plugin task cannot hang shutdown any more than a core refresher can."""
+    handles: list[asyncio.Task[None]] = []
+
+    async def stubborn(_config: GatewayConfig) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        handles.append(task)
+        await _absorbs_cancellation()
+
+    lifespan = _create_lifespan()
+    app = _app_for(_hybrid_config(tmp_path, monkeypatch), BackgroundTaskContribution(name="stubborn", start=stubborn))
+
+    async with lifespan(app):
+        await asyncio.sleep(0)
+        started = asyncio.get_running_loop().time()
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert _REFRESHER_STOP_TIMEOUT_SECONDS <= elapsed < _REFRESHER_STOP_TIMEOUT_SECONDS + 2
+    (task,) = handles
+    assert not task.done()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_a_contributed_task_that_raises_is_logged_by_name_and_does_not_break_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def explodes(_config: GatewayConfig) -> None:
+        raise RuntimeError("plugin blew up")
+
+    lifespan = _create_lifespan()
+    app = _app_for(
+        _hybrid_config(tmp_path, monkeypatch), BackgroundTaskContribution(name="budget alerts", start=explodes)
+    )
+
+    # The gateway logger does not propagate, so attach the capture handler to it directly.
+    gateway_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger="gateway")
+    try:
+        async with lifespan(app):
+            await asyncio.sleep(0)  # let it die before shutdown looks at it
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+
+    assert "contributed budget alerts refresher stopped with an unexpected error" in caplog.text
+    assert "plugin blew up" in caplog.text


### PR DESCRIPTION
## Description

A deployment that extends Otari with a bootstrap module could already swap an adapter or add API routes, but it could not run a periodic worker of its own: the timers Otari runs (cache refreshers, the budget hold sweeper) were a fixed list inside the gateway's startup code, and adding one meant editing Otari itself, which the architecture rules forbid for anything outside the core.

This adds a third thing a bootstrap can contribute: a named background task. Otari starts it beside its own refreshers when the process boots, in both standalone and hybrid mode, and shuts it down under the same bounded wait it already applies to its own workers. A contributed task that ignores cancellation is abandoned after that bound instead of holding shutdown open, and one that crashes is logged under its name rather than taking the gateway down. Two tasks registered under the same name are refused at startup, and the composition-root summary line names the tasks a build contributed, the way it already names contributed routers.

This is one of four seams needed so that budget alerts (#973) can ship as a plugin instead of core: its evaluator is a periodic worker and now has a place to register. Refs #973.

## How to test it locally

Automated coverage:

- `uv run pytest tests/unit/test_container.py tests/unit/test_gateway_lifespan_shutdown.py -q -p no:cacheprovider` covers the contribution being recorded in order, a duplicate name being refused, the summary naming the tasks, a contributed task being started with the config and cancelled at shutdown in both modes, a task that ignores cancellation being abandoned after the shared bound, and a task that raises being logged by name without breaking shutdown.
- `make lint`, `make typecheck`, `uv run pytest tests/unit -q -x -p no:cacheprovider` and the OSS smoke gate `uv run --frozen --no-dev python scripts/oss_edition_smoke.py` all pass locally.
- The integration suite (`make test-integration`) was **not** run locally: the machine this was written on has neither Docker nor a PostgreSQL server, so Testcontainers cannot start. CI runs it. No route, schema, model, or migration changed, so no generated artifact needed regenerating.

To see it by hand, write a bootstrap module on the gateway's `PYTHONPATH`:

```python
# probe_bootstrap.py
import asyncio
from gateway.container import BackgroundTaskContribution, Container
from gateway.log_config import logger

async def tick(config) -> None:
    while True:
        logger.info("probe tick")
        await asyncio.sleep(5)

def register(container: Container) -> None:
    container.contribute_background_task(BackgroundTaskContribution(name="probe", start=tick))
```

Run `OTARI_BOOTSTRAP=probe_bootstrap:register uv run otari serve` and check the startup log: the composition-root line ends in `contributed background tasks probe`, `probe tick` appears every five seconds, and Ctrl+C shuts the process down promptly. Register the same name twice and startup fails with `A background task named 'probe' is already contributed`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #1057
Refs #973

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). (`make test-unit` and the smoke gate locally; the integration half runs in CI, see above.)
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (Not applicable: no route or schema changed.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any additional AI details you'd like to share:** Implemented, tested, and self-reviewed by the agent from the issue's proposed shape. A human should confirm the seam matches what #973 needs before merging.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
