### PR TITLE
refactor(dashboard): make a combo box report an option's id, not its text

### DIFF
--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -56,10 +56,10 @@ Checkbox: { isSelected, onChange: (next: boolean) => void, isDisabled?, ariaLabe
   children }
 Select: { label, value, onChange, options: SelectOption[], description?, placeholder?,
   isRequired?, isDisabled?, isInvalid?, errorMessage?, reserveMessage?, className? }
-ComboBoxField: { label, value, onChange, options: ComboBoxOption[], description?,
-  placeholder?, isRequired?, isDisabled?, isInvalid?, errorMessage?, reserveMessage?,
-  className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus", shouldSelectOnFocus?,
-  isSourceEmpty?, emptyMessage?, noMatchesMessage? }
+ComboBoxField: { label, value, onChange, onQueryChange?, options: ComboBoxOption[],
+  description?, placeholder?, isRequired?, isDisabled?, isInvalid?, errorMessage?,
+  reserveMessage?, className?, allowsCustomValue?, autoFocus?, menuTrigger = "focus",
+  shouldSelectOnFocus?, isSourceEmpty?, emptyMessage?, noMatchesMessage? }
 RadioGroup: { label, value, onChange, options: RadioOption[], description?,
   orientation = "vertical", isRequired?, isDisabled?, isInvalid?, errorMessage?,
   className? }
@@ -116,12 +116,25 @@ Rules:
 ## ComboBoxField
 
 `Select`'s vocabulary for everything the two share, plus what a combo box needs
-beyond it. See its docstring for the contract; three things are worth knowing at
+beyond it. See its docstring for the contract; four things are worth knowing at
 a call site.
