### PR TITLE
feat(dashboard): put the two Tools creation forms in a dialog

### DIFF
--- a/web/src/design-system/layout/SettingsGroup.stories.tsx
+++ b/web/src/design-system/layout/SettingsGroup.stories.tsx
@@ -156,3 +156,27 @@ export const WithDocsLink: Story = {
     </SettingsGroup>
   ),
 }
+
+/**
+ * `action` puts the one thing this group is created into on its heading row,
+ * right-aligned, the way a page's own action sits on `PageIntro`'s. A group
+ * that owns a collection is where that collection is added to, so the control
+ * belongs beside the heading naming it rather than at the foot of its rows.
+ */
+export const WithAction: Story = {
+  render: () => (
+    <SettingsGroup
+      bounded
+      title="Search tools"
+      description="Named tools behind the direct endpoint."
+      action={<Button variant="primary">Add search tool</Button>}
+    >
+      <SettingRow
+        label="Allow web search"
+        control={
+          <Field label="Allow web search" value="on" onChange={() => {}} />
+        }
+      />
+    </SettingsGroup>
+  ),
+}

--- a/web/src/design-system/layout/SettingsGroup.test.tsx
+++ b/web/src/design-system/layout/SettingsGroup.test.tsx
@@ -72,4 +72,39 @@ describe("SettingsGroup", () => {
     const description = screen.getByText("What this group is for.")
     expect(description).toHaveClass("max-w-prose")
   })
+
+  it("puts an action on the heading row, in both shapes", () => {
+    // The slot exists so a group that owns a collection carries the control
+    // that adds to it, beside the words naming it. Both shapes, because the
+    // heading band and the bounded header are two different returns.
+    for (const bounded of [false, true]) {
+      const { unmount } = render(
+        <SettingsGroup
+          bounded={bounded}
+          title="Search tools"
+          action={<button type="button">Add search tool</button>}
+        >
+          <div>a row</div>
+        </SettingsGroup>,
+      )
+      const heading = screen.getByRole("heading", { name: "Search tools" })
+      const action = screen.getByRole("button", { name: "Add search tool" })
+      // The same row, which is what "on the heading row" means structurally:
+      // one element holds both, rather than the action following the band.
+      expect(heading.closest("div")?.parentElement).toContainElement(action)
+      unmount()
+    }
+  })
+
+  it("renders the heading row for an action alone, with no title", () => {
+    // The branch this prop moved: the row used to be skipped whenever there
+    // were no words, which would now also drop the control.
+    render(
+      <SettingsGroup action={<button type="button">Add</button>}>
+        <div>a row</div>
+      </SettingsGroup>,
+    )
+    expect(screen.queryByRole("heading")).toBeNull()
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument()
+  })
 })

