### PR TITLE
docs: give every fenced block a language

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -56,7 +56,7 @@ providers:
 
 Models are addressed as `openai:<model>`:
 
-```
+```text
 openai:gpt-4o
 openai:gpt-4o-mini
 openai:o4-mini
@@ -83,7 +83,7 @@ print(resp.choices[0].message.content)
 
 Expected (sample) output:
 
-```
+```text
 Hello, nice to meet you!
 ```
 

--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -31,7 +31,7 @@ band" rule wants the friction to point: the accent has to be asked for.
   destructive button read as a second primary, which is the whole reason it is not
   one.
 
-```
+```text
 Is it the single thing this band is for?
  ├── Yes -> variant="primary"          (two in one band means the band has no hierarchy)
  └── No

--- a/web/design/colors.md
+++ b/web/design/colors.md
@@ -24,7 +24,7 @@ not a duplicate to collapse.
 
 What background do I use?
 
-```
+```text
 Is it the page itself, the rail, or the top bar?
  ├── Yes -> bg-background   (the shell is flat; hairlines divide it, not levels)
  └── No

--- a/web/design/data.md
+++ b/web/design/data.md
@@ -2,7 +2,7 @@
 
 ## Which shape?
 
-```
+```text
 Is it a list of records with more than one attribute each?
  └── DataTable, inside a TableScrollFrame if it is wide
 Anything else on this list is a metric, and lives in [metrics.md](metrics.md):

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -5,7 +5,7 @@ what happened, what the system did about it, and the one control that fixes it.
 
 ## Which one?
 
-```
+```text
 Did a request fail?
  └── ErrorBanner            (it sanitizes the error; see below)
 Is there a standing condition the operator should know about?

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -7,7 +7,7 @@ border is what makes it an object. HeroUI defaults `--field-border-width` to 0;
 
 ## Which control?
 
-```
+```text
 Is it free text, a number, or a date?
  ├── Is the value a secret (a provider key, a password)?
  │    ├── Collecting one -> SecretField   (masked, never prefilled, autofill off)

--- a/web/design/layout.md
+++ b/web/design/layout.md
@@ -69,7 +69,7 @@ live on 4 pages; see [DESIGN.md](DESIGN.md).
 
 A table page, in order:
 
-```
+```text
 PageIntro          title, sentence, one primary action
 KpiStrip           optional, ruled above and below
 Toolbar            search, filters, refresh. FilterChips goes INSIDE it, and
@@ -82,7 +82,7 @@ TablePagination    range, page size, two bare arrows. No rule under it
 
 A form page, in order:
 
-```
+```text
 PageIntro
 TabRow             only if the page has sibling surfaces
 InfoBanner         only if there is a standing condition to state
@@ -91,7 +91,7 @@ SettingsGroup      one per topic, each with its own Save at its own foot
 
 An autosaving settings page, which is the other shape:
 
-```
+```text
 PageIntro          title, sentence, a trailing docsHref
 SettingsGroup      bounded, one per topic
   SettingRow       label + key left, control right
@@ -106,7 +106,7 @@ so no single button could say what it is about to write.
 A list-and-detail page, which is the shape for a set of records where reading
 one is most of the work:
 
-```
+```text
 PageIntro          title, sentence. No action: the create control goes in the
                    list column, because that is the column it lengthens
 ErrorBanner        only if a read failed

--- a/web/design/metrics.md
+++ b/web/design/metrics.md
@@ -3,7 +3,7 @@
 The numbers a page leads with, and the marks that qualify them. Tables are in
 [data.md](data.md).
 
-```
+```text
 Is it a handful of headline numbers for the whole page?
  └── KpiStrip + KpiCell            (never StatCard; see DESIGN.md)
 Is it one number's change over a period?

--- a/web/design/module-map.md
+++ b/web/design/module-map.md
@@ -67,7 +67,7 @@ they are called out below so nobody mistakes them for the system's own vocabular
 
 ## Target tree
 
-```
+```text
 shared/components/
 ├── layout/       ← design/layout.md
 ├── metrics/      ← design/metrics.md
@@ -254,7 +254,7 @@ nested under `MODELS`; `ORGANIZATION_BUDGETS` keyed apart from `BUDGETS`).
 One module per domain, and `hooks` dropped from the path: under `api/` every export
 is already a hook, so the segment names nothing.
 
-```
+```text
 shared/api/
   client.ts        unchanged
   queryKeys.ts     all 60 constants. MUST stay one module

--- a/web/design/navigation.md
+++ b/web/design/navigation.md
@@ -2,7 +2,7 @@
 
 Three ways to switch, and they are not interchangeable.
 
-```
+```text
 Does the choice change what the page shows, as a sibling surface?
  └── TabRow            (Overview / Members / Domains)
 Is it a closed set of alternatives to one value?

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -3,7 +3,7 @@
 Three components put something on top of the page, and picking the wrong one is
 the most common mistake here, so start with the question rather than the list.
 
-```
+```text
 Does the operator need to interact with what appears?
  ├── No, it is a label for the thing they are pointing at
  │    └── Tooltip                  (hover/focus, no focus of its own)

--- a/web/design/typography.md
+++ b/web/design/typography.md
@@ -41,7 +41,7 @@ disabled.
 
 ## Which role?
 
-```
+```text
 Is it the name of the route?
  ├── Yes -> text-display                (one per page, nothing on the page is larger)
  └── No


### PR DESCRIPTION
## Description

Seventeen fenced code blocks across twelve files opened with a bare ` ``` ` and no language. All of them are prose rather than code, so they take `text`: the decision trees that open each design topic, the module and directory diagrams in `module-map.md` and `layout.md`, the list of model ids in the OpenAI provider guide, and one sample of assistant output in the same file.

