### PR TITLE
fix(dashboard): carry focus through ListDetail's column swap

### DIFF
--- a/web/src/design-system/layout/ListDetail.stories.tsx
+++ b/web/src/design-system/layout/ListDetail.stories.tsx
@@ -170,8 +170,13 @@ export const Empty: Story = {
       isDetailShown={false}
       onShowList={() => {}}
       list={null}
+      isEmpty
       empty="Create your first policy"
-      onEmptyPress={() => {}}
+      emptyAction={
+        <Button size="sm" variant="primary" onPress={() => {}}>
+          Create policy
+        </Button>
+      }
       detail={
         <div className="flex flex-col gap-2 px-4 py-5">
           <h2 className="text-title">No policies yet</h2>

--- a/web/src/design-system/layout/ListDetail.test.tsx
+++ b/web/src/design-system/layout/ListDetail.test.tsx
@@ -2,7 +2,20 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+import { Button } from "../actions/Button"
 import { ListDetail, ListDetailRow } from "./ListDetail"
+
+function Frame({ isDetailShown }: { isDetailShown: boolean }) {
+  return (
+    <ListDetail
+      listLabel="Policies"
+      list={<ListDetailRow label="fast" isSelected onSelect={() => {}} />}
+      detail={<p>detail</p>}
+      isDetailShown={isDetailShown}
+      onShowList={() => {}}
+    />
+  )
+}
 
 describe("ListDetail", () => {
   it("names both columns, so neither half is anonymous", () => {
@@ -75,28 +88,49 @@ describe("ListDetail", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("makes the empty column a real button, reachable by keyboard", async () => {
-    // The whole column is the target, which a div with an onClick would also
-    // manage while being unreachable without a pointer.
-    const onEmptyPress = vi.fn()
+  it("offers the empty column's action as a named control", async () => {
+    // Named, and the size of a control. The column itself was the press target
+    // once, which made a button as tall as the page whose accessible name was
+    // whatever prose happened to be inside it.
+    const onCreate = vi.fn()
     render(
       <ListDetail
         listLabel="Policies"
         list={null}
+        isEmpty
         empty="Create your first policy"
-        onEmptyPress={onEmptyPress}
+        emptyAction={
+          <Button variant="primary" onPress={onCreate}>
+            Create policy
+          </Button>
+        }
         detail={null}
         isDetailShown={false}
         onShowList={() => {}}
       />,
     )
 
-    await userEvent.tab()
-    await userEvent.keyboard("{Enter}")
-    expect(onEmptyPress).toHaveBeenCalledOnce()
-    expect(
-      screen.getByRole("button", { name: "Create your first policy" }),
-    ).toBeInTheDocument()
+    expect(screen.getByText("Create your first policy")).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Create policy" }))
+    expect(onCreate).toHaveBeenCalledOnce()
+  })
+
+  it("shows the rows even when the empty message is a node it was handed", () => {
+    // `empty` used to double as the flag, tested with `=== undefined`, so the
+    // ordinary call-site idiom `empty={cond ? "None yet." : null}` blanked a
+    // list that had rows in it.
+    render(
+      <ListDetail
+        listLabel="Policies"
+        list={<ListDetailRow label="fast" isSelected onSelect={() => {}} />}
+        empty={null}
+        detail={null}
+        isDetailShown={false}
+        onShowList={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /fast/ })).toBeInTheDocument()
   })
 
   it("states the empty column without offering it to a reader who cannot write", () => {
@@ -104,6 +138,7 @@ describe("ListDetail", () => {
       <ListDetail
         listLabel="Policies"
         list={null}
+        isEmpty
         empty="No policies yet."
         detail={null}
         isDetailShown={false}
@@ -127,6 +162,45 @@ describe("ListDetail", () => {
     )
 
     expect(screen.getByText("fast")).toBeInTheDocument()
+  })
+  it("moves focus into the column that appears when a record opens", async () => {
+    // The blocking bug: below `md` the list column becomes `display: none`
+    // while the pressed row still holds focus, which drops
+    // `document.activeElement` to `<body>` at the moment a record opens.
+    //
+    // What this proves and what it does not: jsdom applies no CSS, so it cannot
+    // show the column being hidden, and the original bug is invisible here for
+    // that reason. It does prove the mechanism, that focus follows the swap,
+    // which is the half this component owns. The width gating is CSS: the Back
+    // control is `md:hidden`, so from `md` up the focus call lands on a hidden
+    // element and does nothing.
+    const { rerender } = render(<Frame isDetailShown={false} />)
+    const row = screen.getByRole("button", { name: /fast/ })
+    row.focus()
+    expect(document.activeElement).toBe(row)
+
+    rerender(<Frame isDetailShown />)
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Back to the list" }),
+    )
+  })
+
+  it("returns focus to the open record when the list comes back", async () => {
+    const { rerender } = render(<Frame isDetailShown />)
+    rerender(<Frame isDetailShown={false} />)
+
+    // The row that was open, found by `aria-current`, so focus returns to where
+    // the reader was rather than to the top of the column.
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /fast/ }),
+    )
+  })
+
+  it("does not take focus on arrival", () => {
+    // Only a change of `isDetailShown` moves focus. Stealing it on mount would
+    // take it off whatever the operator was already doing on the page.
+    render(<Frame isDetailShown={false} />)
+    expect(document.activeElement).toBe(document.body)
   })
 })
 

--- a/web/src/design-system/layout/ListDetail.tsx
+++ b/web/src/design-system/layout/ListDetail.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import { type ReactNode, useEffect, useRef } from "react"
 import { FiChevronLeft } from "react-icons/fi"
 
 import { Button } from "../actions/Button"
@@ -18,7 +18,10 @@ import { EmptyMessage } from "../feedback/EmptyMessage"
  * side at 390px gives neither column a readable measure, and stacking them puts
  * every record above the one being read, so an operator scrolls past the list
  * to reach what they opened. The swap is a prop rather than state in here, so
- * the page's own selection stays the single source of what is open.
+ * the page's own selection stays the single source of what is open. Focus
+ * travels with it: the column going out of view is `display: none` while it may
+ * still hold focus, which drops it to `<body>` and throws a keyboard or screen
+ * reader user to the top of the document at the moment they open a record.
  *
  * Presentational: which record is selected is the caller's, and so is every
  * row. Pair with `ListDetailRow`, which is the row this frame's list is made
@@ -28,8 +31,9 @@ export function ListDetail({
   listLabel,
   listAction,
   list,
+  isEmpty = false,
   empty,
-  onEmptyPress,
+  emptyAction,
   detail,
   detailLabel = "Details",
   isDetailShown,
@@ -40,20 +44,26 @@ export function ListDetail({
   listLabel: string
   /** The control that adds a record, at the top of the column it adds to. */
   listAction?: ReactNode
-  /** The rows, which are `ListDetailRow`s. */
+  /**
+   * The rows. A node rather than data plus a row renderer, so a caller keeps
+   * its own record type and can put something that is not a row between two.
+   */
   list: ReactNode
   /**
-   * What stands in for the rows, and so how the frame is told there are none to
-   * show: an empty list's message, or a line while the list is still loading. A
-   * node cannot be counted from in here, which is why this rather than a flag.
+   * Whether the list has nothing to show. Separate from `empty` because a node
+   * is not a count: as one prop, `empty={cond ? "None yet." : null}` read as
+   * "empty" and blanked a list that had rows in it.
    */
+  isEmpty?: boolean
+  /** What the column says while `isEmpty`: no records, or none loaded yet. */
   empty?: ReactNode
   /**
-   * Makes the empty column one press target, for a list whose first record is
-   * the only thing to do with it. Omitted where the caller cannot write, so a
-   * reader who would be refused is told rather than invited.
+   * The control offered beside that message, for a list whose first record is
+   * the only thing to do with it. A slot like `listAction`, so it is a named
+   * button rather than a column-sized press target: the column is not a control
+   * and a button the height of one announces nothing.
    */
-  onEmptyPress?: () => void
+  emptyAction?: ReactNode
   /** The open record, or what stands in for it while none is. */
   detail: ReactNode
   /**
@@ -68,32 +78,54 @@ export function ListDetail({
   /** Names the list on that control, where "the list" is not what to call it. */
   backLabel?: string
 }) {
-  const rows =
-    empty === undefined ? (
-      // The frame divides its children, so a row draws no rule of its own and
-      // the last one leaves none hanging over the space below it.
-      <div className="flex flex-1 flex-col divide-y divide-border-subtle">
-        {list}
-      </div>
-    ) : onEmptyPress === undefined ? (
-      <EmptyMessage>{empty}</EmptyMessage>
-    ) : (
-      <button
-        type="button"
-        onClick={onEmptyPress}
-        className="flex flex-1 flex-col justify-center transition-colors hover:bg-surface-alt motion-reduce:transition-none"
-      >
-        <EmptyMessage>{empty}</EmptyMessage>
-      </button>
-    )
+  const backRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLElement>(null)
+  const wasDetailShown = useRef(isDetailShown)
+
+  useEffect(() => {
+    // Only on a change, so arriving on the page does not take focus off
+    // whatever the operator was doing.
+    if (wasDetailShown.current === isDetailShown) return
+    wasDetailShown.current = isDetailShown
+    // No breakpoint is read here, and deliberately: the control moved to is
+    // itself hidden from `md` up, so `focus()` is a no-op there and CSS decides.
+    // A copy of `AppShell`'s query would be a second literal of it, which is
+    // the kind that goes stale on one side only.
+    const target = isDetailShown
+      ? backRef.current
+      : (listRef.current?.querySelector<HTMLElement>('[aria-current="true"]') ??
+        listRef.current)
+    target?.focus()
+  }, [isDetailShown])
+
+  const rows = isEmpty ? (
+    <EmptyMessage>
+      <span className="flex flex-col items-center gap-3">
+        {empty}
+        {emptyAction}
+      </span>
+    </EmptyMessage>
+  ) : (
+    // The frame divides its children, so a row draws no rule of its own and
+    // the last one leaves none hanging over the space below it.
+    <div className="flex flex-1 flex-col divide-y divide-border-subtle">
+      {list}
+    </div>
+  )
 
   return (
     <div className="grid border border-border md:grid-cols-[1fr_1.75fr]">
       {/* Both halves are regions, so a reader can move between them rather
           than through one to reach the other. */}
       <section
+        ref={listRef}
         aria-label={listLabel}
-        className={`min-w-0 flex-col ${isDetailShown ? "hidden md:flex" : "flex"}`}
+        // Focusable only programmatically, as the landing place when the column
+        // comes back with no record current. Focus has to land somewhere in the
+        // column that just appeared; `<body>` is the failure this exists to
+        // avoid, not an acceptable fallback.
+        tabIndex={-1}
+        className={`min-w-0 flex-col outline-none ${isDetailShown ? "hidden md:flex" : "flex"}`}
       >
         <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
           <h2 className="text-overline">{listLabel}</h2>
@@ -112,7 +144,7 @@ export function ListDetail({
           // there, and a Back control beside it would point at what it is
           // sitting next to.
           <div className="border-b border-border px-2 py-1 md:hidden">
-            <Button className="min-h-11" onPress={onShowList}>
+            <Button ref={backRef} className="min-h-11" onPress={onShowList}>
               <FiChevronLeft aria-hidden="true" className="size-4" />
               {backLabel}
             </Button>
@@ -133,14 +165,23 @@ export function ListDetail({
  *
  * **The action lane is there whether or not a row has actions**, so the
  * trailing controls form a vertical lane down the list instead of landing
- * wherever their row's label ends. Its width is the touch floor, which is also
- * the width of the one control it is sized for.
+ * wherever their row's label ends. Fixed at the touch floor rather than
+ * floored at it: as `min-w-11` a 44px control plus the lane's own padding came
+ * to 52px, so a row with an action and a row without ended their labels 8px
+ * apart, which is the one thing a lane exists to prevent. Whatever inset the
+ * control wants is the control's own padding.
  *
  * `aria-current` rather than `aria-pressed`: this is the record being shown out
- * of a set, not a control that stays down. The selected row wears the accent as
- * a tint, which is the accent spent on selection the way an active nav row
- * spends it, and keeps the page's ink: the accent's own ink is under AA on its
- * tint.
+ * of a set, not a control that stays down.
+ *
+ * The selected row is the accent tint with the page's own ink, which is what
+ * the selected row of the models table wears (`features/models/ModelsPage`).
+ * Not the active nav row's treatment, which is a neutral fill and an ink edge
+ * and is documented in `app/nav/rowStyles` as deliberately not a tint. And not
+ * the accent's own ink on top: `--color-primary` is under AA on
+ * `--color-primary-subtle`, and the darker step that clears it,
+ * `--color-primary-subtle-foreground`, is for the small text of a chip or a nav
+ * item rather than for a row's label.
  */
 export function ListDetailRow({
   label,
@@ -178,7 +219,7 @@ export function ListDetailRow({
           <span className="truncate text-caption">{children}</span>
         )}
       </button>
-      <div className="flex min-w-11 shrink-0 items-center justify-end pr-2">
+      <div className="flex w-11 shrink-0 items-center justify-center">
         {actions}
       </div>
     </div>


### PR DESCRIPTION
## Description

Seven review findings on #1054, which merged before the review landed. All seven were valid, so
this is the follow-up. The component still has no consumer, so none of this changes a page.

The blocking one was an accessibility bug. On a phone the frame shows one column at a time by
hiding the other, and the hidden one could still be holding the focus. So pressing a record threw
a keyboard, switch or screen reader user to the top of the document at the exact moment they
opened it, and again on the way back. Focus now travels with the swap: to the way-back control
when a record opens, and to the record that was open when the list returns.

Worth noting how that is done, because the obvious way would have been a mistake. The reviewer
suggested gating it on the phone breakpoint, but that value lives in the app shell, which this
layer is not allowed to import, so it would have become a second copy of a number that only one
side would remember to change. Instead the control being moved to is already hidden above the
breakpoint, so asking for focus there does nothing and the stylesheet stays the only place the
breakpoint is written down.

Two props were doing one job. The empty message doubled as the signal that the list was empty, so
the natural way to write a call site, an empty message when there is one and nothing otherwise,
hid every record in the list. Emptiness is its own flag now.

The empty column was one button as tall as the column, with a block element inside it, which is
not what a button may contain and is a thing this file avoids elsewhere for exactly that reason.
Its name was also whatever sentence happened to sit in it. The action beside the message is now a
slot, the same way the create control at the top of the column already is, so it is an ordinary
named button.

The lane the row actions sit in was a minimum width rather than a fixed one, so a row with an
action and a row without ended their labels eight pixels apart. Lining those up is the only reason
the lane exists.

The selected row's explanation was wrong twice over. It said the row wears the accent the way an
active navigation row does, but a navigation row deliberately does not use the accent at all, and
it dismissed the accent's own text color without mentioning the darker version that exists for
that background. The colors themselves already matched what the models table does for its
selected row, so the fix is the explanation, not the appearance.

Finally, the responsive behavior had no test at any width, which is the component's main claim and
was its least covered. There are three now.

## How to test it locally

1. `pnpm --dir web run storybook`, then `Design system → Layout → ListDetail`.
2. On the `DetailShown` story, narrow the window below 768px. Tab to a record and press it: focus
   should land on the way-back control rather than vanishing. Press that: focus should return to
   the record you had open, not to the top of the page. Before this change focus went to the
   document body both times, which a screen reader announces as leaving the page content.
3. On the `Empty` story, the action is a normal button you can tab to and whose name is "Create
   policy", rather than a press target the height of the column.
4. On any story with rows, check that a row with a trailing action and a row without one start
   their labels at the same x and end them at the same x.

Automated coverage: `ListDetail.test.tsx`, thirteen tests, three of them new for the focus swap.
Those three are worth reading for what they do not prove: jsdom applies no CSS, so it cannot show
a column being hidden and the original bug is invisible there. They pin the mechanism, and the
width gating is a stylesheet concern. A browser-level check would want Storybook interaction
tests, which this repo has no infrastructure for (the only addon is `addon-docs`, and there is no
`@storybook/test` or any play function anywhere), so adding that is its own change rather than a
rider on this one.

Checks run locally: `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, Vitest over
`src/design-system/layout` and `src/styles` (3547 passing, which includes the token gates) and
`src/architecture.test.ts` (30 passing, run alone because its probe files race another suite's
tree walk). The full suite and the catalog build are left to CI. Nothing under `src/gateway/`
changes, so there is no OpenAPI or Postman artifact to regenerate.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follows up the review on #1054. No issue: that PR merged before its review was posted, so the
findings had nowhere else to land.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (three for the focus swap, one for the empty-flag regression, and the empty column's test rewritten for the slot).
- [x] I ran the Definition of Done checks locally (the `web/` equivalents: `pnpm --dir web run lint`, `run typecheck`, and scoped Vitest; `make lint` and the Python suites cover no part of this change).
- [x] Documentation was updated where necessary (the component's own docstrings, which is where three of the findings were).
- [ ] If the API contract changed, I regenerated the OpenAPI spec (no API change).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:** The review being answered was itself produced
with Claude Code, and it caught two docstrings that justified the code with claims about other
parts of the tree that were not true. Those are the findings worth the most here, since a wrong
comment outlives the code it describes.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
