### PR TITLE
feat(dashboard): move the member add and invite forms into FormDialog

### DIFF
--- a/web/e2e/parity.tenancy.spec.ts
+++ b/web/e2e/parity.tenancy.spec.ts
@@ -118,9 +118,12 @@ test.describe("standalone tenancy", () => {
     await openPage(page, "Members & roles", "Members")
 
     await page.getByRole("button", { name: "Add member" }).click()
-    await page.getByLabel("Email address").fill(MEMBER_EMAIL)
-    await pickOption(page, "Role", "Member")
-    await page.getByRole("button", { name: "Add member" }).click()
+    // Scoped: the heading's trigger and the dialog's submit both say "Add
+    // member", so an unscoped press is ambiguous.
+    const addDialog = page.getByRole("dialog", { name: "New member" })
+    await addDialog.getByLabel("Email address").fill(MEMBER_EMAIL)
+    await pickOption(page, "Role", "Member", addDialog)
+    await addDialog.getByRole("button", { name: "Add member" }).click()
 
     // Nothing is emailed and nothing has to be accepted: this edition answers
     // on the "active" arm of the platform's result union, so the row is live
@@ -149,8 +152,9 @@ test.describe("standalone tenancy", () => {
     // second one, which is also what lets this spec run twice against one
     // gateway.
     await page.getByRole("button", { name: "Add member" }).click()
-    await page.getByLabel("Email address").fill(MEMBER_EMAIL)
-    await page.getByRole("button", { name: "Add member" }).click()
+    const readdDialog = page.getByRole("dialog", { name: "New member" })
+    await readdDialog.getByLabel("Email address").fill(MEMBER_EMAIL)
+    await readdDialog.getByRole("button", { name: "Add member" }).click()
     await expect(memberRow(page, MEMBER_EMAIL)).toHaveCount(1)
 
     // Leave the roster as this spec found it.

--- a/web/src/features/organization/OrganizationMembersPage.test.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.test.tsx
@@ -287,8 +287,9 @@ describe("OrganizationMembersPage", () => {
     await pickOption(user, "Role", "Admin")
     // Ticked by default, since a member in no workspace can reach nothing.
     expect(await screen.findByLabelText("Production")).toBeChecked()
-    // The header action hides itself while the form is open, so the remaining
-    // button of this name is the form's own submit.
+    // The header action stays on screen but the open dialog hides the page
+    // behind it from the accessibility tree, so the one button of this name
+    // left to find is the dialog's own submit.
     await user.click(screen.getByRole("button", { name: "Add member" }))
 
     const post = requests.find((request) => request.method === "POST")
@@ -298,6 +299,60 @@ describe("OrganizationMembersPage", () => {
       role: "admin",
       workspace_assignments: [{ workspace_id: "ws-1", role: "member" }],
     })
+  })
+
+  it("keeps both header triggers on screen while a dialog is open", async () => {
+    // The dialog sits over the page rather than replacing the pair, so neither
+    // control vanishes from under the pointer while one of them is open.
+    mockApi({ members: [OWNER] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    const add = await screen.findByRole("button", { name: "Add member" })
+    const invite = screen.getByRole("button", { name: "Invite member" })
+    await user.click(add)
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(add).toBeVisible()
+    expect(invite).toBeVisible()
+  })
+
+  it("opens each dialog on a blank draft, not on the last one typed", async () => {
+    // Reset on the way in: clearing on the way out would blank the fields
+    // while the dialog is still animating away.
+    mockApi({ members: [OWNER] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Add member" }))
+    await user.type(screen.getByLabelText("Email address"), "ada@example.com")
+    // A draft this far along is dirty, so the way out is through the guard.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Add member" }))
+    expect(await screen.findByLabelText("Email address")).toHaveValue("")
+  })
+
+  it("reads nothing on its own account for the two closed dialogs", async () => {
+    // Both forms are mounted from the first paint now, so anything they read
+    // would be read on page load. Today they read only the workspace list the
+    // page itself needs, which is why one GET serves all three.
+    const requests = mockApi({
+      members: [OWNER],
+      workspaces: [workspace({ id: "ws-1", name: "Production" })],
+    })
+    renderPage(<OrganizationMembersPage />)
+
+    await screen.findByRole("button", { name: "Add member" })
+    await waitFor(() =>
+      expect(
+        requests.filter((request) =>
+          request.url.startsWith(`${API_ROOT}/workspaces?`),
+        ),
+      ).toHaveLength(1),
+    )
   })
 
   it("leaves the default alone once the operator has cleared it", async () => {
@@ -391,8 +446,11 @@ describe("OrganizationMembersPage", () => {
     })
 
     // mail_sent is false in the mocked response, so the link is offered to
-    // share by hand rather than the form just closing.
-    expect(await screen.findByText("Invitation sent")).toBeInTheDocument()
+    // share by hand rather than the form just closing, and the dialog says the
+    // email did not go out rather than claiming it did.
+    expect(
+      await screen.findByText(/Otari did not send the email/),
+    ).toBeInTheDocument()
     expect(
       screen.getByText("/#/accept-invitation?token=abc123"),
     ).toBeInTheDocument()

--- a/web/src/features/organization/OrganizationMembersPage.test.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.test.tsx
@@ -422,6 +422,57 @@ describe("OrganizationMembersPage", () => {
     ).toBeInTheDocument()
   })
 
+  it("guards a role change on the add form, with no address typed", async () => {
+    // The guard reads one snapshot of the whole draft. It read the address
+    // alone, so changing the role, or unticking the seeded workspace the form
+    // itself warns about, was discarded with nothing asked.
+    mockApi({
+      members: [OWNER],
+      workspaces: [workspace({ id: "ws-1", name: "Production" })],
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Add member" }))
+    await pickOption(user, "Role", "Admin")
+
+    // Through Cancel: in jsdom focus lands on `<body>` after picking from a
+    // `Select`, so a keystroke reaches nothing.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(
+      await screen.findByRole("button", { name: "Discard" }),
+    ).toBeInTheDocument()
+  })
+
+  it("guards an unticked workspace on the invite form, and reopens clean", async () => {
+    mockApi({
+      members: [OWNER],
+      workspaces: [workspace({ id: "ws-1", name: "Production" })],
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Invite member" }),
+    )
+    // Seeded once the roster answers, which is after mount: unticking it is a
+    // change, and the seed it is compared against is the ticked default.
+    const production = await screen.findByLabelText("Production")
+    expect(production).toBeChecked()
+    await user.click(production)
+
+    await user.keyboard("{Escape}")
+    await user.click(await screen.findByRole("button", { name: "Discard" }))
+
+    // And the roster landing is not itself a change: the reopened form is
+    // clean, so Escape closes it rather than asking.
+    await user.click(screen.getByRole("button", { name: "Invite member" }))
+    await screen.findByLabelText("Production")
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+  })
+
   it("invites a member by email and shows the accept link when mail is not configured", async () => {
     const requests = mockApi({ members: [OWNER] })
     const user = userEvent.setup()
@@ -434,7 +485,13 @@ describe("OrganizationMembersPage", () => {
       screen.getByText(/Invitation email is unavailable/),
     ).toBeInTheDocument()
     await user.type(screen.getByLabelText("Email address"), "ada@example.com")
-    await user.click(screen.getByRole("button", { name: "Send invitation" }))
+    // Scoped: the trigger and the submit say the same thing, which is the label
+    // rule, so an unscoped press is ambiguous.
+    await user.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Invite member",
+      }),
+    )
 
     const post = requests.find(
       (request) =>

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -25,6 +25,7 @@ import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
+import { Select } from "@/design-system/forms/Select"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
@@ -248,11 +249,12 @@ function AddMemberForm({
           autoFocus
           description="The handle this identity is claimed by. Nothing is emailed here; the membership is active straight away. Use Invite member instead to email an accept link."
         />
-        <FilterSelect
+        <Select
           label="Role"
           value={role}
           onChange={(value) => setRole(asMembershipRole(value) ?? "member")}
           options={ROLE_OPTIONS}
+          reserveMessage={false}
         />
       </div>
       {workspaces.data && workspaces.data.length > 0 ? (
@@ -412,11 +414,12 @@ function InviteMemberForm({
               : "Invitation email is unavailable, so you will get a link to share with them yourself."
           }
         />
-        <FilterSelect
+        <Select
           label="Role"
           value={role}
           onChange={(value) => setRole(asMembershipRole(value) ?? "member")}
           options={ROLE_OPTIONS}
+          reserveMessage={false}
         />
       </div>
       {workspaces.data && workspaces.data.length > 0 ? (

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 
 import type {
   User as ApiUser,
@@ -188,6 +188,11 @@ function AddMemberForm({
   // and behaves like one with nothing in it.
   const rows = workspaces.data
   const [seeded, setSeeded] = useState(false)
+  // Everything the operator can change, against what the form was seeded with.
+  // A list of fields drifts: this one read the address alone, so a role or a
+  // workspace change with no address typed closed unguarded.
+  const draft = JSON.stringify({ email, role, workspaceIds })
+  const seededDraft = useRef(draft)
   if (!seeded && rows && rows.length > 0) {
     setSeeded(true)
     // The workspace the shell is on, when it is one of this organization's.
@@ -196,7 +201,16 @@ function AddMemberForm({
     const preferred = rows.find(
       (workspace) => workspace.id === selected?.workspace_id,
     )
-    setWorkspaceIds([(preferred ?? rows[0]).id])
+    const defaults = [(preferred ?? rows[0]).id]
+    setWorkspaceIds(defaults)
+    // Part of the seed, not a change: this lands after mount, so a snapshot
+    // taken at first render would report the form dirty the moment the roster
+    // answers, and Escape would ask before closing an untouched form.
+    seededDraft.current = JSON.stringify({
+      email,
+      role,
+      workspaceIds: defaults,
+    })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>
@@ -236,7 +250,7 @@ function AddMemberForm({
       onSubmit={submit}
       isPending={add.isPending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={trimmed !== ""}
+      isDirty={draft !== seededDraft.current}
       error={add.error}
     >
       <div className="grid gap-4 sm:grid-cols-2">
@@ -314,12 +328,24 @@ function InviteMemberForm({
 
   const rows = workspaces.data
   const [seeded, setSeeded] = useState(false)
+  // Same snapshot as the add form beside it, and the same reason.
+  const draft = JSON.stringify({ email, role, workspaceIds })
+  const seededDraft = useRef(draft)
   if (!seeded && rows && rows.length > 0) {
     setSeeded(true)
     const preferred = rows.find(
       (workspace) => workspace.id === selected?.workspace_id,
     )
-    setWorkspaceIds([(preferred ?? rows[0]).id])
+    const defaults = [(preferred ?? rows[0]).id]
+    setWorkspaceIds(defaults)
+    // Part of the seed, not a change: this lands after mount, so a snapshot
+    // taken at first render would report the form dirty the moment the roster
+    // answers, and Escape would ask before closing an untouched form.
+    seededDraft.current = JSON.stringify({
+      email,
+      role,
+      workspaceIds: defaults,
+    })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>
@@ -393,11 +419,11 @@ function InviteMemberForm({
         if (!open) onClose()
       }}
       title="Invitation"
-      submitLabel="Send invitation"
+      submitLabel="Invite member"
       onSubmit={submit}
       isPending={invite.isPending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={trimmed !== ""}
+      isDirty={draft !== seededDraft.current}
       error={invite.error}
     >
       <div className="grid gap-4 sm:grid-cols-2">

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -21,6 +21,7 @@ import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
 import { DataTable, type DataTableColumn } from "@/design-system/data/DataTable"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
@@ -164,7 +165,13 @@ function StatusMark({ status }: { status: string }) {
 // drop them into in the same request. A local identity is created for an address
 // nothing else knows yet, which is the handle a future sign-in flow claims it
 // by; until then the row is a place to hang a role, which is the point.
-function AddMemberForm({ onClose }: { onClose: () => void }) {
+function AddMemberForm({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
   const add = useAddOrganizationMember()
   const workspaces = useWorkspaces()
   const { selected } = useSelectedWorkspace()
@@ -218,12 +225,19 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title="New member"
+      submitLabel="Add member"
+      onSubmit={submit}
+      isPending={add.isPending}
+      isSubmitDisabled={trimmed === ""}
+      isDirty={trimmed !== ""}
+      error={add.error}
     >
-      <div className="text-title">Add member</div>
-      <ErrorBanner error={add.error} />
       <div className="grid gap-4 sm:grid-cols-2">
         <Field
           label="Email address"
@@ -268,20 +282,7 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
           ))}
         </fieldset>
       ) : null}
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={trimmed === ""}
-          isPending={add.isPending}
-          onPress={submit}
-        >
-          Add member
-        </Button>
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -290,7 +291,13 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
 // from AddMemberForm rather than a toggle on it: the two produce different
 // results (`mail_sent`, `accept_link`) and this one has something to show
 // after it succeeds, which AddMemberForm's immediate close does not.
-function InviteMemberForm({ onClose }: { onClose: () => void }) {
+function InviteMemberForm({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
   const invite = useInviteOrganizationMember()
   const workspaces = useWorkspaces()
   const { mail_ready } = useDeployment()
@@ -339,11 +346,20 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
   // to share by hand when it was not (or when mail is unconfigured entirely).
   if (result) {
     return (
-      <Section
-        className="border-y border-border py-5"
-        contentClassName="flex flex-col gap-4"
+      <FormDialog
+        isOpen={isOpen}
+        onOpenChange={(open) => {
+          if (!open) onClose()
+        }}
+        title="Invitation"
+        // Dismissable only once the email carried the link. When it did not,
+        // this is the only place the link is shown, so the acknowledgement is
+        // the way out rather than one of two.
+        isDismissable={result.mail_sent}
+        submitLabel="Done"
+        onSubmit={onClose}
+        isPending={false}
       >
-        <div className="text-title">Invitation sent</div>
         {result.mail_sent ? (
           <InfoBanner>
             An email with an accept link was sent to{" "}
@@ -364,22 +380,24 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
             </div>
           </InfoBanner>
         )}
-        <div className="flex gap-2">
-          <Button variant="primary" onPress={onClose}>
-            Done
-          </Button>
-        </div>
-      </Section>
+      </FormDialog>
     )
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      title="Invitation"
+      submitLabel="Send invitation"
+      onSubmit={submit}
+      isPending={invite.isPending}
+      isSubmitDisabled={trimmed === ""}
+      isDirty={trimmed !== ""}
+      error={invite.error}
     >
-      <div className="text-title">Invite member</div>
-      <ErrorBanner error={invite.error} />
       <div className="grid gap-4 sm:grid-cols-2">
         <Field
           label="Email address"
@@ -420,20 +438,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
           ))}
         </fieldset>
       ) : null}
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={trimmed === ""}
-          isPending={invite.isPending}
-          onPress={submit}
-        >
-          Send invitation
-        </Button>
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -802,6 +807,8 @@ export function OrganizationMembersPage() {
   const [revoking, setRevoking] = useState<OrganizationMember | null>(null)
   const [adding, setAdding] = useState(false)
   const [inviting, setInviting] = useState(false)
+  const [addCount, setAddCount] = useState(0)
+  const [inviteCount, setInviteCount] = useState(0)
 
   const rows = useMemo(() => members.data ?? [], [members.data])
   const userByAttribution = useMemo(
@@ -1156,12 +1163,26 @@ export function OrganizationMembersPage() {
       <PageIntro
         title="Members"
         action={
-          manages && !adding && !inviting ? (
+          manages ? (
+            // Both stay on screen while their dialog is open: the dialog is
+            // over the page rather than in place of the action.
             <div className="flex gap-2">
-              <Button variant="ghost" onPress={() => setAdding(true)}>
+              <Button
+                variant="ghost"
+                onPress={() => {
+                  setAddCount((count) => count + 1)
+                  setAdding(true)
+                }}
+              >
                 Add member
               </Button>
-              <Button variant="primary" onPress={() => setInviting(true)}>
+              <Button
+                variant="primary"
+                onPress={() => {
+                  setInviteCount((count) => count + 1)
+                  setInviting(true)
+                }}
+              >
                 Invite member
               </Button>
             </div>
@@ -1204,10 +1225,19 @@ export function OrganizationMembersPage() {
         </InfoBanner>
       )}
 
-      {adding ? <AddMemberForm onClose={() => setAdding(false)} /> : null}
-      {inviting ? (
-        <InviteMemberForm onClose={() => setInviting(false)} />
-      ) : null}
+      {/* Keyed on the open count, so each open remounts a blank form. Clearing
+          the draft on close instead would blank the fields while the dialog is
+          still animating away. */}
+      <AddMemberForm
+        key={`add-${addCount}`}
+        isOpen={adding}
+        onClose={() => setAdding(false)}
+      />
+      <InviteMemberForm
+        key={`invite-${inviteCount}`}
+        isOpen={inviting}
+        onClose={() => setInviting(false)}
+      />
 
       {/* Keyed on the row so switching which member is edited remounts the
           form: its fields seed from the member on mount only. */}


### PR DESCRIPTION
## Description

Adding and inviting someone to an organization each used to append a form section under the page heading, the second of the two creation patterns the dashboard is collapsing into one. Both now open the shared form dialog: the heading keeps its pair of triggers, "Add member" and "Invite member", and neither one disappears while its dialog is open.

The invitation's result stays in the same frame, the way a new key's secret does. When the email went out the dialog says so and can be dismissed; when it did not, the accept link shown there is the only copy, so acknowledging it is the one way out. That step used to be headed "Invitation sent" in both cases, which was untrue on the arm that says the email was not sent, so the frame is titled "Invitation" throughout and the banner underneath carries what actually happened. This is the one copy change in the PR and it is called out here deliberately.

Each dialog opens on a blank draft. The form is remounted when it opens rather than cleared when it closes, so a dialog animating away keeps its fields instead of blanking mid-flight.

A second commit moves the two "Role" pickers in these forms from the toolbar select to the form one. The toolbar control draws its label a rung lighter and smaller than a `Field` does, so inside one dialog the form showed two label styles. The three remaining ones on this page are compact in-table controls named by `ariaLabel`, which is that component's other documented use, and they stay.

Part of #1031

## How to test it locally

1. `make dashboard && make dev`, sign in, and open Organization, Members & roles as an owner or admin.
2. Press "Add member". The dialog opens over the page, both heading buttons are still there, and the email field and the Role picker now carry the same label style.
3. Type an address, press Escape, discard the unsaved changes, and press "Add member" again: the field is empty.
4. Press "Invite member" and send one. With mail unconfigured the dialog stays open on the accept link with no way out but the acknowledgement.

Covered by `OrganizationMembersPage.test.tsx` (26 cases, three new). The two behavioral ones were checked by removing the fix and reading the failure: dropping the remount key makes the draft survive, and restoring the old hide-while-open condition fails the trigger case. The third asserts that mounting both dialogs closed adds no request of their own, and it is a guard rather than a check: it fails only if a future edit gives one of these forms a query the page does not already make.

`e2e/parity.tenancy.spec.ts` now scopes its presses to the "New member" dialog, since the trigger and the submit say the same words.

## PR Type

- [x] Refactor

## Relevant issues

Part of #1031, and takes two of the sites listed on #1043.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
  Dashboard counterparts on this branch: `pnpm --dir web run lint` and `run typecheck` clean, the full vitest suite at 5484 passing, and the Playwright behavioral projects (onboarding, seed, parity, hybrid) at 43 passing with no failures.
- [ ] Documentation was updated where necessary. No documentation covers these forms' placement; the design system's dialog guidance already describes the target pattern.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API change.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 5)

**Any additional AI details you'd like to share:**

The two behavioral tests were verified by deliberately reintroducing each defect and reading the failure, rather than by passing on first write. The third is labeled a guard above because nothing in the current code can make it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