+
+**`value` is the option's `value`, exactly as in `Select`**, and the input shows
+that option's `label`. An id and a name point at the same thing, so identity
+travels as the id and the label is only displayed; the field never reports a
+label, because a label maps back to no single id (two rows may share one, and
+one row's label may be another row's id). `allowsCustomValue` is the one
+addition: text matching no row is reported as the value too, as itself rather
+than as a lookup. So typing somebody's name names a new id rather than
+resolving to theirs, and `description` is where a field says what typing will
+do (`UserComboBox`'s `unknownHint`).
 
 **It filters nothing.** `options` is what the popover holds, already matched and
 capped by the caller, because what counts as a match differs per field (an id as
 well as a name) and a ceiling wants a "showing 50 of 300" line under it.
+`onQueryChange` is what the caller matches on: the field owns the input's text,
+so it is the only thing that can publish it. It reports empty once a row is
+picked, since the field is then showing a choice rather than a search.
 
 **An empty popover has to say which empty it is.** Every combo box here keeps
 its menu open on an empty collection, so that a query matching nothing does not

--- a/web/design/forms.md
+++ b/web/design/forms.md
@@ -120,14 +120,11 @@ beyond it. See its docstring for the contract; four things are worth knowing at
 a call site.
 
 **`value` is the option's `value`, exactly as in `Select`**, and the input shows
-that option's `label`. An id and a name point at the same thing, so identity
-travels as the id and the label is only displayed; the field never reports a
-label, because a label maps back to no single id (two rows may share one, and
-one row's label may be another row's id). `allowsCustomValue` is the one
-addition: text matching no row is reported as the value too, as itself rather
-than as a lookup. So typing somebody's name names a new id rather than
-resolving to theirs, and `description` is where a field says what typing will
-do (`UserComboBox`'s `unknownHint`).
+that option's `label`. The field never reports a label; the docstring says why.
+`allowsCustomValue` is the one addition: text matching no row is reported as the
+value too, as itself rather than as a lookup. So typing somebody's name names a
+new id rather than resolving to theirs, which is what `description` is for
+(`UserComboBox`'s `unknownHint` says the id will be created).
 
 **It filters nothing.** `options` is what the popover holds, already matched and
 capped by the caller, because what counts as a match differs per field (an id as

--- a/web/src/design-system/forms/ComboBoxField.stories.tsx
+++ b/web/src/design-system/forms/ComboBoxField.stories.tsx
@@ -44,8 +44,7 @@ type Story = StoryObj<typeof meta>
 /**
  * `value` is the picked option's `value` and the input shows its `label`, the
  * same division `Select` makes. The field filters nothing: `onQueryChange`
- * publishes what is in the input and the caller decides what matches, which is
- * what lets one field match on an id and another cap a long list.
+ * publishes what is in the input and the caller decides what matches.
  */
 export const Default: Story = {
   render: (args) => {

--- a/web/src/design-system/forms/ComboBoxField.stories.tsx
+++ b/web/src/design-system/forms/ComboBoxField.stories.tsx
@@ -41,10 +41,28 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+/**
+ * `value` is the picked option's `value` and the input shows its `label`, the
+ * same division `Select` makes. The field filters nothing: `onQueryChange`
+ * publishes what is in the input and the caller decides what matches, which is
+ * what lets one field match on an id and another cap a long list.
+ */
 export const Default: Story = {
   render: (args) => {
     const [value, setValue] = useState("")
-    return <ComboBoxField {...args} value={value} onChange={setValue} />
+    const [query, setQuery] = useState("")
+    const match = query.trim().toLowerCase()
+    return (
+      <ComboBoxField
+        {...args}
+        value={value}
+        onChange={setValue}
+        onQueryChange={setQuery}
+        options={MODELS.filter((option) =>
+          option.label.toLowerCase().includes(match),
+        )}
+      />
+    )
   },
 }
 
@@ -63,11 +81,13 @@ export const WithDescription: Story = {
 
 /**
  * `hint` is the option's secondary line: text that identifies the label rather
- * than repeating it, such as the id a person is billed under.
+ * than repeating it, such as the id a person is billed under. The value here is
+ * an id, and the box shows the name it belongs to.
  */
 export const OptionHints: Story = {
   args: {
     label: "Owner",
+    value: "018f0000-0000-4000-8000-000000000001",
     placeholder: "Pick a user, or type a new id…",
     options: [
       {

--- a/web/src/design-system/forms/ComboBoxField.test.tsx
+++ b/web/src/design-system/forms/ComboBoxField.test.tsx
@@ -56,9 +56,8 @@ describe("ComboBoxField", () => {
       await screen.findByRole("option", { name: "Ada Lovelace" }),
     )
 
-    // One report, and it is the id: a label identifies no row, since two rows
-    // may share one and one row's label may be another row's id. The label is
-    // what the box shows, which is the whole division of labor here.
+    // One report, and it is the id. The label is what the box shows, which is
+    // the whole division of labor here.
     expect(seen).toEqual(["018f-0001"])
     expect(field).toHaveValue("Ada Lovelace")
   })
@@ -88,6 +87,49 @@ describe("ComboBoxField", () => {
     )
 
     expect(field).toHaveValue("Ada Lovelace")
+  })
+
+  it("repaints when the caller moves the value out from under it", async () => {
+    const props = {
+      label: "Serves" as const,
+      onChange: () => {},
+      options: OPTIONS,
+      allowsCustomValue: true,
+    }
+    const { rerender } = render(
+      <ComboBoxField {...props} value="openai:gpt-4o" />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.type(field, "!")
+
+    rerender(<ComboBoxField {...props} value="anthropic:claude-sonnet-4-5" />)
+
+    // A row of these fields whose neighbor is removed hands a mounted field
+    // somebody else's value, so a value the field did not report wins over the
+    // text left in the box.
+    expect(field).toHaveValue("anthropic:claude-sonnet-4-5")
+  })
+
+  it("clears the value when the box is emptied", async () => {
+    const seen: string[] = []
+    render(
+      <Harness
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onValue={(value) => seen.push(value)}
+      />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.clear(field)
+
+    // Emptying the box is the one edit a whitelist reports, since it is the
+    // only way to take a selection back.
+    expect(seen).toEqual(["018f-0001", ""])
   })
 
   it("still reports text the operator edits after picking a row", async () => {

--- a/web/src/design-system/forms/ComboBoxField.test.tsx
+++ b/web/src/design-system/forms/ComboBoxField.test.tsx
@@ -112,6 +112,50 @@ describe("ComboBoxField", () => {
     expect(seen.at(-1)).toBe("Ada Lovelace!")
   })
 
+  it("keeps text typed over a picked row when the field is left", async () => {
+    const seen: string[] = []
+    render(
+      <Harness
+        allowsCustomValue
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onValue={(value) => seen.push(value)}
+      />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.clear(field)
+    await userEvent.type(field, "ci-bot")
+    await userEvent.tab()
+
+    // Leaving the field is what commits it, and react-aria clears its selection
+    // there when the text no longer matches the row. The typed value has to
+    // survive that: it is what the form submits.
+    expect(seen.at(-1)).toBe("ci-bot")
+    expect(field).toHaveValue("ci-bot")
+  })
+
+  it("returns to the picked row when custom values are not allowed", async () => {
+    render(
+      <Harness options={[{ value: "018f-0001", label: "Ada Lovelace" }]} />,
+    )
+
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+    await userEvent.type(field, "zzz")
+    await userEvent.tab()
+
+    // A whitelist keeps no text nobody offered, so the box goes back to
+    // reading as the value rather than sitting on a search that lost.
+    expect(field).toHaveValue("Ada Lovelace")
+  })
+
   it("publishes the input's text for a caller that filters", async () => {
     const queries: string[] = []
     render(

--- a/web/src/design-system/forms/ComboBoxField.test.tsx
+++ b/web/src/design-system/forms/ComboBoxField.test.tsx
@@ -16,7 +16,7 @@ const OPTIONS: ComboBoxOption[] = [
   },
 ]
 
-/** The field is controlled, so a test that types into it has to hold the text. */
+/** The field is controlled, so a test that picks or types has to hold the value. */
 function Harness({
   options = OPTIONS,
   onValue,
@@ -41,7 +41,7 @@ function Harness({
 }
 
 describe("ComboBoxField", () => {
-  it("reports a picked option once, as its value rather than its label", async () => {
+  it("reports a picked row once, as its id, and displays its label", async () => {
     const seen: string[] = []
     render(
       <Harness
@@ -50,16 +50,44 @@ describe("ComboBoxField", () => {
       />,
     )
 
-    await userEvent.click(screen.getByRole("combobox", { name: "Serves" }))
+    const field = screen.getByRole("combobox", { name: "Serves" })
+    await userEvent.click(field)
     await userEvent.click(
       await screen.findByRole("option", { name: "Ada Lovelace" }),
     )
 
-    // One report, not two. react-aria writes the row's display text into the
-    // input after reporting the selection; forwarding that echo would hand the
-    // caller a label after a key, and a label does not identify a row (two rows
-    // may share one, and one row's label may be another row's value).
+    // One report, and it is the id: a label identifies no row, since two rows
+    // may share one and one row's label may be another row's id. The label is
+    // what the box shows, which is the whole division of labor here.
     expect(seen).toEqual(["018f-0001"])
+    expect(field).toHaveValue("Ada Lovelace")
+  })
+
+  it("displays a label the caller resolves after mount", () => {
+    const { rerender } = render(
+      <ComboBoxField
+        label="Owner"
+        value="018f-0001"
+        onChange={() => {}}
+        options={[]}
+      />,
+    )
+
+    // A roster or a catalog read lands after the field paints, so the id it
+    // arrives with has to give way to the name it resolves to.
+    const field = screen.getByRole("combobox", { name: "Owner" })
+    expect(field).toHaveValue("018f-0001")
+
+    rerender(
+      <ComboBoxField
+        label="Owner"
+        value="018f-0001"
+        onChange={() => {}}
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+      />,
+    )
+
+    expect(field).toHaveValue("Ada Lovelace")
   })
 
   it("still reports text the operator edits after picking a row", async () => {
@@ -79,10 +107,34 @@ describe("ComboBoxField", () => {
     )
     await userEvent.type(field, "!")
 
-    // Only the one echo is swallowed. Anything typed afterwards is the
-    // operator's, so a field that went quiet after a pick would be a worse bug
-    // than the one the swallowing fixes.
-    expect(seen.at(-1)).toBe("018f-0001!")
+    // Editing the box is not holding a selection: what is in it is text, and a
+    // field that went quiet after a pick would be the worse bug.
+    expect(seen.at(-1)).toBe("Ada Lovelace!")
+  })
+
+  it("publishes the input's text for a caller that filters", async () => {
+    const queries: string[] = []
+    render(
+      <Harness
+        allowsCustomValue
+        options={[{ value: "018f-0001", label: "Ada Lovelace" }]}
+        onQueryChange={(query) => queries.push(query)}
+      />,
+    )
+
+    await userEvent.type(
+      screen.getByRole("combobox", { name: "Serves" }),
+      "ada",
+    )
+    expect(queries.at(-1)).toBe("ada")
+
+    await userEvent.click(
+      await screen.findByRole("option", { name: "Ada Lovelace" }),
+    )
+
+    // Empty once a row is picked: the field shows a choice rather than a
+    // search, so the caller offers its whole list again, not the one row.
+    expect(queries.at(-1)).toBe("")
   })
 
   it("reports free text when the caller allows it", async () => {

--- a/web/src/design-system/forms/ComboBoxField.tsx
+++ b/web/src/design-system/forms/ComboBoxField.tsx
@@ -148,6 +148,16 @@ export function ComboBoxField({
   // an id in the box.
   const [typed, setTyped] = useState<string>()
 
+  // The value as this field last saw it, which is what tells a value the caller
+  // moved from one this field reported. The first kind leaves whatever is in the
+  // box stale: a list of these fields that drops a row moves a value under a
+  // field that is still mounted.
+  const [seen, setSeen] = useState(value)
+  if (value !== seen) {
+    setSeen(value)
+    if (value !== typed) setTyped(undefined)
+  }
+
   const setQuery = (next: string | undefined) => {
     setTyped(next)
     onQueryChange?.(next ?? "")
@@ -172,10 +182,10 @@ export function ComboBoxField({
       selectedKey={selected && typed === undefined ? selected.value : null}
       onInputChange={(next) => {
         setQuery(next)
-        // Only a field offering the list as suggestions can report what was
-        // typed. Elsewhere the value stays whichever row is selected, and
-        // react-aria reports the selection back on commit.
-        if (allowsCustomValue) onChange(next)
+        // A field offering the list as suggestions reports what was typed.
+        // Elsewhere the value stays whichever row is selected, except that an
+        // emptied box is how that selection is cleared.
+        if (allowsCustomValue || next === "") onChange(next)
       }}
       onSelectionChange={(key) => {
         // The input goes back to showing the value, which after a pick is that

--- a/web/src/design-system/forms/ComboBoxField.tsx
+++ b/web/src/design-system/forms/ComboBoxField.tsx
@@ -7,15 +7,16 @@ import {
   ListBox,
   ListBoxItem,
 } from "@heroui/react"
-import { type ReactNode, useRef } from "react"
+import { type ReactNode, useState } from "react"
 
 import { ComboBoxEmpty } from "@/design-system/forms/ComboBoxEmpty"
 import { FieldMessages } from "@/design-system/forms/FieldMessages"
 
 /** One choice in a `ComboBoxField`. `isDisabled` shows a choice that exists but cannot be taken. */
 export interface ComboBoxOption {
-  /** What the field reports, and the key react-aria carries. Never empty: react-aria reads an empty key as "nothing selected". */
+  /** The option's id: what the field reports and the key react-aria carries. Never empty: react-aria reads an empty key as "nothing selected". */
   value: string
+  /** What the row and the input display. Never what the field reports. */
   label: string
   /** A second, muted line inside the row, for text that identifies the label rather than repeating it. */
   hint?: string
@@ -32,6 +33,12 @@ export interface ComboBoxOption {
 export const comboBoxOptionText = (
   option: Pick<ComboBoxOption, "label" | "hint">,
 ) => (option.hint ? `${option.label} (${option.hint})` : option.label)
+
+// `options` is the whole popover, so react-aria must not filter it again: its
+// own filter reads a row's `textValue`, which is the label, and would drop a
+// row the caller matched on its hint. Hoisted so the collection it feeds is not
+// rebuilt on every render.
+const KEEP_EVERY_OPTION = () => true
 
 /**
  * One of a set, searchable, in a form the operator submits.
@@ -51,22 +58,26 @@ export const comboBoxOptionText = (
  * `ComboBoxEmpty` is the sentence that tells those apart, and there is no way
  * to render this control without one.
  *
- * `value` is the input's text rather than a chosen key, which is what lets a
- * caller with `allowsCustomValue` submit something the list never offered.
- * Picking a row reports that option's `value`, and reports it once: react-aria
- * echoes the row's display text into the input afterwards, and that echo is
- * swallowed here rather than forwarded. So `onChange` carries a key when a row
- * was picked and text when text was typed, and never a label. See the handlers
- * for why the caller cannot be the one to sort those out.
+ * `value` is an option's `value`, as in `forms/Select`, and never a label. An
+ * id and a name point at the same thing, so identity travels as the id,
+ * through react-aria's `selectedKey`, and the label is only displayed: this
+ * field owns the input's text and shows the matched option's label. Picking a
+ * row reports its id, once. With `allowsCustomValue` the text an operator
+ * types is reported as the value too, because a list that is a shortcut rather
+ * than a whitelist has to let something it never offered stand; that text is
+ * then itself rather than a lookup, since a label maps back to no single id
+ * (two rows may share one, and one row's label may be another row's id).
  *
- * No filtering of its own: `options` is what the popover holds. The caller
- * matches and caps, because what counts as a match differs per field (an id as
- * well as a name, a ceiling with a "showing N of M" line under it).
+ * No filtering of its own: `options` is what the popover holds, and
+ * `onQueryChange` is what the caller matches on. The caller matches and caps,
+ * because what counts as a match differs per field (an id as well as a name, a
+ * ceiling with a "showing N of M" line under it).
  */
 export function ComboBoxField({
   label,
   value,
   onChange,
+  onQueryChange,
   options,
   description,
   placeholder,
@@ -85,10 +96,16 @@ export function ComboBoxField({
   noMatchesMessage,
 }: {
   label: ReactNode
-  /** The input's text. Not a key: a field allowing custom values holds text no option carries. */
+  /** The selected option's `value`, or, where custom values are allowed, text no option carries. */
   value: string
   /** Takes the value, never an event, which is the convention every control here follows. */
   onChange: (value: string) => void
+  /**
+   * The input's text, for a caller that filters `options` by it. Empty once a
+   * row is picked, because the field is then showing a choice rather than a
+   * search. Only this field can report it: it owns the input's text.
+   */
+  onQueryChange?: (query: string) => void
   /** Already filtered and capped by the caller, whose match rules and ceiling are its own. */
   options: readonly ComboBoxOption[]
   description?: ReactNode
@@ -120,9 +137,21 @@ export function ComboBoxField({
   /** What it says when the source has options and the query matched none. */
   noMatchesMessage?: ReactNode
 }) {
-  // Not state: nothing renders from it, and a re-render between the pick and
-  // its echo would drop it.
-  const echoRef = useRef<string | undefined>(undefined)
+  const selected = options.find((option) => option.value === value)
+  // What the value reads as: the matched row's label, or the value itself,
+  // which is then text no row carries.
+  const shown = selected?.label ?? value
+
+  // What is being typed, which stands in for the value's own text until a row
+  // is picked or the field is committed. Undefined the rest of the time, so a
+  // label the caller resolves after mount reaches the input rather than leaving
+  // an id in the box.
+  const [typed, setTyped] = useState<string>()
+
+  const setQuery = (next: string | undefined) => {
+    setTyped(next)
+    onQueryChange?.(next ?? "")
+  }
 
   return (
     <ComboBox.Root
@@ -132,26 +161,29 @@ export function ComboBoxField({
       // empty message below reachable at all.
       allowsEmptyCollection
       menuTrigger={menuTrigger}
-      inputValue={value}
-      // The echo, and why it is caught here. react-aria reports a pick through
-      // `onSelectionChange` and then writes that row's display text into the
-      // input, firing `onInputChange` with a label where the previous call
-      // carried a key. A caller that forwarded both would have to turn the
-      // label back into a key, and two rows may share a label, or one row's
-      // label may be another row's value, so that mapping can land on the wrong
-      // row. Here the picked option is in hand, so the echo is recognized by
-      // identity and dropped. Anything else the operator types passes through.
+      defaultFilter={KEEP_EVERY_OPTION}
+      // Both halves controlled, which is what keeps a pick reported once:
+      // react-aria writes the picked row's text back into the input only while
+      // one of the two is uncontrolled, and leaves the text here otherwise.
+      inputValue={typed ?? shown}
+      // The row an open list marks as selected. Nothing is selected while text
+      // is being typed, because text that happens to match a row's id is still
+      // text, and treating it as a pick would close the list mid-search.
+      selectedKey={selected && typed === undefined ? selected.value : null}
       onInputChange={(next) => {
-        const echoed = echoRef.current
-        echoRef.current = undefined
-        if (echoed !== undefined && next === echoed) return
-        onChange(next)
+        setQuery(next)
+        // Only a field offering the list as suggestions can report what was
+        // typed. Elsewhere the value stays whichever row is selected, and
+        // react-aria reports the selection back on commit.
+        if (allowsCustomValue) onChange(next)
       }}
       onSelectionChange={(key) => {
-        if (key == null) return
-        const picked = options.find((option) => option.value === String(key))
-        echoRef.current = picked ? comboBoxOptionText(picked) : undefined
-        onChange(String(key))
+        // The input goes back to showing the value, which after a pick is that
+        // row's label. `key` is null when the field was committed on text no
+        // row matches, which needs no report: with custom values that text is
+        // already the value, and without them the value never left the row.
+        setQuery(undefined)
+        if (key != null) onChange(String(key))
       }}
       isRequired={isRequired}
       isDisabled={isDisabled}
@@ -195,7 +227,10 @@ export function ComboBoxField({
           {(option: ComboBoxOption) => (
             <ListBoxItem
               id={option.value}
-              textValue={comboBoxOptionText(option)}
+              // The label alone, because this is also the text react-aria reads
+              // the selection as, and it has to agree with what the input shows
+              // or re-picking the selected row rewrites the input.
+              textValue={option.label}
               // Spelled out, because the row has two text nodes and the name
               // computed from them runs the hint onto the end of the label with
               // no separator. The hint belongs in the name rather than being

--- a/web/src/features/users/UserComboBox.test.tsx
+++ b/web/src/features/users/UserComboBox.test.tsx
@@ -205,9 +205,10 @@ describe("UserComboBox", () => {
   })
 
   it("submits a typed id even when it is another owner's roster name", async () => {
-    // The collision: this member's roster name is exactly another user's id, and
-    // a member sorts ahead of it. Matching either field in one scan would
-    // resolve the typed id to the member's UUID and bill the key to them.
+    // The collision that used to need a tie-break rule: this member's roster
+    // name is exactly another user's id, and a member sorts ahead of it. What
+    // answers it now is that typed text is not looked up at all, so there is
+    // nothing for the two rows to compete over.
     mockRoster([member(UUID, "ci-bot")])
     const changes: string[] = []
     renderBox(
@@ -221,6 +222,27 @@ describe("UserComboBox", () => {
     await userEvent.type(screen.getByRole("combobox"), "ci-bot")
 
     expect(changes.at(-1)).toBe("ci-bot")
+  })
+
+  it("does not turn a typed display name into the id it names", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    const changes: string[] = []
+    renderBox(
+      <UserComboBox
+        value=""
+        onChange={(id) => changes.push(id)}
+        users={[user(UUID)]}
+      />,
+    )
+
+    await userEvent.type(screen.getByRole("combobox"), "Alice Example")
+
+    // Deliberate, and the honest version of the case that produced the two
+    // collisions above: picking the row is how an existing person is chosen,
+    // and a typed name is an id of its own. Resolving it to Alice's UUID would
+    // be a guess, since a roster puts no uniqueness rule on a name.
+    expect(changes.at(-1)).toBe("Alice Example")
+    expect(changes).not.toContain(UUID)
   })
 
   it("submits the picked member, not the owner whose id is their roster name", async () => {

--- a/web/src/features/users/UserComboBox.test.tsx
+++ b/web/src/features/users/UserComboBox.test.tsx
@@ -224,27 +224,6 @@ describe("UserComboBox", () => {
     expect(changes.at(-1)).toBe("ci-bot")
   })
 
-  it("does not turn a typed display name into the id it names", async () => {
-    mockRoster([member(UUID, "Alice Example")])
-    const changes: string[] = []
-    renderBox(
-      <UserComboBox
-        value=""
-        onChange={(id) => changes.push(id)}
-        users={[user(UUID)]}
-      />,
-    )
-
-    await userEvent.type(screen.getByRole("combobox"), "Alice Example")
-
-    // Deliberate, and the honest version of the case that produced the two
-    // collisions above: picking the row is how an existing person is chosen,
-    // and a typed name is an id of its own. Resolving it to Alice's UUID would
-    // be a guess, since a roster puts no uniqueness rule on a name.
-    expect(changes.at(-1)).toBe("Alice Example")
-    expect(changes).not.toContain(UUID)
-  })
-
   it("submits the picked member, not the owner whose id is their roster name", async () => {
     // The same collision as above, reached from the other side: the row that was
     // picked is the member, and their label is the other owner's id.
@@ -263,9 +242,8 @@ describe("UserComboBox", () => {
       await screen.findByRole("option", { name: `ci-bot (${UUID})` }),
     )
 
-    // The member, not the `ci-bot` owner. This is what the display-text echo
-    // would get wrong: the label reported after the id resolves by id first, and
-    // an id match on "ci-bot" is a different row than the one that was clicked.
+    // The member, not the `ci-bot` owner. A picked row reports its own id, so
+    // the row that was clicked is the only answer this can have.
     expect(changes.at(-1)).toBe(UUID)
   })
 
@@ -295,5 +273,26 @@ describe("UserComboBox", () => {
     // Resolving the label back to a row would always answer with the first one,
     // so the second person could never be picked.
     expect(changes.at(-1)).toBe(second)
+  })
+
+  it("does not turn a typed display name into the id it names", async () => {
+    mockRoster([member(UUID, "Alice Example")])
+    const changes: string[] = []
+    renderBox(
+      <UserComboBox
+        value=""
+        onChange={(id) => changes.push(id)}
+        users={[user(UUID)]}
+      />,
+    )
+
+    await userEvent.type(screen.getByRole("combobox"), "Alice Example")
+
+    // Deliberate, and the honest version of the two collisions above: picking
+    // the row is how an existing person is chosen, and a typed name is an id of
+    // its own. Resolving it to Alice's UUID would be a guess, since a roster
+    // puts no uniqueness rule on a name.
+    expect(changes.at(-1)).toBe("Alice Example")
+    expect(changes).not.toContain(UUID)
   })
 })

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -87,7 +87,9 @@ export function UserComboBox({
     <ComboBoxField
       label={label}
       value={value}
-      onChange={onChange}
+      // Trimmed, because a pasted id often carries a space and every caller
+      // submits this as an owner id.
+      onChange={(next) => onChange(next.trim())}
       onQueryChange={setQuery}
       options={visible}
       description={creatingHint}

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react"
-import { useState } from "react"
+import { type ReactNode, useState } from "react"
 
 import type { User } from "@/client"
 import {
@@ -15,6 +14,10 @@ import { userOptionText } from "./userOptions"
 // know). This is the dashboard's user-first gate; it never mints an anonymous
 // virtual user the way an omitted id at the API would. Virtual users are left out
 // of the options: you attach keys to people/teams you name, not to key-shadows.
+//
+// `value` is the owner id, never the name shown for it. Picking a row is how an
+// existing person is chosen; typed text is an id of its own, so typing somebody's
+// display name names a new user rather than resolving to their UUID.
 export function UserComboBox({
   value,
   onChange,
@@ -55,43 +58,27 @@ export function UserComboBox({
       return a.label.localeCompare(b.label)
     })
 
-  const [text, setText] = useState(value)
-  const query = text.trim().toLowerCase()
+  // What is being searched for, reported by the field because it owns the
+  // input's text. Not the value: an id an operator types is a value, and a name
+  // they type is only ever a search.
+  const [query, setQuery] = useState("")
+  const q = query.trim().toLowerCase()
   const visible = options
     .filter(
       (o) =>
-        !query ||
-        o.value.toLowerCase().includes(query) ||
-        o.label.toLowerCase().includes(query),
+        !q ||
+        o.value.toLowerCase().includes(q) ||
+        o.label.toLowerCase().includes(q),
     )
     .slice(0, 50)
 
-  // What the operator types is not necessarily a user_id: it may be a label they
-  // copied, or an id for a user who does not exist yet. Resolve either form to
-  // the canonical id, or the submitted owner would be the label and the keys API
-  // would silently create a second user named after it.
-  const resolveId = (raw: string): string => {
-    const trimmed = raw.trim()
-    // An id match outranks a name match, and the order matters because a
-    // member's label is a free-form roster name rather than its own id: a roster
-    // name can equal another user's `user_id`, members sort to the front, and a
-    // single scan matching either field would then bill the key to whichever of
-    // the two came first. Only the typed path reaches here. Picking a row reports
-    // that row's id, because `ComboBoxField` swallows the display-text echo, so
-    // a label shared by two rows cannot resolve to the wrong one.
-    const byId = options.find((o) => o.value === trimmed)
-    if (byId) return byId.value
-    const byName = options.find((o) => o.label === trimmed)
-    return byName ? byName.value : trimmed
-  }
-
-  const selectedId = resolveId(text)
-  const known = options.some((o) => o.value === selectedId)
+  const ownerId = value.trim()
+  const isKnownOwner = options.some((o) => o.value === ownerId)
   const creatingHint =
-    selectedId !== "" && !known
+    ownerId !== "" && !isKnownOwner
       ? (unknownHint ?? (
           <span>
-            Creates a new user <code>{selectedId}</code>.
+            Creates a new user <code>{ownerId}</code>.
           </span>
         ))
       : (description ?? "Spend and budgets track against this user.")
@@ -99,11 +86,9 @@ export function UserComboBox({
   return (
     <ComboBoxField
       label={label}
-      value={text}
-      onChange={(next) => {
-        setText(next)
-        onChange(resolveId(next))
-      }}
+      value={value}
+      onChange={onChange}
+      onQueryChange={setQuery}
       options={visible}
       description={creatingHint}
       placeholder={placeholder}


### PR DESCRIPTION
## Description

The dashboard's combo box asked its callers to hand it the text sitting in the input rather than the option that was chosen. An option already carries both an id and a name, so a picker that keeps the text has no way to say which row is selected, and every caller had to work backwards from what was on screen to what should be submitted.

The owner picker on the keys page paid for that: it kept a second copy of the text, turned a name back into a user id by searching the list, and needed a hand-written rule to break the tie when two people share a name or one person's name happens to be another person's id. Those were real bugs (#1039 fixed both) and the rule was the only thing standing between them and a key billed to the wrong person.

Now the combo box takes the chosen option's id, reports that id when a row is picked, and puts the name in the box itself. Nothing maps a name back to an id any more, so neither collision can be expressed.

**One behavior change, on the keys page and the two routing pages.** Typing somebody's display name no longer selects them. You pick their row to choose a person; free text is an id of its own, which is what the keys page needs so a brand-new owner can be named (that endpoint creates the user), and what the model picker needs so a model discovery never listed can still be typed. The line under the field still says what typing will do, so the keys page reads "Creates a new user `Alice Example`." rather than quietly billing the key to Alice, and the routing pages, whose endpoints only accept an existing user, keep saying "No such user. Pick an existing one." This is the honest version of the case that produced the collisions: guessing which Alice was meant is what went wrong in the first place.

Two things fall out of it. A picker whose labels arrive after the field paints (a member's name comes from the organization roster) now shows the name once it lands instead of leaving the raw UUID on screen. And because the field owns the text, it publishes it, so a caller still decides what counts as a match: the owner picker keeps matching on an id as well as a name.

Deliberately unchanged: the model picker (a model's id is its label, so nothing diverged there), the multi-select and the provider picker (both already reported ids and needed no reverse mapping, and this PR is about the contract, not about rehoming working code), and the routing page, which has two other PRs in flight on it (#1038, #1056).

## How to test it locally

Automated, and this is the bulk of it:

- `pnpm --dir web exec vitest run src/design-system/forms/ComboBoxField.test.tsx` (13 tests). Rewritten for the new contract: a picked row reports its id exactly once and the box shows its label; typed text is reported where custom values are allowed; a label resolved after mount reaches the input; a value the caller moves under the field wins over the text left in the box; emptying the box clears the value; leaving the field keeps typed text and, on a whitelist, returns to the picked row.
- `pnpm --dir web exec vitest run src/features/users/UserComboBox.test.tsx` (12 tests). **Both collision regressions from #1039 still pass, unedited**: "submits the picked member, not the owner whose id is their roster name" and "submits the member that was picked when two of them share a name". They now hold because there is no reverse mapping to get wrong rather than because a tie-break rule wins, which is the point of the change. One test's comment is re-expressed for that reason, and a new test pins the behavior change itself, so nobody "fixes" a typed name back into a UUID.
- `pnpm --dir web exec vitest run src/design-system/forms src/features/users src/features/models src/features/keys src/features/routing src/features/providers` (16 files), plus `src/styles/foundation.test.ts` and `src/architecture.test.ts`, whose 3133 tests include the catalog rule that every design-system prop is passed by some story. Run these in two or three batches rather than one: the architecture probes time out under the load of eighteen files at once, which reads as seven failures and is not one.
- `pnpm --dir web run lint` and `pnpm --dir web run typecheck`, both clean.

The self-review turned up three holes in the first cut of the contract, each fixed in its own commit with a test: the field kept text it was typing after react-aria had dropped the selection behind it (a row of these fields that removes one hands a mounted field its neighbor's value, and the box went on showing the old one), emptying the box no longer cleared a whitelist's selection, and the owner picker stopped trimming what it reports, which the id resolution it replaces used to do.

By hand, on `/keys`: press New key, open the Owner picker, and pick a person. The box shows their name and the caption says spend tracks against them. Type an id nobody has and the caption becomes "Creates a new user `<id>`". Type a person's name instead and it says the same thing, which is the change: their row is what selects them. Then `/pricing`: the model field still takes a selector discovery never reported, still caps at 50 with "Showing 50 of N matches", and still names a provider it could not list.

Not run, deliberately: the full dashboard suite and the Storybook smoke sweep (the machine this was written on could not afford either). Two stories changed, and `typecheck` covers their compilation.

**This PR is stacked on `fix/user-picker-names` (#1051), not on `main`.** Every real workflow here declares `pull_request: branches: [main]`, so only `Lint PR title` and `check-template` run on it: the local runs above are the evidence, and CI will only cover this once #1051 lands and the base moves to `main`. `.coderabbit.yaml` also skips a non-main base, so CodeRabbit is triggered by a comment. `protect-main` does not apply either, so this can report `CLEAN`: **do not merge it before #1051**, and retarget it at `main` while #1051's branch still exists, since merging the parent with its branch deleted closes this one permanently.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Extends #1051, which is its base. Removes the mechanism behind the two collisions #1039 fixed.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

The dashboard's own checks stand in for the third box (`pnpm --dir web run lint`, `pnpm --dir web run typecheck`, and Vitest scoped to the paths above); nothing here touches Python, a route, or a schema, so the spec and the Postman collection are untouched.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

react-aria's `useComboBoxState` was read before choosing the arrangement, and the choice turns on one line in it: with both `inputValue` and `selectedKey` controlled, it stops writing the picked row's text back into the input and leaves that to the caller. That is what makes the echo-swallowing workaround unnecessary rather than merely hidden, so it is deleted. A row's `textValue` is the label alone for the same reason, so that re-picking the selected row cannot rewrite the input, and react-aria's own filter is turned off because it reads that `textValue` and would drop a row the caller matched on its hint.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
