### PR TITLE
feat(core): let a bootstrap contribute an Alembic migration chain

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,6 +162,17 @@ A contributed router is the additive half of the seam, and it is gated rather th
 
 Entitlement is not authentication either, and the mount point adds none. A capability names no caller, so on an entitled deployment a contributed route is reachable by anyone unless the router says otherwise. A contribution declares the credential each of its routes needs on the route, the way Otari's own routers do; there is no router-level default to mount, because the right answer differs per route, a contributed route may be deliberately public, and the header check resolves a database session a hybrid gateway does not have.
 
+A contributed **migration chain** is the other additive half, for a module that owns tables of its own. Its revisions cannot join Otari's chain without editing the repo, and a second `alembic upgrade` on the default `alembic_version` table would fight Otari's over one row, so a bootstrap records an Alembic script directory of its own together with a version table of its own:
+
+```python
+def register(container: Container) -> None:
+    container.contribute_migrations(
+        MigrationContribution(name="alerts", script_location=str(ALERTS_ALEMBIC_DIR), version_table="alerts_alembic_version")
+    )
+```
+
+At startup, with `auto_migrate` on, `init_db` upgrades Otari's own chain to `head` and then each contribution's, on the same database URL, each stamping only the version table it named, so the two histories never interleave. `alembic_version` itself is refused at contribution time, as is a version table or a name another contribution already holds. Hybrid mode skips `init_db`, and therefore contributed chains too: there is no local database. `otari migrate` runs the core chain only; whether it should also run contributed chains is an open question. The `env.py` contract and the foreign-key caution are in [docs/configuration.md](docs/configuration.md#extending-otari-with-a-bootstrap-module).
+
 > **Where this lives in the tree.** The composition root is `src/gateway/container.py`; it is built once per app in `create_app` (`src/gateway/main.py`) and attached to `app.state` beside the other shared resources, so two apps in one process never share one. Ports are resolved from it through dependencies in `src/gateway/api/deps.py`, which is also where the rest of composition is still hand-wired: the container took over the ports, not every dependency, and a plain single-implementation service stays wired directly.
 
 Not every service goes through a port. Most code has a single implementation and stays plain (see [when a capability earns a port](#cardinal-rules-for-contributors)); only capabilities with a real second implementation are resolved through the container.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,7 +167,9 @@ A contributed **migration chain** is the other additive half, for a module that 
 ```python
 def register(container: Container) -> None:
     container.contribute_migrations(
-        MigrationContribution(name="alerts", script_location=str(ALERTS_ALEMBIC_DIR), version_table="alerts_alembic_version")
+        MigrationContribution(
+            name="alerts", script_location=str(ALERTS_ALEMBIC_DIR), version_table="alerts_alembic_version"
+        )
     )
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -359,10 +359,10 @@ chain, so the script needs no URL handling of its own.
 
 Two cautions. A contributed chain must not reference a core table by foreign
 key in a way that would block a core migration: the core chain runs first and
-knows nothing about contributed tables, so a core revision that rebuilds a
-table (SQLite has no `ALTER` for constraints) fails on a constraint it did not
-create. Prefer plain indexed id columns over enforced foreign keys into core
-tables. And `otari migrate` runs the core chain only; a deployment that
+knows nothing about contributed tables, so a core revision that drops or
+rebuilds a table the contribution points at fails on a constraint the core
+chain did not create. Prefer plain indexed id columns over enforced foreign
+keys into core tables. And `otari migrate` runs the core chain only; a deployment that
 migrates with the CLI instead of on startup has to run each contributed chain
 itself for now. Hybrid mode skips database initialization entirely, contributed
 chains included, since it has no local database.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -306,10 +306,63 @@ usage-report timeout and retries, and first-chunk fallback timeout. See
 ## Extending Otari with a bootstrap module
 
 `bootstrap` or `OTARI_BOOTSTRAP` names a trusted `module:callable` loaded
-inside the gateway process. The callable can rebind extension ports and
-contribute capability-gated routers. Most deployments should leave it unset.
+inside the gateway process. The callable can rebind extension ports,
+contribute capability-gated routers, and contribute an Alembic migration chain
+for tables of its own. Most deployments should leave it unset.
 
 This is executable code, not a feature flag. Install the module in the gateway
 environment, pin it to a compatible Otari release, and authenticate every
 contributed route. See [Architecture](../ARCHITECTURE.md) for the extension
 boundary.
+
+### Contributing a migration chain
+
+A module that owns tables records its own Alembic script directory and its own
+version table on the container:
+
+```python
+from gateway.container import Container, MigrationContribution
+
+
+def register(container: Container) -> None:
+    container.contribute_migrations(
+        MigrationContribution(
+            name="alerts",
+            script_location="/opt/alerts/alembic",
+            version_table="alerts_alembic_version",
+        )
+    )
+```
+
+When `auto_migrate` is on (the default), startup upgrades Otari's own chain to
+`head` first and then each contributed chain, on the same database URL. Each
+chain stamps only the version table it named, so the histories never share a
+row. `alembic_version` is Otari's and is refused, as is a version table or a
+name another contribution already claimed; the refusal happens while the
+container is built, before anything touches the database.
+
+The contract for the contributed `env.py` is that it reads the version table
+from the Alembic config and passes it on:
+
+```python
+from alembic import context
+
+config = context.config
+version_table = config.attributes.get("version_table")
+
+# ... build the engine from config.get_section(config.config_ini_section) ...
+context.configure(connection=connection, target_metadata=metadata, version_table=version_table)
+```
+
+Otari sets `sqlalchemy.url` on that config the same way it does for its own
+chain, so the script needs no URL handling of its own.
+
+Two cautions. A contributed chain must not reference a core table by foreign
+key in a way that would block a core migration: the core chain runs first and
+knows nothing about contributed tables, so a core revision that rebuilds a
+table (SQLite has no `ALTER` for constraints) fails on a constraint it did not
+create. Prefer plain indexed id columns over enforced foreign keys into core
+tables. And `otari migrate` runs the core chain only; a deployment that
+migrates with the CLI instead of on startup has to run each contributed chain
+itself for now. Hybrid mode skips database initialization entirely, contributed
+chains included, since it has no local database.

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -112,9 +112,9 @@ class MigrationContribution:
     ``sqlalchemy.url``; the script reads the attribute and hands it to
     ``context.configure(version_table=...)``. A contributed chain must not
     reference a core table by foreign key in a way that would block a core
-    migration: the core chain runs first and knows nothing about the
-    contributed tables, so a core revision that rebuilds a table (SQLite has
-    no ``ALTER`` for constraints) fails on a foreign key it did not create.
+    migration: the core chain runs first and knows nothing about contributed
+    tables, so a core revision that drops or rebuilds a table the contribution
+    points at fails on a constraint the core chain did not create.
 
     ``name`` identifies the chain in the startup log and in errors; it is
     unique among contributions, as is ``version_table``.
@@ -208,11 +208,15 @@ class Container:
         the database.
 
         Raises:
-            MigrationContributionError: If the contribution claims Otari's own
-                version table, or a version table or name another
-                contribution already holds.
+            MigrationContributionError: If a field is blank, if the contribution
+                claims Otari's own version table, or if it claims a version
+                table or name another contribution already holds.
 
         """
+        for field in ("name", "script_location", "version_table"):
+            if not getattr(contribution, field).strip():
+                msg = f"Migration contribution {contribution.name!r} has a blank {field}"
+                raise MigrationContributionError(msg)
         if contribution.version_table == CORE_VERSION_TABLE:
             msg = (
                 f"Migration contribution {contribution.name!r} claims {CORE_VERSION_TABLE!r}, "

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -16,8 +16,9 @@ claim a swap point that does not exist.
 
 An overlay rebinds ports without editing any Otari source file, by pointing
 ``OTARI_BOOTSTRAP`` at a ``module:callable`` selector. The callable receives
-this container after the core defaults are bound, and may rebind any port and
-contribute routers of its own. Unset, the defaults stand.
+this container after the core defaults are bound, and may rebind any port,
+contribute routers of its own, and contribute an Alembic migration chain for
+tables of its own. Unset, the defaults stand.
 """
 
 import importlib
@@ -90,8 +91,46 @@ class RouterContribution:
     router: APIRouter
 
 
+# The version table Otari's own chain stamps (``alembic/env.py`` leaves
+# Alembic's default in place, see #921). A contribution may not claim it.
+CORE_VERSION_TABLE = "alembic_version"
+
+
+@dataclass(frozen=True)
+class MigrationContribution:
+    """One Alembic chain an overlay runs against Otari's database, after Otari's own.
+
+    A module a bootstrap loads may own tables of its own. Its revisions cannot
+    join Otari's chain without editing the repo, and a second ``upgrade`` on the
+    default version table would fight Otari's over one row, so a contribution
+    brings its own script directory and its own ``version_table``, and the two
+    histories never interleave. ``init_db`` runs Otari's chain to ``head``
+    first, then each contribution's, on the same database URL.
+
+    The contract for the contributed ``env.py``: Otari passes the table name
+    as ``config.attributes["version_table"]`` and the URL as
+    ``sqlalchemy.url``; the script reads the attribute and hands it to
+    ``context.configure(version_table=...)``. A contributed chain must not
+    reference a core table by foreign key in a way that would block a core
+    migration: the core chain runs first and knows nothing about the
+    contributed tables, so a core revision that rebuilds a table (SQLite has
+    no ``ALTER`` for constraints) fails on a foreign key it did not create.
+
+    ``name`` identifies the chain in the startup log and in errors; it is
+    unique among contributions, as is ``version_table``.
+    """
+
+    name: str
+    script_location: str
+    version_table: str
+
+
 class ContainerError(Exception):
     """Base error for composition-root wiring failures."""
+
+
+class MigrationContributionError(ContainerError):
+    """Raised when a contributed migration chain would collide with another chain."""
 
 
 class PortNotBoundError(ContainerError):
@@ -119,6 +158,7 @@ class Container:
     def __init__(self) -> None:
         self._factories: dict[Any, PortFactory[Any]] = {}
         self._router_contributions: list[RouterContribution] = []
+        self._migration_contributions: list[MigrationContribution] = []
         # One line naming what this container was built from, logged by
         # build_container and asserted on by tests.
         self.summary = "unbuilt"
@@ -159,6 +199,41 @@ class Container:
     def router_contributions(self) -> tuple[RouterContribution, ...]:
         """Return the recorded router contributions, in contribution order."""
         return tuple(self._router_contributions)
+
+    def contribute_migrations(self, contribution: MigrationContribution) -> None:
+        """Record an Alembic chain ``init_db`` runs after Otari's own.
+
+        Refused at contribution time rather than at first boot, so a colliding
+        bootstrap fails while the container is being built and never reaches
+        the database.
+
+        Raises:
+            MigrationContributionError: If the contribution claims Otari's own
+                version table, or a version table or name another
+                contribution already holds.
+
+        """
+        if contribution.version_table == CORE_VERSION_TABLE:
+            msg = (
+                f"Migration contribution {contribution.name!r} claims {CORE_VERSION_TABLE!r}, "
+                "which is Otari's own version table; a contributed chain stamps a table of its own"
+            )
+            raise MigrationContributionError(msg)
+        for recorded in self._migration_contributions:
+            if recorded.version_table == contribution.version_table:
+                msg = (
+                    f"Migration contribution {contribution.name!r} claims version table "
+                    f"{contribution.version_table!r}, already held by {recorded.name!r}"
+                )
+                raise MigrationContributionError(msg)
+            if recorded.name == contribution.name:
+                msg = f"Migration contribution {contribution.name!r} is already recorded"
+                raise MigrationContributionError(msg)
+        self._migration_contributions.append(contribution)
+
+    def migration_contributions(self) -> tuple[MigrationContribution, ...]:
+        """Return the recorded migration contributions, in contribution order."""
+        return tuple(self._migration_contributions)
 
 
 def _billing_adapter(session: AsyncSession | None) -> BillingPort:
@@ -249,7 +324,7 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
     """Build the composition-root container for this deployment.
 
     Binds the core adapters, then, if a selector is given, lets the bootstrap it
-    names rebind ports and contribute routers. With no selector the core
+    names rebind ports and contribute routers and migration chains. With no selector the core
     defaults stand and Otari boots standalone.
 
     Raises:
@@ -320,6 +395,9 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
     contributed = ", ".join(contribution.capability for contribution in container.router_contributions())
     if contributed:
         container.summary += f", contributed routers for {contributed}"
+    chains = ", ".join(contribution.name for contribution in container.migration_contributions())
+    if chains:
+        container.summary += f", contributed migration chains {chains}"
     logger.info("Composition root: %s", container.summary)
     return container
 

--- a/src/gateway/core/database.py
+++ b/src/gateway/core/database.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from alembic import command
 from alembic.config import Config
@@ -19,6 +19,9 @@ from sqlalchemy.pool import NullPool
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+
+if TYPE_CHECKING:
+    from gateway.container import MigrationContribution
 
 _engine: AsyncEngine | None = None
 _SessionLocal: async_sessionmaker[AsyncSession] | None = None
@@ -82,13 +85,35 @@ def to_sync_url(database_url: str) -> str:
     return url.set(drivername=sync_drivername).render_as_string(hide_password=False)
 
 
-def _run_migrations(database_url: str) -> None:
+def _alembic_config(script_location: str, database_url: str) -> Config:
     alembic_cfg = Config()
-    alembic_dir = Path(__file__).resolve().parents[3] / "alembic"
-    alembic_cfg.set_main_option("script_location", str(alembic_dir))
+    alembic_cfg.set_main_option("script_location", script_location)
     alembic_cfg.set_main_option("sqlalchemy.url", database_url)
     alembic_cfg.attributes["configure_logger"] = False
-    command.upgrade(alembic_cfg, "head")
+    return alembic_cfg
+
+
+def _run_migrations(database_url: str, contributions: Iterable[MigrationContribution] = ()) -> None:
+    """Upgrade Otari's own chain to ``head``, then each contributed chain in turn.
+
+    Every chain runs against the same URL. A contributed chain keeps its history
+    in the version table its contribution names, handed to its ``env.py`` as
+    ``config.attributes["version_table"]``, which that script passes to
+    ``context.configure(version_table=...)``. Otari's own ``env.py`` reads no
+    such attribute and stays on Alembic's default table, so the histories never
+    share a row.
+    """
+    alembic_dir = Path(__file__).resolve().parents[3] / "alembic"
+    command.upgrade(_alembic_config(str(alembic_dir), database_url), "head")
+    for contribution in contributions:
+        logger.info(
+            "Running contributed migration chain %s (version table %s)",
+            contribution.name,
+            contribution.version_table,
+        )
+        alembic_cfg = _alembic_config(contribution.script_location, database_url)
+        alembic_cfg.attributes["version_table"] = contribution.version_table
+        command.upgrade(alembic_cfg, "head")
 
 
 def _configure_sqlite_pragmas(engine: AsyncEngine) -> None:
@@ -250,8 +275,14 @@ def engine_kwargs(
     return kwargs
 
 
-def init_db(config: GatewayConfig) -> None:
-    """Initialize async database engine and optionally run migrations."""
+def init_db(config: GatewayConfig, *, migration_contributions: Iterable[MigrationContribution] = ()) -> None:
+    """Initialize async database engine and optionally run migrations.
+
+    With ``auto_migrate`` on, Otari's own chain runs first and then each of
+    ``migration_contributions`` (recorded on the container by a bootstrap, see
+    ``gateway.container.MigrationContribution``). ``otari migrate`` runs the
+    core chain only.
+    """
 
     global _engine, _SessionLocal, _log_engine, _LogSessionLocal  # noqa: PLW0603
 
@@ -300,7 +331,7 @@ def init_db(config: GatewayConfig) -> None:
         _LogSessionLocal = async_sessionmaker(_log_engine, expire_on_commit=False)
 
     if config.auto_migrate:
-        _run_migrations(database_url)
+        _run_migrations(database_url, migration_contributions)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
-from gateway.container import build_container
+from gateway.container import Container, build_container
 from gateway.core.config import API_KEY_HEADER, API_ROOT, GATEWAY_TOKEN_HEADER, X_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, dispose_db, init_db
 from gateway.dashboard import DASHBOARD_PACKAGE_PATH, get_dashboard_build_id, get_dashboard_dir
@@ -352,7 +352,12 @@ def _create_lifespan() -> Callable[[FastAPI], Any]:
         if config.is_hybrid_mode:
             log_writer = NoopLogWriter()
         else:
-            init_db(config)
+            # Contributed chains run after Otari's own, so a bootstrap's tables
+            # exist before the first request reaches its routers. create_app
+            # always attaches a container; an app assembled by hand (as some
+            # tests do) may not have one, and then only the core chain runs.
+            container: Container | None = getattr(app.state, "container", None)
+            init_db(config, migration_contributions=container.migration_contributions() if container else ())
             async with create_session() as session:
                 # Persisted dashboard overrides win over config/env; apply them
                 # before pricing init so default-pricing behavior is consistent.

--- a/tests/fixtures/plugin_alembic/env.py
+++ b/tests/fixtures/plugin_alembic/env.py
@@ -1,0 +1,30 @@
+"""A contributed chain's ``env.py``, honoring the contract ``init_db`` documents.
+
+Otari hands the URL over as ``sqlalchemy.url`` and the version table as
+``config.attributes["version_table"]``; this script passes the table to
+``context.configure`` so the chain's history never touches Otari's own row.
+"""
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+# Absent means a bare ``alembic`` run outside Otari, where Alembic's default
+# stands. Through ``init_db`` the attribute is always set.
+version_table = config.attributes.get("version_table")
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=None, version_table=version_table)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+run_migrations_online()

--- a/tests/fixtures/plugin_alembic/versions/c0ffee000001_create_plugin_demo.py
+++ b/tests/fixtures/plugin_alembic/versions/c0ffee000001_create_plugin_demo.py
@@ -1,0 +1,29 @@
+"""create plugin_demo
+
+Revision ID: c0ffee000001
+Revises:
+Create Date: 2026-09-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c0ffee000001"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plugin_demo",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("label", sa.String(length=64), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("plugin_demo")

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -24,6 +24,8 @@ from gateway.adapters.telemetry_storage_adapter import DatabaseTelemetryStorageA
 from gateway.container import (
     BootstrapError,
     Container,
+    MigrationContribution,
+    MigrationContributionError,
     PortNotBoundError,
     RouterContribution,
     build_container,
@@ -96,6 +98,7 @@ def test_no_selector_contributes_no_routers_and_says_so() -> None:
     container = build_container()
 
     assert container.router_contributions() == ()
+    assert container.migration_contributions() == ()
     assert container.summary.startswith("no bootstrap, core defaults for ")
     for port in (
         BillingPort,
@@ -300,3 +303,71 @@ def test_router_contributions_keep_their_order() -> None:
     container.contribute_router(second)
 
     assert container.router_contributions() == (first, second)
+
+
+def _chain(name: str, version_table: str) -> MigrationContribution:
+    return MigrationContribution(name=name, script_location=f"/plugins/{name}/alembic", version_table=version_table)
+
+
+def test_migration_contributions_are_recorded_in_order() -> None:
+    container = Container()
+    first = _chain("one", "one_alembic_version")
+    second = _chain("two", "two_alembic_version")
+
+    container.contribute_migrations(first)
+    container.contribute_migrations(second)
+
+    assert container.migration_contributions() == (first, second)
+
+
+def test_a_migration_contribution_may_not_claim_the_core_version_table() -> None:
+    container = Container()
+
+    with pytest.raises(MigrationContributionError, match="Otari's own version table"):
+        container.contribute_migrations(_chain("greedy", "alembic_version"))
+
+    assert container.migration_contributions() == ()
+
+
+def test_two_migration_contributions_may_not_share_a_version_table() -> None:
+    container = Container()
+    container.contribute_migrations(_chain("one", "shared_alembic_version"))
+
+    with pytest.raises(MigrationContributionError, match="already held by 'one'"):
+        container.contribute_migrations(_chain("two", "shared_alembic_version"))
+
+    assert [contribution.name for contribution in container.migration_contributions()] == ["one"]
+
+
+def test_two_migration_contributions_may_not_share_a_name() -> None:
+    container = Container()
+    container.contribute_migrations(_chain("one", "one_alembic_version"))
+
+    with pytest.raises(MigrationContributionError, match="'one' is already recorded"):
+        container.contribute_migrations(_chain("one", "other_alembic_version"))
+
+
+def test_bootstrap_contributes_a_migration_chain_and_the_summary_names_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "chain_bootstrap",
+        """
+from gateway.container import Container, MigrationContribution
+
+
+def register(container: Container) -> None:
+    container.contribute_migrations(
+        MigrationContribution(
+            name="alerts", script_location="/plugins/alerts/alembic", version_table="alerts_alembic_version"
+        )
+    )
+""",
+    )
+
+    container = build_container("chain_bootstrap:register")
+
+    assert [contribution.name for contribution in container.migration_contributions()] == ["alerts"]
+    assert container.summary == "chain_bootstrap:register rebound no ports, contributed migration chains alerts"

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -371,3 +371,15 @@ def register(container: Container) -> None:
 
     assert [contribution.name for contribution in container.migration_contributions()] == ["alerts"]
     assert container.summary == "chain_bootstrap:register rebound no ports, contributed migration chains alerts"
+
+
+@pytest.mark.parametrize("field", ["name", "script_location", "version_table"])
+def test_a_migration_contribution_with_a_blank_field_is_refused(field: str) -> None:
+    container = Container()
+    values = {"name": "one", "script_location": "/plugins/one/alembic", "version_table": "one_alembic_version"}
+    values[field] = "   "
+
+    with pytest.raises(MigrationContributionError, match=f"blank {field}"):
+        container.contribute_migrations(MigrationContribution(**values))
+
+    assert container.migration_contributions() == ()

--- a/tests/unit/test_contributed_migrations.py
+++ b/tests/unit/test_contributed_migrations.py
@@ -1,0 +1,101 @@
+"""A bootstrap's own Alembic chain runs on startup, beside Otari's and never in it.
+
+``init_db`` upgrades Otari's chain to ``head`` and then each contributed chain,
+on the same database, each stamping the version table its contribution names.
+The fixture chain under ``tests/fixtures/plugin_alembic`` is the shape a plugin
+ships: an ``env.py`` honoring the ``version_table`` attribute and one revision
+creating a table of its own.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+
+from gateway.container import MigrationContribution
+from gateway.core.config import GatewayConfig
+from gateway.core.database import init_db, reset_db
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORE_ALEMBIC = _REPO_ROOT / "alembic"
+_PLUGIN_ALEMBIC = _REPO_ROOT / "tests" / "fixtures" / "plugin_alembic"
+
+PLUGIN = MigrationContribution(
+    name="plugin_demo",
+    script_location=str(_PLUGIN_ALEMBIC),
+    version_table="plugin_demo_alembic_version",
+)
+
+
+def _head(script_location: Path) -> str:
+    config = Config()
+    config.set_main_option("script_location", str(script_location))
+    head = ScriptDirectory.from_config(config).get_current_head()
+    assert head is not None
+    return head
+
+
+def _tables(url: str) -> set[str]:
+    engine = create_engine(url)
+    try:
+        return set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def _version_rows(url: str, version_table: str) -> list[str]:
+    engine = create_engine(url)
+    try:
+        with engine.connect() as connection:
+            return [row[0] for row in connection.execute(text(f"SELECT version_num FROM {version_table}"))]
+    finally:
+        engine.dispose()
+
+
+def test_init_db_runs_the_core_chain_then_each_contributed_chain(tmp_path: Path) -> None:
+    url = f"sqlite:///{tmp_path / 'with-plugin.db'}"
+
+    init_db(GatewayConfig(database_url=url, auto_migrate=True), migration_contributions=(PLUGIN,))
+    reset_db()
+
+    # Core schema and the plugin's table, side by side in one database.
+    assert {"users", "api_keys", "plugin_demo"} <= _tables(url)
+    # Each chain's history lives in its own table and holds only its own head.
+    assert _version_rows(url, "alembic_version") == [_head(_CORE_ALEMBIC)]
+    assert _version_rows(url, PLUGIN.version_table) == [_head(_PLUGIN_ALEMBIC)]
+
+
+def test_init_db_with_no_contribution_leaves_no_contributed_table(tmp_path: Path) -> None:
+    url = f"sqlite:///{tmp_path / 'core-only.db'}"
+
+    init_db(GatewayConfig(database_url=url, auto_migrate=True))
+    reset_db()
+
+    tables = _tables(url)
+    assert "users" in tables
+    assert "plugin_demo" not in tables
+    assert PLUGIN.version_table not in tables
+
+
+def test_a_second_boot_finds_both_chains_at_head(tmp_path: Path) -> None:
+    """Re-running is idempotent: neither chain re-applies or re-stamps."""
+    url = f"sqlite:///{tmp_path / 'twice.db'}"
+    config = GatewayConfig(database_url=url, auto_migrate=True)
+
+    for _ in range(2):
+        init_db(config, migration_contributions=(PLUGIN,))
+        reset_db()
+
+    assert _version_rows(url, "alembic_version") == [_head(_CORE_ALEMBIC)]
+    assert _version_rows(url, PLUGIN.version_table) == [_head(_PLUGIN_ALEMBIC)]
+
+
+def test_auto_migrate_off_runs_no_chain(tmp_path: Path) -> None:
+    db_path = tmp_path / "no-migrate.db"
+
+    init_db(GatewayConfig(database_url=f"sqlite:///{db_path}", auto_migrate=False), migration_contributions=(PLUGIN,))
+    reset_db()
+
+    # The async engine is lazy, so with no chain run nothing has created the file.
+    assert not db_path.exists()


### PR DESCRIPTION
## Description

A module loaded through `OTARI_BOOTSTRAP` can now own database tables of its own. Until now, a bootstrap could rebind ports and add routers, but its tables had nowhere to go: its migrations could not join Otari's chain without editing this repo, and running a second Alembic upgrade against the same database would have fought Otari's over the shared `alembic_version` row.

A bootstrap now records a migration contribution: a name, its own Alembic script directory, and its own version table. With auto-migration on, startup upgrades Otari's own chain first and then each contributed chain, on the same database, each stamping only the version table it named, so the two histories never interleave. Claiming `alembic_version`, or a version table or name another contribution already holds, is refused while the container is built, before anything touches the database. Hybrid mode skips database initialization and therefore contributed chains too, which is correct: it has no local database.

This is one of four seams needed for budget alerts (#973, two new tables) to ship as a plugin rather than in core. Refs #973.

The contract for the contributed `env.py` (read `config.attributes["version_table"]` and pass it to `context.configure`) and a caution against foreign keys into core tables are documented in `docs/configuration.md` and `ARCHITECTURE.md`.

**Known gap, left to settle:** `otari migrate` still runs the core chain only, as a subprocess. Contributed chains run on startup auto-migration only. A deployment that migrates with the CLI has to run each contributed chain itself for now; the docs say so.

Core keeps stamping `alembic_version` (#921 is not addressed here). Refs #921.

## How to test it locally

Automated:

- `uv run pytest tests/unit/test_container.py tests/unit/test_contributed_migrations.py -q`: the container refuses the reserved and duplicate version tables and names contributed chains in its summary; `init_db` on a throwaway SQLite file against the fixture chain under `tests/fixtures/plugin_alembic/` leaves the core schema, a `plugin_demo` table, the contributed head in `plugin_demo_alembic_version`, and only core's head in `alembic_version`. A second boot is idempotent, and `auto_migrate=False` runs nothing.
- `make lint`, `make typecheck`, `uv run pytest tests/unit -q` (3173 passed locally) and the OSS-edition smoke gate `uv run --frozen --no-dev python scripts/oss_edition_smoke.py` all pass locally.
- The integration suite (`make test-integration`) was **not** run locally: the machine this was developed on has no Docker and no PostgreSQL, so it cannot start. CI runs it.

By hand, if you want to see it in a running gateway: write a module with a `register(container)` that calls `container.contribute_migrations(MigrationContribution(name=..., script_location=..., version_table=...))` pointing at `tests/fixtures/plugin_alembic`, put it on `PYTHONPATH`, set `OTARI_BOOTSTRAP=module:register`, start `otari serve` against a fresh SQLite file, and check that the startup log names the chain and that the database holds `plugin_demo` and `plugin_demo_alembic_version` alongside `alembic_version`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #1058
Refs #921
Refs #973

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). (Unit suite, lint, typecheck and the smoke gate locally; integration suite left to CI, see above.)
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No route or schema changed, so nothing to regenerate.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5.1 via Claude Code

**Any additional AI details you'd like to share:** Implemented, tested and self-reviewed by the agent from the issue text; a human is expected to review before merge.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