--- a/web/src/design-system/layout/SettingsGroup.tsx
+++ b/web/src/design-system/layout/SettingsGroup.tsx
@@ -21,6 +21,7 @@ import { Section } from "./Section"
 export function SettingsGroup({
   title,
   count,
+  action,
   description,
   docsHref,
   bounded = false,
@@ -34,6 +35,13 @@ export function SettingsGroup({
   title?: string
   /** Shown beside the title where a group's size is worth knowing up front. */
   count?: number
+  /**
+   * The one thing this group is created into, on its heading row and aligned
+   * to the right, the way `PageIntro`'s does on a page's. A group that owns a
+   * collection is where that collection is added to, so the control belongs
+   * beside the heading naming it rather than at the foot of its rows.
+   */
+  action?: ReactNode
   /**
    * What the group is, under its heading and inside the same band. Capped to a
    * readable measure, because a band spans the page and a sentence should not.
@@ -69,15 +77,24 @@ export function SettingsGroup({
       </div>
     )
 
+  // The heading row: the words on the left, the action on the right, stacked
+  // on a phone where there is no room for two columns. Rendered here rather
+  // than at each call site so a group's action lands in one place.
+  const headingRow =
+    heading === null && blurb === null && action === undefined ? null : (
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-1">
+          {heading}
+          {blurb}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    )
+
   if (bounded) {
     return (
       <section className="flex flex-col gap-3">
-        {heading === null && blurb === null ? null : (
-          <div className="flex flex-col gap-1">
-            {heading}
-            {blurb}
-          </div>
-        )}
+        {headingRow}
         {/* `otari-settings` is the dense place, the way `otari-toolbar` is:
             globals.css sizes `.input` and `.select__trigger` inside it, so a
             row's control is 32px beside its label on a desk and 44px at 16px
@@ -91,13 +108,12 @@ export function SettingsGroup({
 
   return (
     <>
-      {heading === null && blurb === null ? null : (
+      {headingRow === null ? null : (
         <Section
           className="border-t border-border pt-6 pb-3"
           contentClassName="flex flex-col gap-2"
         >
-          {heading}
-          {blurb}
+          {headingRow}
         </Section>
       )}
       {/* `border-subtle` between the rows, `border` around the group. The two

--- a/web/src/design-system/layout/SettingsGroup.tsx
+++ b/web/src/design-system/layout/SettingsGroup.tsx
@@ -81,7 +81,7 @@ export function SettingsGroup({
   // on a phone where there is no room for two columns. Rendered here rather
   // than at each call site so a group's action lands in one place.
   const headingRow =
-    heading === null && blurb === null && action === undefined ? null : (
+    heading === null && blurb === null && !action ? null : (
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1">
           {heading}

--- a/web/src/features/tools/GuardrailParameterFields.tsx
+++ b/web/src/features/tools/GuardrailParameterFields.tsx
@@ -75,7 +75,6 @@ function ParameterControl({
         placeholder="value"
         description={description}
         isDisabled={disabled}
-        isRequired={spec.required}
         isInvalid={Boolean(error)}
         errorMessage={error}
         reserveMessage
@@ -143,7 +142,6 @@ function ParameterControl({
       value={String(value ?? "")}
       onChange={onChange}
       isDisabled={disabled}
-      isRequired={spec.required}
       isInvalid={Boolean(error)}
       errorMessage={error}
       placeholder={placeholderFor(spec)}
@@ -153,6 +151,12 @@ function ParameterControl({
   )
 }
 
+// No `isRequired` on these, deliberately. A required parameter is checked by
+// `parameterErrors`, which names the field and says what it needs; the native
+// attribute would refuse the submit first and silently, so inside a dialog the
+// form would never reach that message. One path, and it is the one that speaks.
+// The cost is the `required` marker these inputs no longer carry; the refusal
+// still arrives on the field, announced, through `isInvalid` and `errorMessage`.
 export function GuardrailParameterFields({
   specs,
   scopeName,

--- a/web/src/features/tools/GuardrailParametersSection.tsx
+++ b/web/src/features/tools/GuardrailParametersSection.tsx
@@ -49,7 +49,7 @@ export function GuardrailParametersSection({
    * takes none.
    */
   described: boolean
-  disabled: boolean
+  disabled?: boolean
   onChange: (name: string, next: ParameterValues[string]) => void
   onExtraJsonChange: (next: string) => void
 }) {
@@ -67,7 +67,7 @@ export function GuardrailParametersSection({
           scopeName={scopeName}
           values={values}
           errors={errors}
-          disabled={disabled}
+          disabled={disabled ?? false}
           onChange={onChange}
         />
       ) : null}

--- a/web/src/features/tools/GuardrailProfileField.tsx
+++ b/web/src/features/tools/GuardrailProfileField.tsx
@@ -3,8 +3,7 @@ import { useState } from "react"
 
 import type { GuardrailCatalog } from "@/client"
 import { Field } from "@/design-system/forms/Field"
-import { FieldMessages } from "@/design-system/forms/FieldMessages"
-import { FilterSelect } from "@/design-system/navigation/FilterSelect"
+import { Select } from "@/design-system/forms/Select"
 import { findProfile } from "@/features/tools/guardrailParameters"
 
 // Which profile a new entry mandates.
@@ -33,7 +32,7 @@ export function GuardrailProfileField({
    */
   pending: boolean
   value: string
-  disabled: boolean
+  disabled?: boolean
   onChange: (next: string) => void
 }) {
   const profiles = catalog?.profiles ?? []
@@ -43,21 +42,19 @@ export function GuardrailProfileField({
 
   if (pending) {
     return (
-      <div className="flex flex-col gap-1">
-        <FilterSelect
-          label="Guardrail profile"
-          value=""
-          disabled
-          onChange={onChange}
-          options={[{ value: "", label: "Reading the guardrails service…" }]}
-        />
-        <FieldMessages reserve>
-          <span className="text-caption">
-            Built by this deployment's guardrails service from the operator's
-            own configuration.
-          </span>
-        </FieldMessages>
-      </div>
+      <Select
+        label="Guardrail profile"
+        value=""
+        isDisabled
+        isRequired
+        onChange={onChange}
+        options={[]}
+        // The waiting sentence is the description rather than the placeholder:
+        // HeroUI's trigger renders the selected option's text and treats an
+        // empty value as a selection of "", so a placeholder never reaches the
+        // trigger here. The description is rendered and announced either way.
+        description="Reading the guardrails service…"
+      />
     )
   }
 
@@ -68,6 +65,7 @@ export function GuardrailProfileField({
           label="Guardrail profile"
           value={value}
           onChange={onChange}
+          isRequired
           isDisabled={disabled}
           placeholder="prompt-injection"
           description={
@@ -97,26 +95,23 @@ export function GuardrailProfileField({
 
   return (
     <div className="flex flex-col gap-1">
-      <FilterSelect
+      <Select
         label="Guardrail profile"
         value={chosen ? value : ""}
-        disabled={disabled}
+        isDisabled={disabled}
+        isRequired
         onChange={onChange}
-        options={[
-          { value: "", label: "Choose a profile" },
-          ...profiles.map((profile) => ({
-            value: profile.profile,
-            label: profile.profile,
-          })),
-        ]}
-      />
-      <FieldMessages reserve>
-        <span className="text-caption">
-          {chosen
+        placeholder="Choose a profile"
+        options={profiles.map((profile) => ({
+          value: profile.profile,
+          label: profile.profile,
+        }))}
+        description={
+          chosen
             ? `Runs ${chosen.guardrail}${chosen.model_id ? ` on ${chosen.model_id}` : ""} on the guardrails service.`
-            : "Built by this deployment's guardrails service from the operator's own configuration."}
-        </span>
-      </FieldMessages>
+            : "Built by this deployment's guardrails service from the operator's own configuration."
+        }
+      />
       <Button
         size="sm"
         variant="ghost"

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -125,7 +125,10 @@ function inDialog() {
 
 async function settledPicker() {
   await openDialog()
-  return await screen.findByRole("button", { name: /Choose a profile/ })
+  // The profile control is a `forms/Select` now: react-aria names its trigger
+  // with the label and the current value, so it is found by label rather than
+  // by the placeholder it happens to be showing.
+  return await waitFor(() => selectTrigger("Guardrail profile"))
 }
 
 function renderCard() {
@@ -451,17 +454,27 @@ describe("OrganizationGuardrailsCard", () => {
     // The control does not start as a free-text box and turn into a picker
     // under the operator's cursor: it is the picker throughout, and says so
     // while it waits.
-    expect(
-      await screen.findByRole("button", {
-        name: /Reading the guardrails service/,
-      }),
-    ).toBeDisabled()
+    // Named by its label now, and reading its waiting placeholder: the control
+    // is the picker throughout rather than a box that becomes one.
+    const waiting = await waitFor(() => selectTrigger("Guardrail profile"))
+    expect(waiting).toBeDisabled()
+    // The waiting sentence is the control's description, which is where it is
+    // both rendered and announced; the trigger's own text is the selected
+    // option's, and there is nothing to select yet.
+    expect(waiting).toHaveAccessibleDescription(
+      /Reading the guardrails service/,
+    )
     expect(
       screen.queryByRole("button", { name: "Name a profile by hand" }),
     ).toBeNull()
 
     answer()
-    expect(await settledPicker()).toBeEnabled()
+    // Waited on the state rather than on the element: the trigger is named by
+    // its label throughout, so it exists before and after the catalog answers
+    // and only its disabled state says which.
+    await waitFor(() =>
+      expect(selectTrigger("Guardrail profile")).toBeEnabled(),
+    )
   })
 
   it("picks a profile from what the guardrails service has built", async () => {
@@ -511,32 +524,23 @@ describe("OrganizationGuardrailsCard", () => {
   })
 
   it("refuses to add an entry whose guardrail needs a parameter it has not got", async () => {
-    // Inside a `FormDialog` the submit is a real form submission, so a
-    // parameter the profile declares required and the operator left blank is
-    // stopped by the browser's own constraint validation before
-    // `parameters.check()` runs. That is a change from the always-open form,
-    // where the Add button called the check directly and the field's own
-    // message spoke; asserted here as what the operator now meets, which is a
-    // required field, a refusal, and a dialog still open on their work.
+    // One validation path, and it is the app's own: `parameters.check()` names
+    // the field and says what it needs. The native `required` attribute would
+    // refuse the submit first and silently, so inside a dialog that message
+    // would never be reached.
     const calls = mockApi()
     const user = userEvent.setup()
     renderCard()
 
     await settledPicker()
     await pickOption(user, "Guardrail profile", "house-policy")
-    const required = inDialog()
-      .getAllByRole("textbox")
-      .filter((box) => box.hasAttribute("required"))
-    expect(required.length).toBeGreaterThan(0)
-    expect(
-      required.every((box) => (box as HTMLInputElement).value === ""),
-    ).toBe(true)
-
     await user.click(
       inDialog().getByRole("button", { name: "Mandate a guardrail" }),
     )
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(
+      await screen.findByText("This guardrail needs a value here."),
+    ).toBeInTheDocument()
     expect(calls.some((call) => call.method === "POST")).toBe(false)
   })
 

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -511,33 +511,32 @@ describe("OrganizationGuardrailsCard", () => {
   })
 
   it("refuses to add an entry whose guardrail needs a parameter it has not got", async () => {
+    // Inside a `FormDialog` the submit is a real form submission, so a
+    // parameter the profile declares required and the operator left blank is
+    // stopped by the browser's own constraint validation before
+    // `parameters.check()` runs. That is a change from the always-open form,
+    // where the Add button called the check directly and the field's own
+    // message spoke; asserted here as what the operator now meets, which is a
+    // required field, a refusal, and a dialog still open on their work.
     const calls = mockApi()
+    const user = userEvent.setup()
     renderCard()
 
     await settledPicker()
-    await pickOption(userEvent.setup(), "Guardrail profile", "house-policy")
-    await userEvent.click(
+    await pickOption(user, "Guardrail profile", "house-policy")
+    const required = inDialog()
+      .getAllByRole("textbox")
+      .filter((box) => box.hasAttribute("required"))
+    expect(required.length).toBeGreaterThan(0)
+    expect(
+      required.every((box) => (box as HTMLInputElement).value === ""),
+    ).toBe(true)
+
+    await user.click(
       inDialog().getByRole("button", { name: "Mandate a guardrail" }),
     )
 
-    // Inside a real form the browser refuses first: the field carries
-    // `required`, so the submit never reaches the mutation and the app's own
-    // "This guardrail needs a value here." never gets to speak. Asserted as
-    // what the operator now meets, which is the refusal and the constraint on
-    // the field, rather than as a message this path no longer produces.
-    // eslint-disable-next-line
-    console.log(
-      "FORMS",
-      document.querySelectorAll("form").length,
-      "IN DIALOG",
-      screen.getByRole("dialog").querySelectorAll("form").length,
-      "BTNFORM",
-      (
-        inDialog().getByRole("button", {
-          name: "Mandate a guardrail",
-        }) as HTMLButtonElement
-      ).form?.tagName,
-    )
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
     expect(calls.some((call) => call.method === "POST")).toBe(false)
   })
 

--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -105,8 +105,26 @@ function mockApi({
   return calls
 }
 
-/** Wait for the profile picker to settle, so a press is not sent to the disabled one. */
+/**
+ * Open the mandate dialog, and wait for the profile picker inside it to settle
+ * so a press is not sent to the disabled one. Idempotent on an open dialog.
+ */
+async function openDialog() {
+  if (screen.queryByRole("dialog") === null) {
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Mandate a guardrail" }),
+    )
+    await screen.findByRole("dialog")
+  }
+}
+
+/** The dialog's own controls, since the heading's trigger shares its words. */
+function inDialog() {
+  return within(screen.getByRole("dialog"))
+}
+
 async function settledPicker() {
+  await openDialog()
   return await screen.findByRole("button", { name: /Choose a profile/ })
 }
 
@@ -160,10 +178,15 @@ describe("OrganizationGuardrailsCard", () => {
     })
     renderCard()
 
-    expect(await screen.findByText("Alpha")).toBeInTheDocument()
+    // The badge, not any "Alpha" on the card: the row's scope picker carries
+    // the same workspace name on a checkbox, so an unscoped query here passed
+    // only while the workspace list had not answered yet.
     expect(
       await screen.findByText("Every workspace, including new ones"),
     ).toBeInTheDocument()
+    expect(
+      screen.getAllByText("Alpha").some((node) => node.tagName === "SPAN"),
+    ).toBe(true)
   })
 
   it("marks a paused entry and one that carries its own endpoint and credential", async () => {
@@ -390,6 +413,7 @@ describe("OrganizationGuardrailsCard", () => {
   it("mandates a new guardrail from the add form", async () => {
     const calls = mockApi()
     renderCard()
+    await openDialog()
 
     // A profile the catalog does not list, which is what the by-hand field is
     // for: this entry may be destined for an endpoint of its own.
@@ -397,7 +421,9 @@ describe("OrganizationGuardrailsCard", () => {
       await screen.findByRole("button", { name: "Name a profile by hand" }),
     )
     await userEvent.type(screen.getByLabelText("Guardrail profile"), "pii")
-    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+    await userEvent.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
     await waitFor(() =>
       expect(calls.some((call) => call.method === "POST")).toBe(true),
@@ -420,6 +446,7 @@ describe("OrganizationGuardrailsCard", () => {
       }),
     })
     renderCard()
+    await openDialog()
 
     // The control does not start as a free-text box and turn into a picker
     // under the operator's cursor: it is the picker throughout, and says so
@@ -443,7 +470,9 @@ describe("OrganizationGuardrailsCard", () => {
 
     await settledPicker()
     await pickOption(userEvent.setup(), "Guardrail profile", "prompt-injection")
-    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+    await userEvent.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
     await waitFor(() =>
       expect(calls.some((call) => call.method === "POST")).toBe(true),
@@ -463,7 +492,9 @@ describe("OrganizationGuardrailsCard", () => {
     await user.type(await screen.findByLabelText("Policy"), "No personal data.")
     await user.type(screen.getByLabelText("Threshold"), "0.8")
     await pickOption(user, "Prompt version", "v2")
-    await user.click(screen.getByRole("button", { name: "Add" }))
+    await user.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
     await waitFor(() =>
       expect(calls.some((call) => call.method === "POST")).toBe(true),
@@ -485,11 +516,28 @@ describe("OrganizationGuardrailsCard", () => {
 
     await settledPicker()
     await pickOption(userEvent.setup(), "Guardrail profile", "house-policy")
-    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+    await userEvent.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
-    expect(
-      await screen.findByText("This guardrail needs a value here."),
-    ).toBeInTheDocument()
+    // Inside a real form the browser refuses first: the field carries
+    // `required`, so the submit never reaches the mutation and the app's own
+    // "This guardrail needs a value here." never gets to speak. Asserted as
+    // what the operator now meets, which is the refusal and the constraint on
+    // the field, rather than as a message this path no longer produces.
+    // eslint-disable-next-line
+    console.log(
+      "FORMS",
+      document.querySelectorAll("form").length,
+      "IN DIALOG",
+      screen.getByRole("dialog").querySelectorAll("form").length,
+      "BTNFORM",
+      (
+        inDialog().getByRole("button", {
+          name: "Mandate a guardrail",
+        }) as HTMLButtonElement
+      ).form?.tagName,
+    )
     expect(calls.some((call) => call.method === "POST")).toBe(false)
   })
 
@@ -501,7 +549,9 @@ describe("OrganizationGuardrailsCard", () => {
     await settledPicker()
     await pickOption(user, "Guardrail profile", "house-policy")
     await user.type(await screen.findByLabelText("Policy"), "No personal data.")
-    await user.click(screen.getByRole("button", { name: "Add" }))
+    await user.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
     await waitFor(() =>
       expect(calls.some((call) => call.method === "POST")).toBe(true),
@@ -590,12 +640,15 @@ describe("OrganizationGuardrailsCard", () => {
       },
     })
     renderCard()
+    await openDialog()
 
     expect(
       await screen.findByText("The guardrails service could not be reached."),
     ).toBeInTheDocument()
     await userEvent.type(screen.getByLabelText("Guardrail profile"), "pii")
-    await userEvent.click(screen.getByRole("button", { name: "Add" }))
+    await userEvent.click(
+      inDialog().getByRole("button", { name: "Mandate a guardrail" }),
+    )
 
     await waitFor(() =>
       expect(calls.some((call) => call.method === "POST")).toBe(true),

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -1,12 +1,11 @@
-import { Button } from "@heroui/react"
-import { useEffect, useState } from "react"
-
+import { useEffect, useRef, useState } from "react"
 import type {
   GuardrailCatalog,
   GuardrailParameterSpec,
   OrganizationGuardrail,
   Workspace,
 } from "@/client"
+import { Button } from "@/design-system/actions/Button"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
@@ -208,18 +207,6 @@ function useParameterForm(
       return raw === undefined && Object.keys(found).length === 0
     },
     build: () => buildValidateKwargs(specs, state.values, state.extraJson),
-    /**
-     * Put the form back to what a fresh profile seeds, for the caller that
-     * clears the rest of its fields itself. The effect above cannot do it: it
-     * re-seeds on the serialized specs and stored values, and a cleared profile
-     * whose predecessor also took no typed parameters leaves both unchanged, so
-     * a raw entry would survive into the next guardrail this form adds.
-     */
-    reset: () => {
-      setState(seedParameters(specs, undefined))
-      setIssues({})
-      setRawError(undefined)
-    },
   }
 }
 
@@ -508,20 +495,20 @@ function AddGuardrailDialog({
   // moves to a profile with a different schema.
   const parameters = useParameterForm(specs, undefined)
 
-  // One predicate naming every field, the parameters included: a form whose
-  // only edits are parameter values is still a form with something to lose.
-  const isPristine =
-    profile === "" &&
-    mode === "monitor" &&
-    url === "" &&
-    credential === "" &&
-    !everywhere &&
-    scope.length === 0 &&
-    Object.keys(parameters.values).every(
-      (name) =>
-        parameters.values[name] === "" || parameters.values[name] === false,
-    ) &&
-    parameters.extraJson === ""
+  // One snapshot rather than a hand-listed predicate: a field added to this
+  // form would otherwise have to be remembered in a second place, and the
+  // parameters are the half most easily forgotten.
+  const draft = JSON.stringify({
+    profile,
+    mode,
+    url,
+    credential,
+    everywhere,
+    scope,
+    values: parameters.values,
+    extraJson: parameters.extraJson,
+  })
+  const seed = useRef(draft)
 
   const submit = () => {
     const named = profile.trim()
@@ -560,7 +547,7 @@ function AddGuardrailDialog({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={profile.trim() === ""}
-      isDirty={!isPristine}
+      isDirty={draft !== seed.current}
       error={create.error}
     >
       <GuardrailProfileField
@@ -575,7 +562,6 @@ function AddGuardrailDialog({
         value={mode}
         onChange={(next) => setMode(next as Mode)}
         options={MODE_OPTIONS}
-        reserveMessage={false}
         description="A caller can tighten a mandated guardrail but never weaken it."
       />
       <Field
@@ -584,6 +570,7 @@ function AddGuardrailDialog({
         onChange={setUrl}
         isDisabled={create.isPending}
         placeholder="blank uses the guardrails URL above"
+        reserveMessage={false}
       />
       <SecretField
         label="Credential"
@@ -675,6 +662,27 @@ export function OrganizationGuardrailsCard({
       {manages ? (
         <>
           <ErrorBanner error={guardrails.error ?? workspaces.error} />
+          {/* Ahead of the rows, not after them. `FormDialog` renders its
+              trigger slot in place as a real element, so a dialog mounted last
+              inside a `divide-y` container takes `:last-child` off the final
+              row and draws a divider right above the container's own bottom
+              edge. `display: none` does not exempt an element from that.
+
+              Keyed on the open count, so each open remounts a blank form:
+              clearing the draft on close would blank the fields while the
+              dialog is still animating away. */}
+          <AddGuardrailDialog
+            key={openCount}
+            isOpen={adding}
+            onClose={() => setAdding(false)}
+            catalog={catalog.data}
+            // `isFetched` rather than `isPending`: an errored query returns to
+            // pending when its observers remount, which would leave the picker
+            // stuck reading a service that already answered.
+            catalogPending={!catalog.isFetched}
+            workspaces={known}
+            onSaved={onSaved}
+          />
           {entries.map((guardrail) => (
             <GuardrailRow
               key={guardrail.id}
@@ -690,21 +698,6 @@ export function OrganizationGuardrailsCard({
               for run.
             </p>
           ) : null}
-          {/* Keyed on the open count, so each open remounts a blank form.
-              Clearing the draft on close instead would blank the fields while
-              the dialog is still animating away. */}
-          <AddGuardrailDialog
-            key={openCount}
-            isOpen={adding}
-            onClose={() => setAdding(false)}
-            catalog={catalog.data}
-            // `isFetched` rather than `isPending`: an errored query returns to
-            // pending when its observers remount, which would leave the picker
-            // stuck reading a service that already answered.
-            catalogPending={!catalog.isFetched}
-            workspaces={known}
-            onSaved={onSaved}
-          />
         </>
       ) : null}
     </SettingsGroup>

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type {
   GuardrailCatalog,
   GuardrailParameterSpec,
@@ -16,6 +16,7 @@ import { Field } from "@/design-system/forms/Field"
 import { INPUT_CLASS } from "@/design-system/forms/inputClass"
 import { SecretField } from "@/design-system/forms/SecretField"
 import { Select } from "@/design-system/forms/Select"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Badge } from "@/design-system/indicators/Badge"
 import { SettingsGroup } from "@/design-system/layout/SettingsGroup"
 import { FilterSelect } from "@/design-system/navigation/FilterSelect"
@@ -92,6 +93,7 @@ function WorkspaceScope({
   selected,
   workspaces,
   disabled,
+  variant = "filter",
   onEverywhere,
   onToggle,
 }: {
@@ -100,22 +102,40 @@ function WorkspaceScope({
   everywhere: boolean
   selected: readonly string[]
   workspaces: readonly Workspace[]
-  disabled: boolean
+  disabled?: boolean
+  /**
+   * Which half of the pair the picker is. A row on this card is a dense line
+   * of toolbar controls; the dialog is a form, where a caption label beside
+   * the control would be the one thing on it reading differently.
+   */
+  variant?: "filter" | "form"
   onEverywhere: (value: boolean) => void
   onToggle: (workspaceId: string) => void
 }) {
+  const scopeOptions = [
+    { value: "all", label: "Every workspace" },
+    { value: "chosen", label: "Chosen workspaces" },
+  ]
   return (
     <div className="flex flex-col gap-2">
-      <FilterSelect
-        label="Runs in"
-        value={everywhere ? "all" : "chosen"}
-        onChange={(next) => onEverywhere(next === "all")}
-        options={[
-          { value: "all", label: "Every workspace" },
-          { value: "chosen", label: "Chosen workspaces" },
-        ]}
-        disabled={disabled}
-      />
+      {variant === "form" ? (
+        <Select
+          label="Runs in"
+          value={everywhere ? "all" : "chosen"}
+          onChange={(next) => onEverywhere(next === "all")}
+          options={scopeOptions}
+          isDisabled={disabled}
+          reserveMessage={false}
+        />
+      ) : (
+        <FilterSelect
+          label="Runs in"
+          value={everywhere ? "all" : "chosen"}
+          onChange={(next) => onEverywhere(next === "all")}
+          options={scopeOptions}
+          disabled={disabled}
+        />
+      )}
       {everywhere ? null : (
         // A named group rather than a per-box aria-label. Each box is labelled
         // by the workspace name a reader can see, and the group says which
@@ -495,10 +515,10 @@ function AddGuardrailDialog({
   // moves to a profile with a different schema.
   const parameters = useParameterForm(specs, undefined)
 
-  // One snapshot rather than a hand-listed predicate: a field added to this
+  // Everything the operator can change, in one snapshot: a field added to this
   // form would otherwise have to be remembered in a second place, and the
   // parameters are the half most easily forgotten.
-  const draft = JSON.stringify({
+  const { isDirty } = useDirtySnapshot({
     profile,
     mode,
     url,
@@ -508,7 +528,6 @@ function AddGuardrailDialog({
     values: parameters.values,
     extraJson: parameters.extraJson,
   })
-  const seed = useRef(draft)
 
   const submit = () => {
     const named = profile.trim()
@@ -547,14 +566,13 @@ function AddGuardrailDialog({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={profile.trim() === ""}
-      isDirty={draft !== seed.current}
+      isDirty={isDirty}
       error={create.error}
     >
       <GuardrailProfileField
         catalog={catalog}
         pending={catalogPending}
         value={profile}
-        disabled={create.isPending}
         onChange={setProfile}
       />
       <Select
@@ -568,7 +586,6 @@ function AddGuardrailDialog({
         label="Endpoint"
         value={url}
         onChange={setUrl}
-        isDisabled={create.isPending}
         placeholder="blank uses the guardrails URL above"
         reserveMessage={false}
       />
@@ -580,10 +597,10 @@ function AddGuardrailDialog({
       />
       <WorkspaceScope
         scopeName={profile || "New guardrail"}
+        variant="form"
         everywhere={everywhere}
         selected={scope}
         workspaces={workspaces}
-        disabled={create.isPending}
         onEverywhere={setEverywhere}
         onToggle={(workspaceId) =>
           setScope((current) =>
@@ -605,7 +622,6 @@ function AddGuardrailDialog({
         extraJson={parameters.extraJson}
         extraJsonError={parameters.rawError}
         described={describedProfile}
-        disabled={create.isPending}
         onChange={parameters.setValue}
         onExtraJsonChange={parameters.setExtraJson}
       />
@@ -641,65 +657,65 @@ export function OrganizationGuardrailsCard({
   const known = workspaces.data ?? []
 
   return (
-    <SettingsGroup
-      bounded
-      title="Organization guardrails"
-      description="Guardrails that run on every request from the workspaces below, whether the caller asked for them or not. They compose with the deployment settings above rather than replacing them: an entry with no endpoint of its own is sent to the guardrails URL set there, and an organization that mandates nothing leaves every request checked exactly as it is today."
-      action={
-        manages ? (
-          <Button variant="primary" onPress={openAdd}>
-            Mandate a guardrail
-          </Button>
-        ) : null
-      }
-    >
-      {manages ? null : (
-        <InfoBanner>
-          Organization guardrails are set by an owner or admin of the
-          organization.
-        </InfoBanner>
-      )}
-      {manages ? (
-        <>
-          <ErrorBanner error={guardrails.error ?? workspaces.error} />
-          {/* Ahead of the rows, not after them. `FormDialog` renders its
-              trigger slot in place as a real element, so a dialog mounted last
-              inside a `divide-y` container takes `:last-child` off the final
-              row and draws a divider right above the container's own bottom
-              edge. `display: none` does not exempt an element from that.
+    <>
+      {/* Outside the group, not inside it: `FormDialog` renders its trigger
+          slot as a real element, and a group's rows are a `divide-y` container
+          where one more child changes which row is last.
 
-              Keyed on the open count, so each open remounts a blank form:
-              clearing the draft on close would blank the fields while the
-              dialog is still animating away. */}
-          <AddGuardrailDialog
-            key={openCount}
-            isOpen={adding}
-            onClose={() => setAdding(false)}
-            catalog={catalog.data}
-            // `isFetched` rather than `isPending`: an errored query returns to
-            // pending when its observers remount, which would leave the picker
-            // stuck reading a service that already answered.
-            catalogPending={!catalog.isFetched}
-            workspaces={known}
-            onSaved={onSaved}
-          />
-          {entries.map((guardrail) => (
-            <GuardrailRow
-              key={guardrail.id}
-              guardrail={guardrail}
-              catalog={catalog.data}
-              workspaces={known}
-              onSaved={onSaved}
-            />
-          ))}
-          {entries.length === 0 && !guardrails.isLoading ? (
-            <p className="py-4 text-sm text-muted">
-              No organization guardrails, so only the guardrails a caller asks
-              for run.
-            </p>
-          ) : null}
-        </>
+          Keyed on the open count, so each open remounts a blank form. */}
+      {manages ? (
+        <AddGuardrailDialog
+          key={openCount}
+          isOpen={adding}
+          onClose={() => setAdding(false)}
+          catalog={catalog.data}
+          // `isFetched` rather than `isPending`: an errored query returns to
+          // pending when its observers remount, which would leave the picker
+          // stuck reading a service that already answered.
+          catalogPending={!catalog.isFetched}
+          workspaces={known}
+          onSaved={onSaved}
+        />
       ) : null}
-    </SettingsGroup>
+      <SettingsGroup
+        bounded
+        title="Organization guardrails"
+        description="Guardrails that run on every request from the workspaces below, whether the caller asked for them or not. They compose with the deployment settings above rather than replacing them: an entry with no endpoint of its own is sent to the guardrails URL set there, and an organization that mandates nothing leaves every request checked exactly as it is today."
+        action={
+          manages ? (
+            <Button variant="primary" onPress={openAdd}>
+              Mandate a guardrail
+            </Button>
+          ) : null
+        }
+      >
+        {manages ? null : (
+          <InfoBanner>
+            Organization guardrails are set by an owner or admin of the
+            organization.
+          </InfoBanner>
+        )}
+        {manages ? (
+          <>
+            <ErrorBanner error={guardrails.error ?? workspaces.error} />
+            {entries.map((guardrail) => (
+              <GuardrailRow
+                key={guardrail.id}
+                guardrail={guardrail}
+                catalog={catalog.data}
+                workspaces={known}
+                onSaved={onSaved}
+              />
+            ))}
+            {entries.length === 0 && !guardrails.isLoading ? (
+              <p className="py-4 text-sm text-muted">
+                No organization guardrails, so only the guardrails a caller asks
+                for run.
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </SettingsGroup>
+    </>
   )
 }

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -10,9 +10,13 @@ import type {
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { errorMessage } from "@/design-system/feedback/errorMessage"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
+import { Field } from "@/design-system/forms/Field"
 import { INPUT_CLASS } from "@/design-system/forms/inputClass"
+import { SecretField } from "@/design-system/forms/SecretField"
+import { Select } from "@/design-system/forms/Select"
 import { Badge } from "@/design-system/indicators/Badge"
 import { SettingsGroup } from "@/design-system/layout/SettingsGroup"
 import { FilterSelect } from "@/design-system/navigation/FilterSelect"
@@ -473,12 +477,16 @@ function GuardrailRow({
   )
 }
 
-function AddGuardrailForm({
+function AddGuardrailDialog({
+  isOpen,
+  onClose,
   catalog,
   catalogPending,
   workspaces,
   onSaved,
 }: {
+  isOpen: boolean
+  onClose: () => void
   catalog: GuardrailCatalog | undefined
   catalogPending: boolean
   workspaces: readonly Workspace[]
@@ -491,7 +499,6 @@ function AddGuardrailForm({
   const [credential, setCredential] = useState("")
   const [everywhere, setEverywhere] = useState(false)
   const [scope, setScope] = useState<string[]>([])
-  const [error, setError] = useState("")
   const specs = parameterSpecs(catalog, profile)
   // An empty picker describes nothing, but its panel should not open on that
   // account: there is no profile yet for a raw parameter to belong to.
@@ -501,8 +508,22 @@ function AddGuardrailForm({
   // moves to a profile with a different schema.
   const parameters = useParameterForm(specs, undefined)
 
+  // One predicate naming every field, the parameters included: a form whose
+  // only edits are parameter values is still a form with something to lose.
+  const isPristine =
+    profile === "" &&
+    mode === "monitor" &&
+    url === "" &&
+    credential === "" &&
+    !everywhere &&
+    scope.length === 0 &&
+    Object.keys(parameters.values).every(
+      (name) =>
+        parameters.values[name] === "" || parameters.values[name] === false,
+    ) &&
+    parameters.extraJson === ""
+
   const submit = () => {
-    setError("")
     const named = profile.trim()
     if (!parameters.check()) return
     create.mutate(
@@ -517,21 +538,31 @@ function AddGuardrailForm({
       },
       {
         onSuccess: () => {
-          setProfile("")
-          setUrl("")
-          setCredential("")
-          setScope([])
-          parameters.reset()
           onSaved(`${named} added`)
+          onClose()
         },
-        onError: (err) => setError(errorMessage(err)),
       },
     )
   }
 
   return (
-    <div className="flex flex-col gap-2 py-4">
-      <span className="text-body">Mandate a guardrail</span>
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // `lg`, unlike the search-tool dialog beside it: the parameters section
+      // is a variable-length list of controls plus a raw-JSON escape hatch,
+      // which the small frame has no room for.
+      size="lg"
+      title="Mandated guardrail"
+      submitLabel="Mandate a guardrail"
+      onSubmit={submit}
+      isPending={create.isPending}
+      isSubmitDisabled={profile.trim() === ""}
+      isDirty={!isPristine}
+      error={create.error}
+    >
       <GuardrailProfileField
         catalog={catalog}
         pending={catalogPending}
@@ -539,35 +570,27 @@ function AddGuardrailForm({
         disabled={create.isPending}
         onChange={setProfile}
       />
-      <div className="flex flex-wrap items-end gap-2">
-        <FilterSelect
-          ariaLabel="Guardrail mode"
-          value={mode}
-          onChange={(next) => setMode(next as Mode)}
-          options={MODE_OPTIONS}
-          disabled={create.isPending}
-        />
-        <input
-          type="text"
-          inputMode="url"
-          aria-label="Guardrails endpoint"
-          value={url}
-          disabled={create.isPending}
-          placeholder="endpoint (blank uses the URL above)"
-          onChange={(event) => setUrl(event.target.value)}
-          className={`w-full sm:w-72 ${INPUT_CLASS}`}
-        />
-        <input
-          type="password"
-          autoComplete="new-password"
-          aria-label="Guardrail credential"
-          value={credential}
-          disabled={create.isPending}
-          placeholder="credential (needs an https endpoint)"
-          onChange={(event) => setCredential(event.target.value)}
-          className={`w-full sm:w-52 ${INPUT_CLASS}`}
-        />
-      </div>
+      <Select
+        label="Mode"
+        value={mode}
+        onChange={(next) => setMode(next as Mode)}
+        options={MODE_OPTIONS}
+        reserveMessage={false}
+        description="A caller can tighten a mandated guardrail but never weaken it."
+      />
+      <Field
+        label="Endpoint"
+        value={url}
+        onChange={setUrl}
+        isDisabled={create.isPending}
+        placeholder="blank uses the guardrails URL above"
+      />
+      <SecretField
+        label="Credential"
+        value={credential}
+        onChange={setCredential}
+        description="Needs an https endpoint of its own, since the URL above may be a plain-http sidecar, and OTARI_SECRET_KEY set on the gateway."
+      />
       <WorkspaceScope
         scopeName={profile || "New guardrail"}
         everywhere={everywhere}
@@ -599,26 +622,7 @@ function AddGuardrailForm({
         onChange={parameters.setValue}
         onExtraJsonChange={parameters.setExtraJson}
       />
-      <div className="flex items-center gap-2">
-        <Button
-          size="sm"
-          variant="primary"
-          isDisabled={profile.trim() === "" || create.isPending}
-          onPress={submit}
-        >
-          {create.isPending ? "Adding…" : "Add"}
-        </Button>
-      </div>
-      <span className="text-caption">
-        A caller can tighten a mandated guardrail but never weaken it. A
-        credential needs an https endpoint of its own, since the URL above may
-        be a plain-http sidecar, and{" "}
-        <code className="font-mono">OTARI_SECRET_KEY</code> set on the gateway.
-      </span>
-      {error ? (
-        <span className="break-words text-caption text-danger">{error}</span>
-      ) : null}
-    </div>
+    </FormDialog>
   )
 }
 
@@ -638,6 +642,14 @@ export function OrganizationGuardrailsCard({
   // asked for over a form the caller cannot use.
   const catalog = useGuardrailProfiles(manages)
   const workspaces = useWorkspaces()
+  const [adding, setAdding] = useState(false)
+  // Bumped on every open and used as the dialog's key, so the draft is cleared
+  // on the way in rather than on the way out.
+  const [openCount, setOpenCount] = useState(0)
+  const openAdd = () => {
+    setOpenCount((count) => count + 1)
+    setAdding(true)
+  }
   const entries = guardrails.data ?? []
   const known = workspaces.data ?? []
 
@@ -646,6 +658,13 @@ export function OrganizationGuardrailsCard({
       bounded
       title="Organization guardrails"
       description="Guardrails that run on every request from the workspaces below, whether the caller asked for them or not. They compose with the deployment settings above rather than replacing them: an entry with no endpoint of its own is sent to the guardrails URL set there, and an organization that mandates nothing leaves every request checked exactly as it is today."
+      action={
+        manages ? (
+          <Button variant="primary" onPress={openAdd}>
+            Mandate a guardrail
+          </Button>
+        ) : null
+      }
     >
       {manages ? null : (
         <InfoBanner>
@@ -671,7 +690,13 @@ export function OrganizationGuardrailsCard({
               for run.
             </p>
           ) : null}
-          <AddGuardrailForm
+          {/* Keyed on the open count, so each open remounts a blank form.
+              Clearing the draft on close instead would blank the fields while
+              the dialog is still animating away. */}
+          <AddGuardrailDialog
+            key={openCount}
+            isOpen={adding}
+            onClose={() => setAdding(false)}
             catalog={catalog.data}
             // `isFetched` rather than `isPending`: an errored query returns to
             // pending when its observers remount, which would leave the picker

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -162,19 +162,46 @@ describe("SearchToolsCard", () => {
     expect(screen.queryByText("0 tools")).toBeNull()
   })
 
+  it("keeps the heading trigger on screen and opens on a blank draft", async () => {
+    mockApi()
+    const user = userEvent.setup()
+    await renderOpened(user)
+    await screen.findByText("local")
+
+    const trigger = screen.getByRole("button", { name: "Add search tool" })
+    await user.click(trigger)
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+    expect(trigger).toBeVisible()
+
+    await user.type(
+      within(screen.getByRole("dialog")).getByLabelText(/^Name/),
+      "second",
+    )
+    // A draft this far along is dirty, so the way out is through the guard.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+
+    await user.click(trigger)
+    expect(
+      within(await screen.findByRole("dialog")).getByLabelText(/^Name/),
+    ).toHaveValue("")
+  })
+
   it("adds a tool with the chosen provider", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()
     await renderOpened(user)
     await screen.findByText("local")
 
-    await user.type(screen.getByLabelText("Search tool name"), "second")
-    await pickOption(user, "Search provider", "searxng")
-    await user.type(
-      screen.getByLabelText("Search backend URL"),
-      "http://other:8080",
-    )
-    await user.click(screen.getByRole("button", { name: "Add" }))
+    await user.click(screen.getByRole("button", { name: "Add search tool" }))
+    // Scoped to the dialog: the heading's trigger and the submit say the same
+    // words, and every row behind it has a backend-URL box of its own.
+    const dialog = within(await screen.findByRole("dialog"))
+    await user.type(dialog.getByLabelText(/^Name/), "second")
+    await pickOption(user, "Provider", "searxng")
+    await user.type(dialog.getByLabelText(/^Backend URL/), "http://other:8080")
+    await user.click(dialog.getByRole("button", { name: "Add search tool" }))
 
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(
@@ -196,11 +223,14 @@ describe("SearchToolsCard", () => {
     await renderOpened(user)
     await screen.findByText("local")
 
-    await user.type(screen.getByLabelText("Search tool name"), "keyless-exa")
-    expect(screen.getByRole("button", { name: "Add" })).toBeDisabled()
+    await user.click(screen.getByRole("button", { name: "Add search tool" }))
+    const dialog = within(await screen.findByRole("dialog"))
+    await user.type(dialog.getByLabelText(/^Name/), "keyless-exa")
+    const submit = dialog.getByRole("button", { name: "Add search tool" })
+    expect(submit).toBeDisabled()
 
-    await user.type(screen.getByLabelText("Search API key"), "exa-live")
-    expect(screen.getByRole("button", { name: "Add" })).toBeEnabled()
+    await user.type(dialog.getByLabelText(/^API key/), "exa-live")
+    expect(submit).toBeEnabled()
   })
 
   it("omits api_key from a save that only changes the backend URL", async () => {

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -162,6 +162,34 @@ describe("SearchToolsCard", () => {
     expect(screen.queryByText("0 tools")).toBeNull()
   })
 
+  it("opens the drill-in when a tool is created, so the new row is on screen", async () => {
+    // The row lands inside a disclosure that is collapsed by default, and the
+    // trigger is on the group heading outside it, so without this the dialog
+    // closes and the only thing that changes is the trailing count.
+    mockApi()
+    const user = userEvent.setup()
+    renderWithClient(<SearchToolsCard docsHref="https://docs.example/tools" />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add search tool" }),
+    )
+    const dialog = within(await screen.findByRole("dialog"))
+    await user.type(dialog.getByLabelText(/^Name/), "second")
+    await pickOption(user, "Provider", "searxng")
+    await user.type(dialog.getByLabelText(/^Backend URL/), "http://other:8080")
+    await user.click(dialog.getByRole("button", { name: "Add search tool" }))
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    // The drill-in itself reports open, which is what puts the new row in
+    // front of the operator; asserting a row's text would pass on a closed
+    // disclosure whose content is still in the DOM.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Configure search tools/ }),
+      ).toHaveAttribute("aria-expanded", "true"),
+    )
+  })
+
   it("keeps the heading trigger on screen and opens on a blank draft", async () => {
     mockApi()
     const user = userEvent.setup()

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -8,11 +8,13 @@ import type {
 import { Button } from "@/design-system/actions/Button"
 import { ConfirmDialog } from "@/design-system/feedback/ConfirmDialog"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
-import { errorMessage } from "@/design-system/feedback/errorMessage"
+import { FormDialog } from "@/design-system/feedback/FormDialog"
+import { Field } from "@/design-system/forms/Field"
 import { INPUT_CLASS } from "@/design-system/forms/inputClass"
+import { SecretField } from "@/design-system/forms/SecretField"
+import { Select } from "@/design-system/forms/Select"
 import { SettingsGroup } from "@/design-system/layout/SettingsGroup"
 import { DisclosureRow } from "@/design-system/navigation/DisclosureRow"
-import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
 import {
   useCreateSearchTool,
@@ -217,13 +219,20 @@ function ConfigToolLine({ tool }: { tool: ConfigSearchTool }) {
   )
 }
 
-function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
+function AddToolDialog({
+  isOpen,
+  onClose,
+  providers,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  providers: SearchProviderInfo[]
+}) {
   const create = useCreateSearchTool()
   const [name, setName] = useState("")
   const [provider, setProvider] = useState(providers[0]?.id ?? "")
   const [apiBase, setApiBase] = useState("")
   const [apiKey, setApiKey] = useState("")
-  const [error, setError] = useState("")
 
   const selected = providers.find((entry) => entry.id === provider)
   const inherited = selected?.default_api_base ?? null
@@ -239,7 +248,6 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
     (!keyRequired || apiKey !== "")
 
   const submit = () => {
-    setError("")
     create.mutate(
       {
         name: name.trim(),
@@ -247,86 +255,69 @@ function AddToolForm({ providers }: { providers: SearchProviderInfo[] }) {
         api_base: apiBase.trim() === "" ? null : apiBase.trim(),
         api_key: apiKey === "" ? null : apiKey,
       },
-      {
-        onSuccess: () => {
-          setName("")
-          setApiBase("")
-          setApiKey("")
-        },
-        onError: (cause) => setError(errorMessage(cause)),
-      },
+      { onSuccess: onClose },
     )
   }
 
   return (
-    <div className="flex flex-col gap-2 px-4 py-3">
-      <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
-        <input
-          type="text"
-          aria-label="Search tool name"
-          value={name}
-          placeholder="local"
-          disabled={create.isPending}
-          onChange={(event) => setName(event.target.value)}
-          className={`otari-machine-field w-full md:w-[7.5rem] ${INPUT_CLASS}`}
-        />
-        <FilterSelect
-          ariaLabel="Search provider"
-          value={provider}
-          onChange={setProvider}
-          options={providers.map((entry) => ({
-            value: entry.id,
-            label: entry.id,
-          }))}
-          disabled={create.isPending}
-        />
-        <input
-          type="text"
-          inputMode="url"
-          aria-label="Search backend URL"
-          value={apiBase}
-          disabled={create.isPending}
-          placeholder={
-            inherited
-              ? `inherits ${inherited}`
-              : baseRequired
-                ? "backend URL (required)"
-                : "backend URL"
-          }
-          onChange={(event) => setApiBase(event.target.value)}
-          className={`otari-machine-field w-full md:w-[15rem] ${INPUT_CLASS}`}
-        />
-        <input
-          type="password"
-          autoComplete="new-password"
-          aria-label="Search API key"
-          value={apiKey}
-          disabled={create.isPending}
-          placeholder={
-            keyRequired ? "API key (required)" : "API key (optional)"
-          }
-          onChange={(event) => setApiKey(event.target.value)}
-          className={`otari-machine-field w-full md:w-[10rem] ${INPUT_CLASS}`}
-        />
-        <Button
-          size="sm"
-          variant="primary"
-          isDisabled={!ready || create.isPending}
-          onPress={submit}
-        >
-          {create.isPending ? "Adding…" : "Add"}
-        </Button>
-      </div>
-      <p className="text-caption text-subtle">
-        Storing an API key needs{" "}
-        <code className="font-mono">OTARI_SECRET_KEY</code> set on the gateway.
-      </p>
-      {error ? (
-        <p role="alert" className="break-words text-caption text-danger">
-          {error}
-        </p>
-      ) : null}
-    </div>
+    <FormDialog
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      size="sm"
+      title="New search tool"
+      submitLabel="Add search tool"
+      onSubmit={submit}
+      isPending={create.isPending}
+      isSubmitDisabled={!ready}
+      isDirty={name.trim() !== "" || apiBase.trim() !== "" || apiKey !== ""}
+      error={create.error}
+    >
+      <Field
+        label="Name"
+        value={name}
+        onChange={setName}
+        isRequired
+        autoFocus
+        placeholder="local"
+        description="What a caller names in search_tool_name, or in the /api/v1/search/{tool} path."
+      />
+      <Select
+        label="Provider"
+        value={provider}
+        onChange={setProvider}
+        options={providers.map((entry) => ({
+          value: entry.id,
+          label: entry.id,
+        }))}
+        reserveMessage={false}
+      />
+      <Field
+        label="Backend URL"
+        value={apiBase}
+        onChange={setApiBase}
+        isRequired={baseRequired}
+        placeholder={inherited ?? "https://…"}
+        description={
+          inherited
+            ? `Leave blank to inherit ${inherited}.`
+            : baseRequired
+              ? "This provider has no endpoint of its own, so it needs one here."
+              : "Optional for this provider."
+        }
+      />
+      <SecretField
+        label="API key"
+        value={apiKey}
+        onChange={setApiKey}
+        description={
+          keyRequired
+            ? "This provider needs one. Storing it needs OTARI_SECRET_KEY set on the gateway."
+            : "Optional for this provider. Storing one needs OTARI_SECRET_KEY set on the gateway."
+        }
+      />
+    </FormDialog>
   )
 }
 
@@ -342,6 +333,8 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
   const tools = useSearchTools()
   const providers = useSearchProviders()
   const [isOpen, setIsOpen] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [openCount, setOpenCount] = useState(0)
 
   const known = providers.data ?? []
   const stored = tools.data?.stored ?? []
@@ -359,7 +352,29 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
       title="Search tools"
       description="Named tools behind the direct endpoint, POST /api/v1/search. A searxng tool with no URL of its own reuses the backend above."
       docsHref={docsHref}
+      action={
+        known.length > 0 ? (
+          <Button
+            variant="primary"
+            onPress={() => {
+              setOpenCount((count) => count + 1)
+              setAdding(true)
+            }}
+          >
+            Add search tool
+          </Button>
+        ) : null
+      }
     >
+      {/* Keyed on the open count, so each open remounts a blank form. Clearing
+          the draft on close instead would blank the fields while the dialog is
+          still animating away. */}
+      <AddToolDialog
+        key={openCount}
+        isOpen={adding}
+        onClose={() => setAdding(false)}
+        providers={known}
+      />
       {tools.error || providers.error ? (
         // Outside the disclosure: a read that failed is the thing the operator
         // most needs to see, and the row is collapsed by default.
@@ -393,7 +408,6 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
           {fromConfig.map((tool) => (
             <ConfigToolLine key={tool.name} tool={tool} />
           ))}
-          {known.length > 0 ? <AddToolForm providers={known} /> : null}
         </div>
       </DisclosureRow>
     </SettingsGroup>

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useState } from "react"
 import type {
   ConfigSearchTool,
   SearchProviderInfo,
@@ -13,6 +13,7 @@ import { Field } from "@/design-system/forms/Field"
 import { INPUT_CLASS } from "@/design-system/forms/inputClass"
 import { SecretField } from "@/design-system/forms/SecretField"
 import { Select } from "@/design-system/forms/Select"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { SettingsGroup } from "@/design-system/layout/SettingsGroup"
 import { DisclosureRow } from "@/design-system/navigation/DisclosureRow"
 import { usePolicyWriter } from "@/features/tools/usePolicyWriter"
@@ -148,7 +149,6 @@ function StoredToolLine({
           className={`otari-machine-field w-full md:w-[10rem] ${INPUT_CLASS}`}
         />
         <Button
-          size="sm"
           variant="ghost"
           // Named per row, as this row's fields are: the card is a list of
           // tools, so a bare "Remove" is the same name on every one of them.
@@ -222,10 +222,18 @@ function ConfigToolLine({ tool }: { tool: ConfigSearchTool }) {
 function AddToolDialog({
   isOpen,
   onClose,
+  onCreated,
   providers,
 }: {
   isOpen: boolean
   onClose: () => void
+  /**
+   * A tool landed. Separate from `onClose` because the created row is inside a
+   * drill-in that is collapsed by default: closing on a cancel should leave it
+   * as it was, and closing on a create should open it, or the only thing that
+   * changes on screen is the trailing count.
+   */
+  onCreated: () => void
   providers: SearchProviderInfo[]
 }) {
   const create = useCreateSearchTool()
@@ -245,8 +253,7 @@ function AddToolDialog({
   // One snapshot rather than a hand-listed predicate: the provider is a field
   // like the others, and a guard that forgot it discarded a changed provider
   // with no question asked.
-  const draft = JSON.stringify({ name, provider, apiBase, apiKey })
-  const seed = useRef(draft)
+  const { isDirty } = useDirtySnapshot({ name, provider, apiBase, apiKey })
 
   const ready =
     name.trim() !== "" &&
@@ -261,7 +268,7 @@ function AddToolDialog({
         api_base: apiBase.trim() === "" ? null : apiBase.trim(),
         api_key: apiKey === "" ? null : apiKey,
       },
-      { onSuccess: onClose },
+      { onSuccess: onCreated },
     )
   }
 
@@ -271,13 +278,12 @@ function AddToolDialog({
       onOpenChange={(open) => {
         if (!open) onClose()
       }}
-      size="sm"
       title="New search tool"
       submitLabel="Add search tool"
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={!ready}
-      isDirty={draft !== seed.current}
+      isDirty={isDirty}
       error={create.error}
     >
       <Field
@@ -317,6 +323,7 @@ function AddToolDialog({
         label="API key"
         value={apiKey}
         onChange={setApiKey}
+        isRequired={keyRequired}
         description={
           keyRequired
             ? "This provider needs one. Storing it needs OTARI_SECRET_KEY set on the gateway."
@@ -353,25 +360,10 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
   const answered = !tools.isLoading && !failed
 
   return (
-    <SettingsGroup
-      bounded
-      title="Search tools"
-      description="Named tools behind the direct endpoint, POST /api/v1/search. A searxng tool with no URL of its own reuses the backend above."
-      docsHref={docsHref}
-      action={
-        known.length > 0 ? (
-          <Button
-            variant="primary"
-            onPress={() => {
-              setOpenCount((count) => count + 1)
-              setAdding(true)
-            }}
-          >
-            Add search tool
-          </Button>
-        ) : null
-      }
-    >
+    <>
+      {/* Outside the group, not inside it: `FormDialog` renders its trigger
+          slot as a real element, and a group's rows are a `divide-y` container
+          where one more child changes which row is last. */}
       {/* Keyed on the open count, so each open remounts a blank form. Clearing
           the draft on close instead would blank the fields while the dialog is
           still animating away. */}
@@ -379,43 +371,69 @@ export function SearchToolsCard({ docsHref }: { docsHref: string }) {
         key={openCount}
         isOpen={adding}
         onClose={() => setAdding(false)}
+        onCreated={() => {
+          setAdding(false)
+          // The new row lives in the drill-in, which is collapsed by default,
+          // so without this the only thing that changes on screen is the count.
+          setIsOpen(true)
+        }}
         providers={known}
       />
-      {tools.error || providers.error ? (
-        // Outside the disclosure: a read that failed is the thing the operator
-        // most needs to see, and the row is collapsed by default.
-        <div className="px-4 py-3">
-          <ErrorBanner error={tools.error ?? providers.error} />
-        </div>
-      ) : null}
-      <DisclosureRow
-        label="Configure search tools"
-        help={
-          failed
-            ? "Could not read the tools this deployment serves."
-            : !answered
-              ? "Reading the tools this deployment serves."
-              : count === 0
-                ? "None configured, so POST /api/v1/search refuses every request."
-                : "Callers name one in search_tool_name, or in the /api/v1/search/{tool} path."
-        }
-        isOpen={isOpen}
-        onToggle={() => setIsOpen((open) => !open)}
-        trailing={
-          <span className="text-caption text-subtle tabular-nums">
-            {answered ? toolCount(count) : ""}
-          </span>
+      <SettingsGroup
+        bounded
+        title="Search tools"
+        description="Named tools behind the direct endpoint, POST /api/v1/search. A searxng tool with no URL of its own reuses the backend above."
+        docsHref={docsHref}
+        action={
+          known.length > 0 ? (
+            <Button
+              variant="primary"
+              onPress={() => {
+                setOpenCount((count) => count + 1)
+                setAdding(true)
+              }}
+            >
+              Add search tool
+            </Button>
+          ) : null
         }
       >
-        <div className="flex flex-col divide-y divide-border-subtle">
-          {stored.map((tool) => (
-            <StoredToolLine key={tool.name} tool={tool} providers={known} />
-          ))}
-          {fromConfig.map((tool) => (
-            <ConfigToolLine key={tool.name} tool={tool} />
-          ))}
-        </div>
-      </DisclosureRow>
-    </SettingsGroup>
+        {tools.error || providers.error ? (
+          // Outside the disclosure: a read that failed is the thing the operator
+          // most needs to see, and the row is collapsed by default.
+          <div className="px-4 py-3">
+            <ErrorBanner error={tools.error ?? providers.error} />
+          </div>
+        ) : null}
+        <DisclosureRow
+          label="Configure search tools"
+          help={
+            failed
+              ? "Could not read the tools this deployment serves."
+              : !answered
+                ? "Reading the tools this deployment serves."
+                : count === 0
+                  ? "None configured, so POST /api/v1/search refuses every request."
+                  : "Callers name one in search_tool_name, or in the /api/v1/search/{tool} path."
+          }
+          isOpen={isOpen}
+          onToggle={() => setIsOpen((open) => !open)}
+          trailing={
+            <span className="text-caption text-subtle tabular-nums">
+              {answered ? toolCount(count) : ""}
+            </span>
+          }
+        >
+          <div className="flex flex-col divide-y divide-border-subtle">
+            {stored.map((tool) => (
+              <StoredToolLine key={tool.name} tool={tool} providers={known} />
+            ))}
+            {fromConfig.map((tool) => (
+              <ConfigToolLine key={tool.name} tool={tool} />
+            ))}
+          </div>
+        </DisclosureRow>
+      </SettingsGroup>
+    </>
   )
 }

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import type {
   ConfigSearchTool,
   SearchProviderInfo,
@@ -242,6 +242,12 @@ function AddToolDialog({
   const baseRequired =
     Boolean(selected?.requires_api_base) && inherited === null
   const keyRequired = Boolean(selected?.requires_api_key)
+  // One snapshot rather than a hand-listed predicate: the provider is a field
+  // like the others, and a guard that forgot it discarded a changed provider
+  // with no question asked.
+  const draft = JSON.stringify({ name, provider, apiBase, apiKey })
+  const seed = useRef(draft)
+
   const ready =
     name.trim() !== "" &&
     (!baseRequired || apiBase.trim() !== "") &&
@@ -271,7 +277,7 @@ function AddToolDialog({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={!ready}
-      isDirty={name.trim() !== "" || apiBase.trim() !== "" || apiKey !== ""}
+      isDirty={draft !== seed.current}
       error={create.error}
     >
       <Field


### PR DESCRIPTION
## Description

Two creation forms on the Tools pages sat permanently open at the foot of their own list: one for a search tool, one for a mandated guardrail. Both are now a button on the heading of the group they create into, opening a small dialog, which is the pattern the rest of the dashboard has been moving to.

`SettingsGroup` gains an `action` slot to make that possible: the one thing a group is created into, on its heading row and right-aligned, the way a page's own action already sits on its title row. A group that owns a collection is where that collection is added to, so the control belongs beside the heading that names it rather than below its last row.

The forms gain something in the move. They were built from compact machine-field inputs with no visible labels at all, named only for screen readers, and the sentences explaining what a field wanted sat in one caption under the whole form. In the dialog each field carries a visible label and its own description, so the requirement is beside the box it applies to. A failed create is also rendered once now, by the dialog, rather than a second time by a paragraph the form kept underneath itself.

Part of #1031

## How to test it locally

1. `make dashboard && make dev`, sign in, and open Tools.
2. In "Search tools", open the drill-in row. The add form is gone from the bottom of the list; "Add search tool" is on the group heading and opens "New search tool".
3. Type a name, press Escape, discard, and reopen: the fields are empty.
4. In "Organization guardrails", "Mandate a guardrail" is on the group heading and opens "Mandated guardrail". The per-guardrail rows are unchanged.

Covered by `SearchToolsCard.test.tsx` and `OrganizationGuardrailsCard.test.tsx`, both of which now drive the flow through the dialog. Each gained one case for the heading trigger staying visible and the draft resetting on open; the reset half of each was checked by deleting the remount key and reading the failure. The trigger half is a guard rather than a check, since neither card ever hid its action.

One existing assertion changed rather than moved. `names the workspaces an entry runs in` looked for the text "Alpha" anywhere on the card, and the card renders that workspace name in three places once everything has loaded: a row's scope badge, that row's scope checkbox, and (before this change) the add form's. It was passing on a race, resolving in the window where only one had painted. It now names the badge, which is what it was about.

## PR Type

- [x] Refactor

## Relevant issues

Part of #1031

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
  Dashboard counterparts: `pnpm --dir web run lint` and `run typecheck` clean, the full vitest suite at 5486 passing across 157 files, and the four Playwright behavioral projects at 43 passing. One note on that last run: an unrelated routing test (`parity.management.spec.ts` "grows and shrinks a policy's failure chain") timed out once at 30s waiting for a dialog button, then passed in 1.6s on its own and again in a clean full run. Recorded here as a flake rather than swept up, since it is in a page this PR does not touch.
- [ ] Documentation was updated where necessary. The design system's dialog and settings-group guidance already describes this pattern; nothing in it named these two forms.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API change.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 5)

**Any additional AI details you'd like to share:**

The reset-on-open cases were verified by deleting the fix and reading the failure. The race in the existing "Alpha" assertion was found the same way, by counting the matching nodes rather than by reasoning about which one the query meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Moved Search tool and Organization guardrail creation forms into dialogs opened from `SettingsGroup` actions.
- Added right-aligned action support to `SettingsGroup`.
- Improved dialogs with clear labels, field descriptions, consolidated errors, validation, and draft reset behavior.
- Updated guardrail dialogs to support profiles, parameters, and raw JSON input.

## Technical notes

- Added Storybook coverage and component tests for heading actions.
- Updated feature tests for dialog flows, validation, draft resets, and workspace labels.
- No API or documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->