`text` rather than a guess at a language, because that is what says "do not highlight this" instead of leaving each reader's tooling to decide. The blocks that hold real code already carry `tsx` and are untouched.

**Being precise about what this fixes:** there is no markdownlint config in the repo and no CI job that runs it, so nothing here was failing. The rule (MD040) came up as a review comment from CodeRabbit's own linters on a stacked PR, against a file that PR did not touch. Rather than fix the one block a bot happened to anchor on, this does the whole class: I walked every `.md` in the repo outside `node_modules`, and after this change **zero** bare opening fences remain.

The diff is exactly seventeen lines each way, all of them the fence itself:

    17 -```
    17 +```text

## How to test it locally

Read the diff; it is one token per block. To confirm the class is closed rather than sampled:

```bash
python3 - <<'PY'
import pathlib
bad = {}
for f in pathlib.Path(".").rglob("*.md"):
    if any(x in f.parts for x in ("node_modules", ".git", "storybook-static", ".venv")):
        continue
    inside = False
    hits = []
    for i, line in enumerate(f.read_text(errors="ignore").split("\n")):
        if line.startswith("```"):
            if not inside:
                inside = True
                if line.strip() == "```":
                    hits.append(i + 1)
            else:
                inside = False
    if hits:
        bad[str(f)] = hits
print(bad or "no bare opening fences")
PY
```

It prints `no bare opening fences` on this branch and eleven files on `main`.

Nothing else applies: the change adds no code, and the checks that could see a Markdown-only diff under `web/design/` and `docs/` do not exist.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. It came out of a review comment on an unrelated stacked PR, and it is too small to warrant an issue to point at.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). **Not applicable:** the change is one token per fenced block in Markdown. A test asserting it would be a reimplementation of markdownlint, and if this is worth enforcing then the answer is markdownlint in CI, not a bespoke test.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` passes. Being precise: the other two cannot be affected by a Markdown-only change, so their result says nothing about it either way.
- [x] Documentation was updated where necessary. This is only documentation.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API change.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The seventeen were found by walking the fences and tracking open/closed state rather than by grepping for ` ``` `, which cannot tell an opening fence from a closing one and would have "found" every block in the repo. Each block was read before its language was chosen.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `text` labels to 17 Markdown code blocks across 12 documentation files.
- Preserved all block content and existing `tsx` blocks.
- Removed bare opening fences from the affected Markdown files.
- Improved consistent rendering of prose, diagrams, model IDs, and sample output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->