### PR TITLE
fix(config): describe data_plane_url against the API root it is suffixed with

### DIFF
--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -541,10 +541,10 @@ class GatewayConfig(BaseSettings):
         default=None,
         description=(
             "Where this deployment's inference traffic belongs, as an absolute http(s) URL "
-            "with no trailing slash and no '/v1' path segment anywhere in it, not even as part "
-            "of a full endpoint like '/api/v1/chat/completions' (e.g. 'https://gateway.otari.ai'): "
-            "the dashboard appends that path itself. It carries no credential either, so no "
-            "query string, fragment, or user:password. Only a hosted control "
+            f"with no trailing slash and no '{API_ROOT}' or '/v1' path segment anywhere in it, not "
+            f"even as part of a full endpoint like '{API_ROOT}/chat/completions' (e.g. "
+            "'https://gateway.otari.ai'): the dashboard appends that path itself. It carries no "
+            "credential either, so no query string, fragment, or user:password. Only a hosted control "
             "plane needs it: a standalone gateway and a hybrid one both serve inference at "
             "their own address, so whatever reached the dashboard reaches the API, and this "
             "stays unset. A control plane serving many organizations does not, so it has to "
@@ -1995,8 +1995,8 @@ class GatewayConfig(BaseSettings):
         command an operator copies and cannot explain.
 
         The trailing slash is normalized away here so no consumer has to: the
-        dashboard suffixes this with ``/v1``, and ``https://host//v1`` is a
-        different path on a strict router.
+        dashboard suffixes this with ``/api/v1``, and ``https://host//api/v1``
+        is a different path on a strict router.
 
         A query string or a fragment is refused for the same reason, and it is
         the case a scheme check alone would miss: this is a base URL a client
@@ -2006,17 +2006,17 @@ class GatewayConfig(BaseSettings):
         ``docs_url``, which is a link a person follows, nothing downstream can
         recover from that.
 
-        A ``/v1`` suffix is refused too, and it is the likelier mistake of the
-        two: everywhere else a client meets one, "base URL" means the ``/v1``
-        address (the OpenAI SDK's own ``base_url`` includes it), so writing that
-        here is the natural error, and it renders a snippet posting to
-        ``/api/v1/v1/chat/completions``, which looks right and 404s on first use.
-        Refused rather than stripped, because stripping would be silent and
-        would be wrong for a gateway genuinely mounted under such a path, while
-        refusing costs one edit. Any segment counts and not just the last, so
-        pasting the whole endpoint (``https://host/api/v1/chat/completions``, the
-        likelier copy-paste of the two) is refused as well rather than rendering
-        that path twice. Any other prefix is left alone: a gateway proxied at
+        A path carrying the API root is refused too, and it is the likelier
+        mistake of the two: everywhere else a client meets one, "base URL"
+        means the ``/api/v1`` address (the OpenAI SDK's own ``base_url``
+        includes it), so writing it here is the natural error, and it renders
+        a snippet posting to ``/api/v1/api/v1/chat/completions``, which looks
+        right and 404s on first use. Refused rather than stripped, because
+        stripping would be silent and wrong for a gateway genuinely mounted
+        under such a path, while refusing costs one edit. Any ``v1`` segment
+        counts, not just a trailing root, so a pasted endpoint
+        (``https://host/api/v1/chat/completions``) is refused as well. Any
+        other prefix is left alone: a gateway proxied at
         ``https://api.example.com/otari`` is a real deployment.
         """
         normalized = (value or "").strip().rstrip("/")
@@ -2047,9 +2047,9 @@ class GatewayConfig(BaseSettings):
             raise ValueError(msg)
         if any(segment.lower() == "v1" for segment in parsed.path.split("/")):
             msg = (
-                "data_plane_url must not contain a /v1 segment: the dashboard appends that path "
-                f"itself, so give the gateway's own address (for example 'https://gateway.otari.ai'). "
-                f"Got '{value}'"
+                f"data_plane_url must not carry the API root ({API_ROOT}) or any /v1 segment: the "
+                "dashboard appends that path itself, so give the gateway's own address (for example "
+                f"'https://gateway.otari.ai'). Got '{value}'"
             )
             raise ValueError(msg)
         return normalized

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -8,6 +8,7 @@ on the SQLite file each test stands up, so there is no PostgreSQL to wait for.
 """
 
 import logging
+import re
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -719,6 +720,8 @@ def test_a_blank_data_plane_url_is_an_unset_one(configured: str) -> None:
 @pytest.mark.parametrize(
     "configured",
     [
+        f"https://gateway.otari.ai{API_ROOT}",
+        f"https://gateway.otari.ai{API_ROOT}/",
         "https://gateway.otari.ai/v1",
         "https://gateway.otari.ai/v1/",
         "https://gateway.otari.ai/V1",
@@ -727,20 +730,23 @@ def test_a_blank_data_plane_url_is_an_unset_one(configured: str) -> None:
         # what a curl example on this very page shows. Caught because any
         # segment counts, not only the last one, which an earlier version of
         # this guard got wrong and let render the path twice over.
+        f"https://gateway.otari.ai{API_ROOT}/chat/completions",
         "https://gateway.otari.ai/v1/chat/completions",
         "https://gateway.otari.ai/v1/messages",
     ],
 )
-def test_a_data_plane_url_that_already_names_v1_is_refused(configured: str) -> None:
+def test_a_data_plane_url_that_already_carries_the_api_root_is_refused(configured: str) -> None:
     """The likelier mistake, refused where it is cheap.
 
-    Everywhere else a client meets one, "base URL" means the ``/v1`` address, so
-    writing that here is the natural error, and it renders a snippet posting to
-    ``/v1/v1/chat/completions``: it looks right and 404s on first use. Refused
-    rather than stripped, because stripping would be silent and would be wrong
-    for a gateway genuinely mounted under such a path.
+    Everywhere else a client meets one, "base URL" means the ``/api/v1``
+    address, so writing that here is the natural error, and it renders a
+    snippet posting to ``/api/v1/api/v1/chat/completions``: it looks right and
+    404s on first use. Refused rather than stripped, because stripping would be
+    silent and would be wrong for a gateway genuinely mounted under such a path.
+    A bare ``/v1`` is refused for the same reason; it is the root every SDK's
+    ``base_url`` ends with.
     """
-    with pytest.raises(ValidationError, match="must not contain a /v1 segment"):
+    with pytest.raises(ValidationError, match=rf"API root \({re.escape(API_ROOT)}\).*appends that path itself"):
         GatewayConfig(data_plane_url=configured)
 
 
@@ -748,6 +754,7 @@ def test_a_data_plane_url_that_already_names_v1_is_refused(configured: str) -> N
     "configured",
     [
         "https://api.example.com/otari",
+        "https://api.example.com/otari/",
         # Not a ``v1`` segment, so it survives: the guard matches whole segments
         # rather than a prefix, or a real deployment would be refused for the
         # first three characters of its path.
@@ -760,7 +767,7 @@ def test_a_path_that_does_not_name_v1_is_left_alone(configured: str) -> None:
     The guard has to stay narrow enough that it cannot cost an operator a
     deployment shape the gateway otherwise supports.
     """
-    assert GatewayConfig(data_plane_url=configured).data_plane_url == configured
+    assert GatewayConfig(data_plane_url=configured).data_plane_url == configured.rstrip("/")
 
 
 def test_a_trailing_slash_is_trimmed_from_the_data_plane_url() -> None:


### PR DESCRIPTION
## Description

A hosted control plane tells the dashboard where inference lives by giving it the gateway's bare address. The dashboard adds the API root to that address when it builds a request snippet, so an address that already ends in the API root would produce a snippet that posts to the root twice and fails on first use. The gateway already refuses such an address at startup. But its refusal message, and the prose around the rule, still described the root as `/v1`, from before the API moved to `/api/v1`. An operator who pasted the address every SDK calls a base URL got a message that did not name the thing it refused.

The rule itself does not change. The message now names the API root it refuses, and the surrounding descriptions say `/api/v1` where they said `/v1`. The test gains the `/api/v1` cases and requires the message to name the root. Nothing about this reaches the published API document, so no generated artifact changed.

## How to test it locally

Set `OTARI_DATA_PLANE_URL=https://gateway.example.com/api/v1` and start the gateway. It refuses to start, and the message says the value must not carry the API root (`/api/v1`) or any `/v1` segment. Set it to `https://gateway.example.com` instead and it starts.

Automated: `uv run pytest tests/unit/test_deployment_bootstrap.py tests/integration/test_hosted_mode_surface.py tests/integration/test_api_prefix_contract.py`. `make lint` and `make typecheck` pass. `make openapi-check` and `make postman-check` pass with no regeneration needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follows #1026 and #1064.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code

**Any additional AI details you'd like to share:**

The design, the plan and the review are human. AI drafted the edits and ran the checks under that plan.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `data_plane_url` documentation and validation messages to describe the `/api/v1` API root.
- Added test coverage for API-root paths, trailing slashes, and complete endpoints.
- Preserved the existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->