### PR TITLE
docs(api): describe internal prose at the API root it is served from

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -369,9 +369,9 @@ async def require_deployment_operator(
     which declare it as their authentication gate and then re-check the caller's
     role against the organization, workspace or deployment they are acting on.
     It is wrong for the deployment-wide routers, where clearing it *is* the
-    whole authorization: `/v1/keys` mints a key into any workspace,
-    `/v1/provider-credentials` holds process-global provider secrets, and
-    `POST /v1/settings/master-key/rotate` replaces the deployment credential. On
+    whole authorization: `/api/v1/keys` mints a key into any workspace,
+    `/api/v1/provider-credentials` holds process-global provider secrets, and
+    `POST /api/v1/settings/master-key/rotate` replaces the deployment credential. On
     a single-operator deployment every login is that operator and the
     distinction is invisible; once mutually-untrusting tenants sign in to one
     process, a member of one organization holding master-key authority is a
@@ -380,7 +380,7 @@ async def require_deployment_operator(
     A **header master key** is the deployment credential itself, so it passes; it
     names nobody, and ``get_current_identity`` resolves it to the bootstrap
     operator. A **session** is put to
-    ``DeploymentUserService.has_administration_access``, which `/v1/admin`
+    ``DeploymentUserService.has_administration_access``, which `/api/v1/admin`
     already treats as the answer to "may this caller act deployment-wide": a
     superuser, or the bootstrap operator whatever its flag says. Reused rather
     than re-derived so the routers guarded here and the account administration
@@ -458,8 +458,8 @@ async def verify_catalog_reader(
     """As :func:`verify_api_key_or_master_key`, and a dashboard session also reads.
 
     The narrow exception to the rule above, for the catalog reads that describe
-    the deployment rather than act on it: ``GET /v1/models``, ``GET /v1/pricing``
-    and ``GET /v1/tools`` (with their by-id variants). The dashboard's Models and
+    the deployment rather than act on it: ``GET /api/v1/models``, ``GET /api/v1/pricing``
+    and ``GET /api/v1/tools`` (with their by-id variants). The dashboard's Models and
     Pricing pages are built on these, so a session has to reach them; they call
     no provider, write nothing, and bill nothing, so reaching them
     deployment-wide costs a signed-in caller's own organization nothing.

--- a/src/gateway/api/routes/invitations.py
+++ b/src/gateway/api/routes/invitations.py
@@ -1,6 +1,6 @@
 """Accepting an organization invitation (standalone mode only).
 
-Deliberately public, unlike every other route under ``/v1``: the person
+Deliberately public, unlike every other route under ``/api/v1``: the person
 following an emailed link holds no master key and no session, and the token
 in the link is their whole proof of anything here. Both routes therefore take
 no ``CurrentIdentity`` and are scoped to exactly the one invitation the token

--- a/src/gateway/api/routes/invitations.py
+++ b/src/gateway/api/routes/invitations.py
@@ -1,10 +1,9 @@
 """Accepting an organization invitation (standalone mode only).
 
-Deliberately public, unlike every other route under ``/api/v1``: the person
-following an emailed link holds no master key and no session, and the token
-in the link is their whole proof of anything here. Both routes therefore take
-no ``CurrentIdentity`` and are scoped to exactly the one invitation the token
-names.
+Deliberately public: the person following an emailed link holds no master
+key and no session, and the token in the link is their whole proof of
+anything here. Both routes therefore take no ``CurrentIdentity`` and are
+scoped to exactly the one invitation the token names.
 
 No session is minted on accept: the token proves possession of an emailed
 link, not of a password, so accepting only resolves the membership to

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -108,7 +108,7 @@ TOOLS_ENDPOINT = "/v1/mcp/servers/{mcp_server_id}/tools"
 
 # The in-flight registry describes work by model, and these endpoints run no
 # model. The label names what is actually being done instead, so an operator
-# watching /v1/usage/in-flight sees a stateless MCP call rather than a blank.
+# watching /api/v1/usage/in-flight sees a stateless MCP call rather than a blank.
 EXECUTE_LABEL = "mcp.execute"
 TOOLS_LABEL = "mcp.list_tools"
 

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -700,7 +700,7 @@ async def create_message(
     except HTTPException as exc:
         # The hybrid preamble (platform resolve / auth) raises format-agnostic
         # plain-string HTTPExceptions (some with a Retry-After header); re-wrap
-        # them in the Anthropic envelope so /v1/messages errors stay structured.
+        # them in the Anthropic envelope so /api/v1/messages errors stay structured.
         raise _ensure_anthropic_error(exc) from exc
 
     if request.container is not None and ctx.hybrid_mode:
@@ -901,7 +901,7 @@ async def count_message_tokens(
             # the plane a cookie may not reach, so it must not report on one.
             await verify_api_key_or_master_key(raw_request, db, config)
     except HTTPException as exc:
-        # Keep /v1/messages/count_tokens auth errors in the Anthropic envelope too.
+        # Keep count_tokens auth errors in the Anthropic envelope too.
         raise _ensure_anthropic_error(exc) from exc
 
     return CountTokensResponse(input_tokens=_estimate_input_tokens(request))

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -18,8 +18,8 @@ size, published-date) are ignored rather than rejected. Both are called out in
 
 Both the body-selected (``POST /api/v1/search``) and path-selected
 (``POST /api/v1/search/{search_tool_name}``) forms log ``endpoint="/v1/search"``,
-so one Activity filter covers every search regardless of how the tool was
-named.
+a frozen label rather than a path, so one Activity filter covers every search
+regardless of how the tool was named.
 
 A request the gateway itself turns away (an unknown or ambiguous tool name, a
 workspace that has web search switched off, a tool the caller's key may not use)

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -17,7 +17,7 @@ size, published-date) are ignored rather than rejected. Both are called out in
 ``docs/api-reference.md`` so a migrating caller can check for them.
 
 Both the body-selected (``POST /api/v1/search``) and path-selected
-(``POST /v1/search/{search_tool_name}``) forms log ``endpoint="/v1/search"``,
+(``POST /api/v1/search/{search_tool_name}``) forms log ``endpoint="/v1/search"``,
 so one Activity filter covers every search regardless of how the tool was
 named.
 

--- a/src/gateway/api/routes/tool_settings.py
+++ b/src/gateway/api/routes/tool_settings.py
@@ -19,7 +19,7 @@ gated, mirroring the other management routers.
   and applies them to the running worker.
 * ``POST /api/v1/tool-settings/{service}/test`` structurally validates a (typically
   unsaved) URL and probes it for reachability, returning ``{ok, reason}``.
-* ``GET /v1/tool-settings/guardrails/profiles`` reads the guardrail catalog off
+* ``GET /api/v1/tool-settings/guardrails/profiles`` reads the guardrail catalog off
   the service ``guardrails_url`` names. It sits here because that field is the
   only input it takes, and on the reader router for the reason the GET above is:
   a profile name is what a caller puts in a request body, so the set of them is

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -451,7 +451,7 @@ def import_claude_code(
 
     The OTLP exporter documented in docs/use-with-claude-code.md only carries
     sessions that run after it is configured. This reads the transcripts Claude
-    Code has already written and posts them to /v1/usage/external-events, which
+    Code has already written and posts them to /api/v1/usage/external-events, which
     is idempotent on (source, source_event_id): re-running imports only what is
     new and reports the rest as duplicates.
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1190,8 +1190,8 @@ class GatewayConfig(BaseSettings):
             "On by default (the opposite of the other SSRF gates) because operator-supplied api_base "
             "values are master-key gated and the home-lab / self-hosted use case depends on private "
             "endpoints. Set to false to make provider connection tests, model discovery, and the "
-            "credential write path (POST /api/v1/provider-credentials and PATCH "
-            "/api/v1/provider-credentials/{instance}) refuse an internal api_base. "
+            f"credential write path (POST {API_ROOT}/provider-credentials and PATCH "
+            f"{API_ROOT}/provider-credentials/{{instance}}) refuse an internal api_base. "
             "Chat dispatch (which dials the endpoint on every request) is not gated, so this is not a "
             "general egress control. Also settable via OTARI_PROVIDER_ALLOW_PRIVATE_HOSTS."
         ),

--- a/src/gateway/core/usage_source.py
+++ b/src/gateway/core/usage_source.py
@@ -2,7 +2,7 @@
 
 The column carries provenance: the bare slug ``gateway`` for a request Otari served,
 and a source slug (``claude_code``, ``codex``) for usage imported through
-``POST /v1/usage/external-events``. Hosted history adds a third shape, because a row
+``POST /api/v1/usage/external-events``. Hosted history adds a third shape, because a row
 backfilled from otari.ai keeps its origin under a legacy prefix: traffic that
 deployment served itself arrives as ``otari-ai:gateway``, and usage a customer had
 imported there as ``otari-ai:claude_code``.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -440,7 +440,7 @@ def test_user(client: TestClient, master_key_header: dict[str, str]) -> dict[str
 
 @pytest.fixture
 def responses_request_body(test_user: dict[str, Any]) -> dict[str, Any]:
-    """A minimal /v1/responses request body. Shared so endpoint and
+    """A minimal /api/v1/responses request body. Shared so endpoint and
     provider-error-classification tests can both use it."""
     return {
         "model": "openai:gpt-4o-mini",
@@ -451,7 +451,7 @@ def responses_request_body(test_user: dict[str, Any]) -> dict[str, Any]:
 
 @pytest.fixture
 def messages_request_body() -> dict[str, Any]:
-    """A minimal /v1/messages request body. Shared so endpoint and
+    """A minimal /api/v1/messages request body. Shared so endpoint and
     provider-error-classification tests can both use it."""
     return {
         "model": "anthropic:claude-3-5-sonnet",

--- a/tests/integration/test_alias_api.py
+++ b/tests/integration/test_alias_api.py
@@ -1,6 +1,6 @@
 """End-to-end behavior for runtime (stored) model aliases.
 
-A stored alias is a row in ``model_aliases``, created through /v1/aliases. It
+A stored alias is a row in ``model_aliases``, created through /api/v1/aliases. It
 means the same thing to a request as a ``config.yml`` alias, but it can appear
 without a restart, so the interesting cases are the ones where the two kinds
 have to agree: routing, listing, pricing, and validation.

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the POST /v1/audio/transcriptions and POST /v1/audio/speech endpoints."""
+"""Tests for the POST /api/v1/audio/transcriptions and POST /api/v1/audio/speech endpoints."""
 
 from datetime import UTC, datetime
 from typing import Any
@@ -28,7 +28,7 @@ FAKE_AUDIO_BYTES = b"fake-audio-content-mp3"
 
 
 def test_transcription_requires_auth(client: TestClient) -> None:
-    """POST /v1/audio/transcriptions requires authentication."""
+    """POST /api/v1/audio/transcriptions requires authentication."""
     resp = client.post(
         f"{API_ROOT}/audio/transcriptions",
         files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
@@ -41,7 +41,7 @@ def test_transcription_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/transcriptions works with API key authentication."""
+    """POST /api/v1/audio/transcriptions works with API key authentication."""
     mock_resp = _mock_transcription_response()
     with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -59,7 +59,7 @@ def test_transcription_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/transcriptions with master key requires 'user' field."""
+    """POST /api/v1/audio/transcriptions with master key requires 'user' field."""
     mock_resp = _mock_transcription_response()
     with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -77,7 +77,7 @@ def test_transcription_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/transcriptions with master key + user field succeeds."""
+    """POST /api/v1/audio/transcriptions with master key + user field succeeds."""
     mock_resp = _mock_transcription_response()
     with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -93,7 +93,7 @@ def test_transcription_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/transcriptions returns 502 when the provider fails."""
+    """POST /api/v1/audio/transcriptions returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.audio.atranscription",
         new_callable=AsyncMock,
@@ -115,7 +115,7 @@ def test_transcription_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/transcriptions creates a usage log entry."""
+    """POST /api/v1/audio/transcriptions creates a usage log entry."""
     mock_resp = _mock_transcription_response()
     user_id = api_key_obj["user_id"]
 
@@ -143,7 +143,7 @@ def test_transcription_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/transcriptions logs an error entry when the provider fails."""
+    """POST /api/v1/audio/transcriptions logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -173,7 +173,7 @@ def test_transcription_optional_fields(
     api_key_header: dict[str, str],
     extra_field: str,
 ) -> None:
-    """POST /v1/audio/transcriptions forwards optional fields."""
+    """POST /api/v1/audio/transcriptions forwards optional fields."""
     mock_resp = _mock_transcription_response()
     values = {"language": "en", "prompt": "Previous context", "response_format": "verbose_json", "temperature": "0.2"}
     with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp) as mock:
@@ -192,7 +192,7 @@ def test_transcription_optional_fields(
 
 
 def test_speech_requires_auth(client: TestClient) -> None:
-    """POST /v1/audio/speech requires authentication."""
+    """POST /api/v1/audio/speech requires authentication."""
     resp = client.post(
         f"{API_ROOT}/audio/speech",
         json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
@@ -204,7 +204,7 @@ def test_speech_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech works with API key authentication."""
+    """POST /api/v1/audio/speech works with API key authentication."""
     with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
         resp = client.post(
             f"{API_ROOT}/audio/speech",
@@ -220,7 +220,7 @@ def test_speech_content_type_matches_format(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech returns correct Content-Type for each format."""
+    """POST /api/v1/audio/speech returns correct Content-Type for each format."""
     format_types = {
         "opus": "audio/opus",
         "aac": "audio/aac",
@@ -242,7 +242,7 @@ def test_speech_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech with master key requires 'user' field."""
+    """POST /api/v1/audio/speech with master key requires 'user' field."""
     with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
         resp = client.post(
             f"{API_ROOT}/audio/speech",
@@ -258,7 +258,7 @@ def test_speech_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/speech with master key + user field succeeds."""
+    """POST /api/v1/audio/speech with master key + user field succeeds."""
     with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
         resp = client.post(
             f"{API_ROOT}/audio/speech",
@@ -277,7 +277,7 @@ def test_speech_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech returns 502 when the provider fails."""
+    """POST /api/v1/audio/speech returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.audio.aspeech",
         new_callable=AsyncMock,
@@ -298,7 +298,7 @@ def test_speech_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/speech creates a usage log entry."""
+    """POST /api/v1/audio/speech creates a usage log entry."""
     user_id = api_key_obj["user_id"]
 
     with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
@@ -324,7 +324,7 @@ def test_speech_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/audio/speech logs an error entry when the provider fails."""
+    """POST /api/v1/audio/speech logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -353,7 +353,7 @@ def test_speech_optional_fields(
     api_key_header: dict[str, str],
     extra_field: str,
 ) -> None:
-    """POST /v1/audio/speech forwards optional fields."""
+    """POST /api/v1/audio/speech forwards optional fields."""
     values = {"response_format": "opus", "speed": 1.5, "instructions": "Speak slowly"}
     with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES) as mock:
         resp = client.post(
@@ -377,7 +377,7 @@ def test_transcription_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/transcriptions records auditable charge lines alongside cost.
+    """POST /api/v1/audio/transcriptions records auditable charge lines alongside cost.
 
     Audio bills per request like moderations (input_price_per_million holds the
     per-million-request rate), so a priced model yields one request meter and one
@@ -453,7 +453,7 @@ def test_speech_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech records auditable charge lines alongside cost."""
+    """POST /api/v1/audio/speech records auditable charge lines alongside cost."""
     client.post(
         f"{API_ROOT}/pricing",
         json={

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the /v1/batches batch API endpoints."""
+"""Tests for the /api/v1/batches batch API endpoints."""
 
 import os
 from collections.abc import Generator
@@ -54,12 +54,12 @@ def _create_batch_body(**overrides: Any) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/batches — Create batch
+# POST /api/v1/batches: Create batch
 # ---------------------------------------------------------------------------
 
 
 def test_create_batch_auth_required(client: TestClient) -> None:
-    """POST /v1/batches requires authentication."""
+    """POST /api/v1/batches requires authentication."""
     resp = client.post(f"{API_ROOT}/batches", json=_create_batch_body())
     assert resp.status_code == 401
 
@@ -68,7 +68,7 @@ def test_create_batch_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches works with API key and returns provider field."""
+    """POST /api/v1/batches works with API key and returns provider field."""
     mock_batch = _mock_batch()
 
     class _SupportsBatch:
@@ -98,7 +98,7 @@ def test_create_batch_with_master_key(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches works with master key naming an existing user."""
+    """POST /api/v1/batches works with master key naming an existing user."""
     mock_batch = _mock_batch()
 
     class _SupportsBatch:
@@ -129,7 +129,7 @@ def test_create_batch_unsupported_provider(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches returns 422 for unsupported provider."""
+    """POST /api/v1/batches returns 422 for unsupported provider."""
 
     class _NoBatch:
         SUPPORTS_BATCH = False
@@ -145,7 +145,7 @@ def test_create_batch_empty_requests(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches returns 422 for empty requests array."""
+    """POST /api/v1/batches returns 422 for empty requests array."""
     resp = client.post(
         f"{API_ROOT}/batches",
         json=_create_batch_body(requests=[]),
@@ -158,7 +158,7 @@ def test_create_batch_invalid_model_format(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches returns 400 when model has no provider prefix."""
+    """POST /api/v1/batches returns 400 when model has no provider prefix."""
     with patch(
         "gateway.api.routes.batches.AnyLLM.split_model_provider",
         side_effect=ValueError("Model must be in 'provider:model' format"),
@@ -176,7 +176,7 @@ def test_create_batch_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches returns 502 when provider fails."""
+    """POST /api/v1/batches returns 502 when provider fails."""
 
     class _SupportsBatch:
         SUPPORTS_BATCH = True
@@ -201,7 +201,7 @@ def test_create_batch_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/batches creates a usage log entry."""
+    """POST /api/v1/batches creates a usage log entry."""
     mock_batch = _mock_batch()
     user_id = api_key_obj["user_id"]
 
@@ -228,7 +228,7 @@ def test_create_batch_temp_file_cleanup(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches cleans up temp file even on error."""
+    """POST /api/v1/batches cleans up temp file even on error."""
     created_files: list[str] = []
 
     class _SupportsBatch:
@@ -258,7 +258,7 @@ def test_create_batch_temp_file_cleanup(
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/batches/{batch_id} — Retrieve batch
+# GET /api/v1/batches/{batch_id}: Retrieve batch
 # ---------------------------------------------------------------------------
 
 
@@ -266,7 +266,7 @@ def test_retrieve_batch(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id} retrieves batch status."""
+    """GET /api/v1/batches/{batch_id} retrieves batch status."""
     mock_batch = _mock_batch(status="in_progress")
 
     with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=mock_batch):
@@ -283,13 +283,13 @@ def test_retrieve_batch_missing_provider(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id} without provider returns 422."""
+    """GET /api/v1/batches/{batch_id} without provider returns 422."""
     resp = client.get(f"{API_ROOT}/batches/batch_abc123", headers=api_key_header)
     assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/batches/{batch_id}/cancel — Cancel batch
+# POST /api/v1/batches/{batch_id}/cancel: Cancel batch
 # ---------------------------------------------------------------------------
 
 
@@ -297,7 +297,7 @@ def test_cancel_batch(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches/{batch_id}/cancel cancels a batch."""
+    """POST /api/v1/batches/{batch_id}/cancel cancels a batch."""
     mock_batch = _mock_batch(status="cancelling")
 
     with (
@@ -318,7 +318,7 @@ def test_cancel_batch(
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/batches — List batches
+# GET /api/v1/batches: List batches
 # ---------------------------------------------------------------------------
 
 
@@ -326,7 +326,7 @@ def test_list_batches(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches lists batches for a provider."""
+    """GET /api/v1/batches lists batches for a provider."""
     mock_batches = [_mock_batch(id="batch_1"), _mock_batch(id="batch_2")]
 
     with patch(
@@ -349,7 +349,7 @@ def test_list_batches(
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/batches/{batch_id}/results — Retrieve batch results
+# GET /api/v1/batches/{batch_id}/results: Retrieve batch results
 # ---------------------------------------------------------------------------
 
 
@@ -357,7 +357,7 @@ def test_retrieve_batch_results(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id}/results returns per-request results."""
+    """GET /api/v1/batches/{batch_id}/results returns per-request results."""
     mock_completion = MagicMock()
     mock_completion.model = "gpt-4o-mini"
     mock_completion.usage = None
@@ -399,7 +399,7 @@ def test_retrieve_batch_results_not_complete(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id}/results returns 409 when batch is not complete."""
+    """GET /api/v1/batches/{batch_id}/results returns 409 when batch is not complete."""
     with (
         patch(
             "gateway.api.routes.batches.aretrieve_batch",
@@ -427,7 +427,7 @@ def test_retrieve_batch_results_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """GET /v1/batches/{batch_id}/results creates a usage log entry."""
+    """GET /api/v1/batches/{batch_id}/results creates a usage log entry."""
     mock_result = BatchResult(results=[])
     user_id = api_key_obj["user_id"]
 
@@ -472,7 +472,7 @@ def test_create_batch_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches with master key and no user field is rejected with 400."""
+    """POST /api/v1/batches with master key and no user field is rejected with 400."""
     create_patch, supports_patch = _batch_enforcement_patches()
     with create_patch as mock_call, supports_patch:
         resp = client.post(f"{API_ROOT}/batches", json=_create_batch_body(), headers=master_key_header)
@@ -486,7 +486,7 @@ def test_create_batch_master_key_unknown_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches with master key naming a nonexistent user returns 404."""
+    """POST /api/v1/batches with master key naming a nonexistent user returns 404."""
     create_patch, supports_patch = _batch_enforcement_patches()
     with create_patch as mock_call, supports_patch:
         resp = client.post(
@@ -504,7 +504,7 @@ def test_create_batch_blocked_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches for a blocked user is rejected before the provider call."""
+    """POST /api/v1/batches for a blocked user is rejected before the provider call."""
     resp = client.post(
         f"{API_ROOT}/users",
         json={"user_id": "batch-blocked-user", "blocked": True},
@@ -529,7 +529,7 @@ def test_create_batch_over_budget_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches for a user over budget is rejected before the provider call."""
+    """POST /api/v1/batches for a user over budget is rejected before the provider call."""
     budget_resp = client.post(
         f"{API_ROOT}/budgets",
         json={"max_budget": 0.0},
@@ -610,7 +610,7 @@ def batch_rate_limit_client(postgres_url: str) -> Generator[TestClient]:
 
 
 def test_create_batch_rate_limited(batch_rate_limit_client: TestClient) -> None:
-    """POST /v1/batches enforces the per-user rate limit."""
+    """POST /api/v1/batches enforces the per-user rate limit."""
     header = {API_KEY_HEADER: "Bearer test-master-key"}
     resp = batch_rate_limit_client.post(
         f"{API_ROOT}/users",
@@ -648,7 +648,7 @@ def test_retrieve_batch_owned_by_other_user_is_404(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id} hides batches owned by another user."""
+    """GET /api/v1/batches/{batch_id} hides batches owned by another user."""
     foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
 
     with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=foreign):
@@ -663,7 +663,7 @@ def test_retrieve_batch_owned_by_self(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """GET /v1/batches/{batch_id} returns batches owned by the key's user."""
+    """GET /api/v1/batches/{batch_id} returns batches owned by the key's user."""
     own = _mock_batch(metadata={"otari_user_id": api_key_obj["user_id"]})
 
     with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=own):
@@ -690,7 +690,7 @@ def test_cancel_batch_owned_by_other_user_is_404(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches/{batch_id}/cancel refuses batches owned by another user."""
+    """POST /api/v1/batches/{batch_id}/cancel refuses batches owned by another user."""
     foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
 
     with (
@@ -707,7 +707,7 @@ def test_retrieve_batch_results_owned_by_other_user_is_404(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/batches/{batch_id}/results refuses batches owned by another user."""
+    """GET /api/v1/batches/{batch_id}/results refuses batches owned by another user."""
     foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
 
     with (
@@ -725,7 +725,7 @@ def test_list_batches_filters_foreign_batches(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """GET /v1/batches hides other users' batches but keeps own and legacy ones."""
+    """GET /api/v1/batches hides other users' batches but keeps own and legacy ones."""
     own = _mock_batch(id="batch_own", metadata={"otari_user_id": api_key_obj["user_id"]})
     foreign = _mock_batch(id="batch_foreign", metadata={"otari_user_id": "someone-else"})
     legacy = _mock_batch(id="batch_legacy")
@@ -780,7 +780,7 @@ def test_retrieve_batch_results_records_tokens_and_cost(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """GET /v1/batches/{batch_id}/results records summed tokens and cost."""
+    """GET /api/v1/batches/{batch_id}/results records summed tokens and cost."""
     pricing_resp = client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -1007,7 +1007,7 @@ def test_batch_lines_keep_their_cached_token_discount(
     # 1000 fresh at 2.5/M + 9000 cached at 0.25/M + 500 output at 10/M.
     assert row["cost"] == pytest.approx(0.0025 + 0.00225 + 0.005)
     # The row shows the cached count its cost already reflects. Read through
-    # /v1/usage rather than the per-user view, which does not carry the column.
+    # /api/v1/usage rather than the per-user view, which does not carry the column.
     entries = client.get(
         f"{API_ROOT}/usage", params={"endpoint": "/v1/batches/results"}, headers=master_key_header
     ).json()

--- a/tests/integration/test_budget_dashboard.py
+++ b/tests/integration/test_budget_dashboard.py
@@ -227,7 +227,7 @@ def test_a_calendar_aligned_budget_gives_a_user_a_boundary_reset(
 ) -> None:
     """The user plane reads both cadences, not just the duration.
 
-    ``/v1/budgets`` accepts ``reset_alignment``, and the assignment path used to
+    ``/api/v1/budgets`` accepts ``reset_alignment``, and the assignment path used to
     read only ``budget_duration_sec``, so a user on a calendar-aligned budget got
     a null next reset. A null next reset never fires, so their spend never
     refilled and they were eventually refused permanently.

--- a/tests/integration/test_code_execution_policy_enforcement.py
+++ b/tests/integration/test_code_execution_policy_enforcement.py
@@ -3,7 +3,7 @@
 The management surface is covered in
 ``test_workspace_code_execution_policy.py``; this is the other half of #657's
 Definition of Done, the request path honoring what the policy says. Every case
-goes through ``/v1/messages`` with the sandbox backend and the tool loop
+goes through ``/api/v1/messages`` with the sandbox backend and the tool loop
 patched out, so what is asserted is admission and the values handed to the
 loop, not any execution.
 """

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -3,7 +3,7 @@
 `api/deps.verify_master_key` answers *authenticated*, not *authorized*: a
 dashboard session clears it for any active identity. Two families of router
 declare it, and only one of them re-checks the caller afterwards. The
-tenant-scoped family (organizations, workspaces, org provider keys, `/v1/admin`)
+tenant-scoped family (organizations, workspaces, org provider keys, `/api/v1/admin`)
 resolves `CurrentIdentity` and asks a service whether that identity may act on
 the organization, workspace or deployment named; the deployment-wide family does
 not, so clearing the credential check *was* the whole authorization there.
@@ -105,7 +105,7 @@ _CATALOG_PROBES: list[tuple[str, str]] = [
 # joined them in otari-ai#1944), and their own 403 is indistinguishable here
 # from the one this file is about.
 #
-# ``GET /v1/tool-settings`` sits here because it *narrows* rather than refuses,
+# ``GET /api/v1/tool-settings`` sits here because it *narrows* rather than refuses,
 # withholding the three service-endpoint fields from a non-operator
 # (otari-ai#1969). It rides its own ``reader_router`` for that, since a
 # router-level gate always runs and a route cannot opt out of one in place, which
@@ -194,7 +194,7 @@ def test_a_plain_member_session_is_refused_by_every_deployment_wide_route(
 ) -> None:
     """otari-ai#1880: this is the whole of the cross-organization breach.
 
-    403 rather than 404: unlike `/v1/admin`, these routes are no secret, and the
+    403 rather than 404: unlike `/api/v1/admin`, these routes are no secret, and the
     dashboard has to tell "you may not" apart from "there is nothing here" to
     decide whether to keep the caller signed in.
     """
@@ -334,7 +334,7 @@ def test_the_admin_router_keeps_its_own_404_rather_than_the_gate_403(
     db_session_factory: Callable[[], Session],
     test_config: GatewayConfig,
 ) -> None:
-    """`/v1/admin` hides itself from a non-operator on purpose, and still does.
+    """`/api/v1/admin` hides itself from a non-operator on purpose, and still does.
 
     Its refusal is a 404 so the surface does not confirm it exists, and
     `GET /access` answers 200 either way so the dashboard has something to gate

--- a/tests/integration/test_deployment_user_administration.py
+++ b/tests/integration/test_deployment_user_administration.py
@@ -1,4 +1,4 @@
-"""Deployment-wide account administration (`/v1/admin`), end to end and at the service.
+"""Deployment-wide account administration (`/api/v1/admin`), end to end and at the service.
 
 Split the way `test_tenancy_authorization.py` explains: a master-key request is
 always the one bootstrap operator, who is a superuser, so a header-authenticated

--- a/tests/integration/test_email_domain_auto_join_routes.py
+++ b/tests/integration/test_email_domain_auto_join_routes.py
@@ -45,7 +45,7 @@ _TOKEN_IN_LINK = re.compile(r"token=([\w-]+)")
 
 @pytest.fixture
 def mail_configured(test_config: GatewayConfig, monkeypatch: pytest.MonkeyPatch) -> None:
-    """What ``POST /v1/auth/signup`` needs before it will send anything.
+    """What ``POST /api/v1/auth/signup`` needs before it will send anything.
 
     Both settings, because the route refuses on either alone: the transport
     decides whether mail can go out and ``public_base_url`` is what the verify
@@ -67,7 +67,7 @@ def claiming_organization(
 
     The operator is switched back to the organization the deployment booted
     before this returns, and that is load-bearing rather than tidiness.
-    ``POST /v1/organizations/me/members`` adds to whichever organization the
+    ``POST /api/v1/organizations/me/members`` adds to whichever organization the
     caller is pointed at, so leaving the operator in Beta would put Ada straight
     into the claiming organization and every assertion below would hold with
     auto-join deleted.

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the POST /v1/embeddings endpoint."""
+"""Tests for the POST /api/v1/embeddings endpoint."""
 
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -21,7 +21,7 @@ def _mock_embedding_response(prompt_tokens: int = 10) -> CreateEmbeddingResponse
 
 
 def test_embeddings_requires_auth(client: TestClient) -> None:
-    """POST /v1/embeddings requires authentication."""
+    """POST /api/v1/embeddings requires authentication."""
     resp = client.post(f"{API_ROOT}/embeddings", json={"model": "openai:text-embedding-3-small", "input": "hello"})
     assert resp.status_code == 401
 
@@ -30,7 +30,7 @@ def test_embeddings_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings works with API key authentication."""
+    """POST /api/v1/embeddings works with API key authentication."""
     mock_resp = _mock_embedding_response()
     with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -48,7 +48,7 @@ def test_embeddings_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings with master key requires 'user' field."""
+    """POST /api/v1/embeddings with master key requires 'user' field."""
     mock_resp = _mock_embedding_response()
     with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -65,7 +65,7 @@ def test_embeddings_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/embeddings with master key + user field succeeds."""
+    """POST /api/v1/embeddings with master key + user field succeeds."""
     mock_resp = _mock_embedding_response()
     with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -84,7 +84,7 @@ def test_embeddings_list_input(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings accepts a list of strings as input."""
+    """POST /api/v1/embeddings accepts a list of strings as input."""
     mock_resp = _mock_embedding_response()
     with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -99,7 +99,7 @@ def test_embeddings_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings returns 502 when the provider fails."""
+    """POST /api/v1/embeddings returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.embeddings.aembedding",
         new_callable=AsyncMock,
@@ -120,7 +120,7 @@ def test_embeddings_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/embeddings creates a usage log entry."""
+    """POST /api/v1/embeddings creates a usage log entry."""
     mock_resp = _mock_embedding_response()
     user_id = api_key_obj["user_id"]
 
@@ -148,7 +148,7 @@ def test_embeddings_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/embeddings logs an error entry when the provider fails."""
+    """POST /api/v1/embeddings logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -177,7 +177,7 @@ def test_embeddings_optional_fields(
     api_key_header: dict[str, str],
     extra_field: str,
 ) -> None:
-    """POST /v1/embeddings forwards optional OpenAI fields."""
+    """POST /api/v1/embeddings forwards optional OpenAI fields."""
     mock_resp = _mock_embedding_response()
     values = {"encoding_format": "float", "dimensions": 256}
     with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp) as mock:
@@ -202,7 +202,7 @@ def test_embeddings_cost_tracked_with_pricing(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/embeddings calculates cost when model pricing exists.
+    """POST /api/v1/embeddings calculates cost when model pricing exists.
 
     A realistic prompt, because settlement is to the micro-dollar: ten tokens at
     $0.02 per million is two ten-millionths of a dollar, which the cost column
@@ -280,7 +280,7 @@ def test_embeddings_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings records auditable charge lines alongside cost."""
+    """POST /api/v1/embeddings records auditable charge lines alongside cost."""
     client.post(
         f"{API_ROOT}/pricing",
         json={

--- a/tests/integration/test_exact_budget_columns.py
+++ b/tests/integration/test_exact_budget_columns.py
@@ -53,7 +53,7 @@ def test_the_only_cap_surface_is_the_one_that_is_bounded(
     client: TestClient, master_key_header: dict[str, str]
 ) -> None:
     """A scoped ceiling names a budget rather than carrying its own limit, so
-    the bound on ``/v1/budgets`` is the whole of the guard. Asserted rather than
+    the bound on ``/api/v1/budgets`` is the whole of the guard. Asserted rather than
     assumed: a future surface that reintroduced a cap field would need bounding
     too, and this is what would notice.
     """

--- a/tests/integration/test_external_usage_events.py
+++ b/tests/integration/test_external_usage_events.py
@@ -1,4 +1,4 @@
-"""Integration tests for POST /v1/usage/external-events.
+"""Integration tests for POST /api/v1/usage/external-events.
 
 Covers auth, content-free validation, idempotency, historical + cache pricing,
 organization-scoped rates, budget isolation, and the read-surface (source filter,
@@ -55,7 +55,7 @@ def _seed_pricing(
     assert resp.status_code == 200, resp.text
 
 
-# An hour ago, not a fixed date. `GET /v1/usage/summary` bounds itself to the
+# An hour ago, not a fixed date. `GET /api/v1/usage/summary` bounds itself to the
 # last 30 days when the caller names no window (`_DEFAULT_SUMMARY_LOOKBACK`), so
 # a literal timestamp puts every summary assertion in this file on a fuse: it
 # passes until the day the clock is 30 days past it, then fails everywhere at

--- a/tests/integration/test_files_endpoint.py
+++ b/tests/integration/test_files_endpoint.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /v1/files API and end-to-end file understanding.
+"""Integration tests for the /api/v1/files API and end-to-end file understanding.
 
 The headline test exercises the full path: upload a file, send a chat request
 that references it by ``file_id``, and assert the gateway extracted the file to

--- a/tests/integration/test_hosted_mode_surface.py
+++ b/tests/integration/test_hosted_mode_surface.py
@@ -140,8 +140,8 @@ def test_hosted_mode_still_serves_the_management_plane(hosted_client: TestClient
         # Discovery, not dispatch, and a surface bootstrap publishes for a
         # hosted deployment, so it stays mounted.
         f"{API_ROOT}/models",
-        # The catalog POST /v1/search dispatches against. Management, and the
-        # one prefix a careless /v1/search stub could shadow.
+        # The catalog POST /api/v1/search dispatches against. Management, and the
+        # one prefix a careless /api/v1/search stub could shadow.
         f"{API_ROOT}/search-tools",
     ):
         response = hosted_client.get(path)
@@ -215,7 +215,7 @@ def test_the_refusal_names_the_data_plane_when_the_deployment_knows_it(
 
     "Send it to your Otari gateway" is what they already believed they were
     doing. Where ``data_plane_url`` is set, which is the same value
-    ``GET /v1/bootstrap`` hands the dashboard, the refusal names the host.
+    ``GET /api/v1/bootstrap`` hands the dashboard, the refusal names the host.
     """
     response = hosted_client_knowing_its_data_plane.post(f"{API_ROOT}/chat/completions", json={})
 

--- a/tests/integration/test_hosted_mode_surface.py
+++ b/tests/integration/test_hosted_mode_surface.py
@@ -140,8 +140,8 @@ def test_hosted_mode_still_serves_the_management_plane(hosted_client: TestClient
         # Discovery, not dispatch, and a surface bootstrap publishes for a
         # hosted deployment, so it stays mounted.
         f"{API_ROOT}/models",
-        # The catalog POST /api/v1/search dispatches against. Management, and the
-        # one prefix a careless /api/v1/search stub could shadow.
+        # The catalog that POST /api/v1/search dispatches against: management,
+        # and the one prefix a careless /api/v1/search stub could shadow.
         f"{API_ROOT}/search-tools",
     ):
         response = hosted_client.get(path)

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -2549,7 +2549,7 @@ def test_platform_mode_sandbox_unreachable_returns_502(
     """Hybrid non-streaming chat with the sandbox backend down surfaces the
     backend-specific 502, not a generic provider error or a 500. Regression
     for the drift where only messages/responses translated this failure: the
-    translation now lives in run_platform_non_stream, so /v1/chat/completions
+    translation now lives in run_platform_non_stream, so /api/v1/chat/completions
     inherits it."""
     monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
 

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -1,4 +1,4 @@
-"""Hybrid-mode integration tests for /v1/messages.
+"""Hybrid-mode integration tests for /api/v1/messages.
 
 Mirrors :mod:`tests.integration.test_hybrid_mode_chat`: exercises the
 multi-attempt platform resolve / fallback / usage-reporting flow against the
@@ -129,7 +129,7 @@ def test_hybrid_mode_requires_authorization_header(platform_client: TestClient) 
     )
 
     assert response.status_code == 401
-    # /v1/messages errors, including auth, are delivered in the Anthropic envelope.
+    # /api/v1/messages errors, including auth, are delivered in the Anthropic envelope.
     assert response.json() == {
         "detail": {
             "type": "error",
@@ -681,7 +681,7 @@ def test_hybrid_mode_tool_loop_falls_through_pre_lock_in(
     its successful completion.
 
     Verifies the ``[:1]`` collapse is gone for tool-loop requests on
-    ``/v1/messages`` now that ``on_first_response`` lock-in is wired into
+    ``/api/v1/messages`` now that ``on_first_response`` lock-in is wired into
     ``anthropic_tool_loop``.
     """
     usage_reports: list[dict[str, Any]] = []
@@ -1148,7 +1148,7 @@ def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Streaming MCP request on /v1/messages: the first attempt errors before
+    """Streaming MCP request on /api/v1/messages: the first attempt errors before
     yielding any event, so the gateway falls through to the second attempt and
     streams its response (same pre-lock-in semantics as chat, which this
     format previously collapsed to a single attempt)."""

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -1,4 +1,4 @@
-"""Hybrid-mode integration tests for /v1/responses.
+"""Hybrid-mode integration tests for /api/v1/responses.
 
 Mirror of :mod:`tests.integration.test_hybrid_mode_messages` for the OpenAI
 Responses endpoint. Tool-loop platform requests are tested only in the
@@ -552,7 +552,7 @@ def test_hybrid_mode_tool_loop_falls_through_pre_lock_in(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Non-streaming MCP request on /v1/responses: first attempt errors before
+    """Non-streaming MCP request on /api/v1/responses: first attempt errors before
     any tool round completes → fallback to the second attempt.
     """
     usage_reports: list[dict[str, Any]] = []
@@ -837,7 +837,7 @@ def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Streaming MCP request on /v1/responses: the first attempt errors before
+    """Streaming MCP request on /api/v1/responses: the first attempt errors before
     yielding any event, so the gateway falls through to the second attempt and
     streams its response (same pre-lock-in semantics as chat, which this
     format previously collapsed to a single attempt)."""

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -89,7 +89,7 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
     with TestClient(app) as client:
         for path in (
             f"{API_ROOT}/settings",
-            # Covered by the /v1/settings/{path} stub: a hybrid gateway sends no
+            # Covered by the /api/v1/settings/{path} stub: a hybrid gateway sends no
             # mail of its own, and the mail surface must 404 with the same hint
             # rather than reporting an unconfigured transport as if it were one
             # this deployment could configure.
@@ -101,14 +101,14 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
             f"{API_ROOT}/workspaces",
             # A workspace's MCP servers are stored with a bearer token, and in
             # hybrid mode they live on the platform. Listed explicitly rather
-            # than left to the `/v1/workspaces` entry above: this is a distinct
+            # than left to the `/api/v1/workspaces` entry above: this is a distinct
             # router, so re-mounting it would not show up in that check.
             f"{API_ROOT}/workspaces/11111111-1111-1111-1111-111111111111/mcp-servers",
             # A workspace's web-search configuration lives on the platform in
             # hybrid mode, where `prepare_gateway_tools` resolves it from
             # otari.ai rather than from a local row. Listed for the same reason
             # as the servers above: its own router, so re-mounting it would not
-            # show up in the `/v1/workspaces` check.
+            # show up in the `/api/v1/workspaces` check.
             f"{API_ROOT}/workspaces/11111111-1111-1111-1111-111111111111/web-search",
         ):
             response = client.get(path)

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the POST /v1/images/generations endpoint."""
+"""Tests for the POST /api/v1/images/generations endpoint."""
 
 from datetime import UTC, datetime
 from typing import Any
@@ -31,7 +31,7 @@ def _mock_images_response(n: int = 1) -> ImagesResponse:
 
 
 def test_images_requires_auth(client: TestClient) -> None:
-    """POST /v1/images/generations requires authentication."""
+    """POST /api/v1/images/generations requires authentication."""
     resp = client.post(
         f"{API_ROOT}/images/generations",
         json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
@@ -43,7 +43,7 @@ def test_images_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/images/generations works with API key authentication."""
+    """POST /api/v1/images/generations works with API key authentication."""
     mock_resp = _mock_images_response()
     with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -61,7 +61,7 @@ def test_images_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/images/generations with master key requires 'user' field."""
+    """POST /api/v1/images/generations with master key requires 'user' field."""
     mock_resp = _mock_images_response()
     with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -78,7 +78,7 @@ def test_images_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/images/generations with master key + user field succeeds."""
+    """POST /api/v1/images/generations with master key + user field succeeds."""
     mock_resp = _mock_images_response()
     with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
@@ -97,7 +97,7 @@ def test_images_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/images/generations returns 502 when the provider fails."""
+    """POST /api/v1/images/generations returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.images.aimage_generation",
         new_callable=AsyncMock,
@@ -118,7 +118,7 @@ def test_images_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/images/generations creates a usage log entry."""
+    """POST /api/v1/images/generations creates a usage log entry."""
     mock_resp = _mock_images_response()
     user_id = api_key_obj["user_id"]
 
@@ -146,7 +146,7 @@ def test_images_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/images/generations logs an error entry when the provider fails."""
+    """POST /api/v1/images/generations logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -175,7 +175,7 @@ def test_images_optional_fields(
     api_key_header: dict[str, str],
     extra_field: str,
 ) -> None:
-    """POST /v1/images/generations forwards optional fields."""
+    """POST /api/v1/images/generations forwards optional fields."""
     mock_resp = _mock_images_response()
     values = {"n": 2, "size": "1792x1024", "quality": "hd", "style": "natural"}
     with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp) as mock:
@@ -200,7 +200,7 @@ def test_images_cost_tracked_with_pricing(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/images/generations calculates cost when model pricing exists."""
+    """POST /api/v1/images/generations calculates cost when model pricing exists."""
     # Set up pricing: input_price_per_million is repurposed as price-per-image
     client.post(
         f"{API_ROOT}/pricing",
@@ -238,7 +238,7 @@ def test_images_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/images/generations records auditable charge lines alongside cost."""
+    """POST /api/v1/images/generations records auditable charge lines alongside cost."""
     client.post(
         f"{API_ROOT}/pricing",
         json={

--- a/tests/integration/test_in_flight_requests.py
+++ b/tests/integration/test_in_flight_requests.py
@@ -1,4 +1,4 @@
-"""GET /v1/usage/in-flight reports what the gateway is serving right now.
+"""GET /api/v1/usage/in-flight reports what the gateway is serving right now.
 
 The usage log only records requests that have settled, so a slow backend (a local
 model taking 30 seconds) is invisible while it runs. These tests pin the two

--- a/tests/integration/test_invitee_membership_inbox.py
+++ b/tests/integration/test_invitee_membership_inbox.py
@@ -74,7 +74,7 @@ async def _identity_with_a_home(db: AsyncSession, *, email: str) -> tuple[User, 
     """An identity that already belongs somewhere, which is who the inbox is for.
 
     An invitation to an address with no identity mints a password-less one that
-    cannot sign in until ``POST /v1/auth/signup`` claims it, so it could not
+    cannot sign in until ``POST /api/v1/auth/signup`` claims it, so it could not
     reach an inbox at all. Every case here starts from an identity that can.
     """
     home = await _organization(db, slug=f"home-{uuid.uuid4().hex[:8]}")

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the /v1/messages gateway endpoint."""
+"""Tests for the /api/v1/messages gateway endpoint."""
 
 from typing import Any
 from unittest.mock import AsyncMock, patch

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -1,4 +1,4 @@
-"""Route-level tests for the /v1/messages endpoint wiring.
+"""Route-level tests for the /api/v1/messages endpoint wiring.
 
 These complement :mod:`tests.unit.test_mcp_loop_messages` (which tests the
 Anthropic tool loop in isolation) by exercising the FastAPI route handler:

--- a/tests/integration/test_messages_streaming_usage.py
+++ b/tests/integration/test_messages_streaming_usage.py
@@ -1,9 +1,9 @@
-"""Regression test for streaming /v1/messages token + cost metering.
+"""Regression test for streaming /api/v1/messages token + cost metering.
 
-Reproduces the surface of mozilla-ai/otari#256: a streaming ``/v1/messages``
+Reproduces the surface of mozilla-ai/otari#256: a streaming ``/api/v1/messages``
 request whose stream completes cleanly must record the request's tokens and
 cost in the usage log, the same as the non-streaming path and as streaming
-``/v1/chat/completions``. The undercount originated in any-llm (the messages
+``/api/v1/chat/completions``. The undercount originated in any-llm (the messages
 bridge did not request usage on streaming, so the translated Anthropic events
 carried zero), fixed upstream in any-llm 1.21.0; otari's settlement path
 (``_messages_stream_usage`` -> ``streaming_generator``) already merges the
@@ -195,7 +195,7 @@ def test_messages_streaming_records_tokens_and_cost(
     assert "message_stop" in body
 
     row = _poll_usage_row(db_session_factory, user_id)
-    assert row is not None, "streaming /v1/messages must record a usage row"
+    assert row is not None, "streaming /api/v1/messages must record a usage row"
     assert row.status == "success"
     assert row.prompt_tokens == _INPUT_TOKENS
     assert row.completion_tokens == _OUTPUT_TOKENS
@@ -229,7 +229,7 @@ def test_messages_streaming_bills_compaction_iterations(
     assert "message_stop" in body
 
     row = _poll_usage_row(db_session_factory, user_id)
-    assert row is not None, "streaming /v1/messages must bill compaction usage"
+    assert row is not None, "streaming /api/v1/messages must bill compaction usage"
     assert row.status == "success"
     assert row.prompt_tokens == _INPUT_TOKENS + _COMPACTION_INPUT_TOKENS
     assert row.completion_tokens == _OUTPUT_TOKENS + _COMPACTION_OUTPUT_TOKENS

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -3,7 +3,7 @@
 An alias is a display name (e.g. ``myopusmodel``) that maps to a real selector
 (``provider:model`` or a named ``instance:model``). A request naming the alias
 routes to the target with the target's credentials, billing keys on the target,
-and the alias is what appears in GET /v1/models and in the response ``model``.
+and the alias is what appears in GET /api/v1/models and in the response ``model``.
 """
 
 from collections.abc import AsyncIterator, Generator

--- a/tests/integration/test_model_discovery.py
+++ b/tests/integration/test_model_discovery.py
@@ -1,4 +1,4 @@
-"""Integration tests for model auto-discovery in the GET /v1/models endpoint."""
+"""Integration tests for model auto-discovery in the GET /api/v1/models endpoint."""
 
 from collections.abc import Generator
 from typing import Any
@@ -76,7 +76,7 @@ def test_list_models_with_discovery(
     discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """Discovered models appear in GET /v1/models."""
+    """Discovered models appear in GET /api/v1/models."""
     from any_llm.types.model import Model
 
     fake_models = [
@@ -165,7 +165,7 @@ def test_list_models_includes_keyless_local_provider(
     Regression for mozilla-ai/otari#389. Ollama, llama.cpp, and llamafile take no
     credential, so ``ollama:`` with no body under ``providers`` is the whole
     config. That entry used to fail to load (YAML gives ``None``), leaving a
-    running local server callable but permanently absent from GET /v1/models.
+    running local server callable but permanently absent from GET /api/v1/models.
     """
     from any_llm.types.model import Model
 
@@ -420,7 +420,7 @@ def test_get_model_tolerates_a_provider_without_created(
     discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """The same missing ``created`` must not fail GET /v1/models/{id}."""
+    """The same missing ``created`` must not fail GET /api/v1/models/{id}."""
     from any_llm.types.model import Model
 
     get_model_cache().set(
@@ -437,7 +437,7 @@ def test_get_model_from_discovery_cache(
     discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """GET /v1/models/{id} finds a model that exists only in the discovery cache."""
+    """GET /api/v1/models/{id} finds a model that exists only in the discovery cache."""
     from any_llm.types.model import Model
 
     fake_models = [Model(**_make_openai_model("gpt-4o"))]
@@ -457,7 +457,7 @@ def test_get_model_not_found_with_discovery(
     discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """GET /v1/models/{id} returns 404 when not in cache or pricing table."""
+    """GET /api/v1/models/{id} returns 404 when not in cache or pricing table."""
     resp = discovery_client.get(
         f"{API_ROOT}/models/openai:nonexistent-model",
         headers=discovery_master_header,
@@ -497,7 +497,7 @@ def test_list_models_sorted(
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/models/discoverable
+# GET /api/v1/models/discoverable
 # ---------------------------------------------------------------------------
 
 
@@ -575,7 +575,7 @@ def test_discoverable_queries_providers_when_discovery_disabled(
     two_provider_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """model_discovery is a listing policy for /v1/models, not a query switch.
+    """model_discovery is a listing policy for /api/v1/models, not a query switch.
 
     The fixture config sets model_discovery=False; the operator still gets the
     models their credentials can reach.
@@ -596,7 +596,7 @@ def test_discoverable_queries_providers_when_discovery_disabled(
 
     openai_models = next(p for p in discoverable.json()["providers"] if p["provider"] == "openai")
     assert [m["id"] for m in openai_models["models"]] == ["gpt-4o", "gpt-4o-mini"]
-    # Same config, same call: /v1/models still publishes nothing, as configured.
+    # Same config, same call: /api/v1/models still publishes nothing, as configured.
     assert listed.json()["data"] == []
 
 
@@ -692,7 +692,7 @@ def test_discoverable_is_not_shadowed_by_get_model(
     two_provider_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """The path must not be captured by GET /v1/models/{model_id:path}.
+    """The path must not be captured by GET /api/v1/models/{model_id:path}.
 
     Registration order decides this, so a reordering would silently turn the
     response into a 404 ModelObject lookup for a model named "discoverable".
@@ -710,7 +710,7 @@ def test_discoverable_is_not_shadowed_by_get_model(
 
 
 # ---------------------------------------------------------------------------
-# GET /v1/providers/health (provider health monitor)
+# GET /api/v1/providers/health (provider health monitor)
 # ---------------------------------------------------------------------------
 
 
@@ -956,7 +956,7 @@ def test_models_read_serves_an_expired_cache_without_dialing(
     cached_discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """The fix: an expired entry is served, not re-dialed, on GET /v1/models.
+    """The fix: an expired entry is served, not re-dialed, on GET /api/v1/models.
 
     Before the background refresher, whichever request arrived after the TTL
     lapsed paid ``model_discovery_timeout_seconds`` per unreachable provider and
@@ -1095,7 +1095,7 @@ def test_model_detail_agrees_with_the_listing_on_a_stale_entry(
     cached_discovery_client: TestClient,
     discovery_master_header: dict[str, str],
 ) -> None:
-    """GET /v1/models/{id} must not 404 a model GET /v1/models is listing.
+    """GET /api/v1/models/{id} must not 404 a model GET /api/v1/models is listing.
 
     Nothing on the request path renews ``cached_at`` any more, and the refresher
     sleeps its interval *after* each round, so an entry is expired from the moment

--- a/tests/integration/test_model_metadata_endpoint.py
+++ b/tests/integration/test_model_metadata_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for GET /v1/models/metadata (models.dev enrichment, mocked fetch)."""
+"""Tests for GET /api/v1/models/metadata (models.dev enrichment, mocked fetch)."""
 
 from collections.abc import Generator
 from typing import Any

--- a/tests/integration/test_models_endpoint.py
+++ b/tests/integration/test_models_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the GET /v1/models endpoint."""
+"""Tests for the GET /api/v1/models endpoint."""
 
 from datetime import UTC, datetime
 from typing import Any
@@ -12,7 +12,7 @@ def test_list_models_empty(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/models returns empty list when no pricing is configured."""
+    """GET /api/v1/models returns empty list when no pricing is configured."""
     resp = client.get(f"{API_ROOT}/models", headers=master_key_header)
     assert resp.status_code == 200
     data = resp.json()
@@ -25,7 +25,7 @@ def test_list_models_returns_configured_models(
     master_key_header: dict[str, str],
     model_pricing: dict[str, Any],
 ) -> None:
-    """GET /v1/models returns models from the pricing table."""
+    """GET /api/v1/models returns models from the pricing table."""
     resp = client.get(f"{API_ROOT}/models", headers=master_key_header)
     assert resp.status_code == 200
     data = resp.json()
@@ -95,7 +95,7 @@ def test_list_models_exposes_cache_pricing(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """Cache read/write rates set via /v1/pricing surface on the model catalog."""
+    """Cache read/write rates set via /api/v1/pricing surface on the model catalog."""
     client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -131,7 +131,7 @@ def test_get_model_found(
     master_key_header: dict[str, str],
     model_pricing: dict[str, Any],
 ) -> None:
-    """GET /v1/models/{model_id} returns the model when it exists."""
+    """GET /api/v1/models/{model_id} returns the model when it exists."""
     model_key = model_pricing["model_key"]
     resp = client.get(f"{API_ROOT}/models/{model_key}", headers=master_key_header)
     assert resp.status_code == 200
@@ -146,19 +146,19 @@ def test_get_model_not_found(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/models/{model_id} returns 404 for unknown models."""
+    """GET /api/v1/models/{model_id} returns 404 for unknown models."""
     resp = client.get(f"{API_ROOT}/models/nonexistent:model", headers=master_key_header)
     assert resp.status_code == 404
 
 
 def test_list_models_requires_auth(client: TestClient) -> None:
-    """GET /v1/models requires authentication."""
+    """GET /api/v1/models requires authentication."""
     resp = client.get(f"{API_ROOT}/models")
     assert resp.status_code == 401
 
 
 def test_get_model_requires_auth(client: TestClient) -> None:
-    """GET /v1/models/{model_id} requires authentication."""
+    """GET /api/v1/models/{model_id} requires authentication."""
     resp = client.get(f"{API_ROOT}/models/openai:gpt-4o")
     assert resp.status_code == 401
 
@@ -167,7 +167,7 @@ def test_list_models_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/models works with API key authentication (not just master key)."""
+    """GET /api/v1/models works with API key authentication (not just master key)."""
     resp = client.get(f"{API_ROOT}/models", headers=api_key_header)
     assert resp.status_code == 200
     assert resp.json()["object"] == "list"
@@ -177,7 +177,7 @@ def test_list_models_sorted_by_key(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/models returns models sorted by model_key."""
+    """GET /api/v1/models returns models sorted by model_key."""
     for model_key in ["openai:gpt-4o", "anthropic:claude-3-haiku"]:
         client.post(
             f"{API_ROOT}/pricing",

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the POST /v1/moderations endpoint."""
+"""Tests for the POST /api/v1/moderations endpoint."""
 
 import logging
 from datetime import UTC, datetime
@@ -33,7 +33,7 @@ def _mock_moderation_response() -> ModerationResponse:
 
 
 def test_moderations_requires_auth(client: TestClient) -> None:
-    """POST /v1/moderations requires authentication."""
+    """POST /api/v1/moderations requires authentication."""
     resp = client.post(
         f"{API_ROOT}/moderations",
         json={"model": "openai:omni-moderation-latest", "input": "hello"},
@@ -45,7 +45,7 @@ def test_moderations_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations works with API key authentication."""
+    """POST /api/v1/moderations works with API key authentication."""
     mock_resp = _mock_moderation_response()
     with patch(
         "gateway.api.routes.moderations.amoderation",
@@ -68,7 +68,7 @@ def test_moderations_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations with master key requires 'user' field."""
+    """POST /api/v1/moderations with master key requires 'user' field."""
     mock_resp = _mock_moderation_response()
     with patch(
         "gateway.api.routes.moderations.amoderation",
@@ -89,7 +89,7 @@ def test_moderations_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/moderations with master key + user field succeeds."""
+    """POST /api/v1/moderations with master key + user field succeeds."""
     mock_resp = _mock_moderation_response()
     with patch(
         "gateway.api.routes.moderations.amoderation",
@@ -112,7 +112,7 @@ def test_moderations_list_input(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations accepts a list of strings as input."""
+    """POST /api/v1/moderations accepts a list of strings as input."""
     mock_resp = _mock_moderation_response()
     with patch(
         "gateway.api.routes.moderations.amoderation",
@@ -134,7 +134,7 @@ def test_moderations_multimodal_input(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations accepts multimodal content-part dicts."""
+    """POST /api/v1/moderations accepts multimodal content-part dicts."""
     mock_resp = _mock_moderation_response()
     multimodal_input = [
         {"type": "text", "text": "describe this"},
@@ -161,7 +161,7 @@ def test_moderations_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations returns 502 when the provider fails."""
+    """POST /api/v1/moderations returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.moderations.amoderation",
         new_callable=AsyncMock,
@@ -221,7 +221,7 @@ def test_moderations_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/moderations creates a usage log entry on success."""
+    """POST /api/v1/moderations creates a usage log entry on success."""
     mock_resp = _mock_moderation_response()
     user_id = api_key_obj["user_id"]
 
@@ -258,7 +258,7 @@ def test_moderations_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/moderations logs an error entry when the provider fails."""
+    """POST /api/v1/moderations logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -285,7 +285,7 @@ def test_moderations_include_raw_opts_in(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations forwards the include_raw query param to amoderation."""
+    """POST /api/v1/moderations forwards the include_raw query param to amoderation."""
     mock_resp = _mock_moderation_response()
     with patch(
         "gateway.api.routes.moderations.amoderation",
@@ -320,7 +320,7 @@ def test_moderations_cost_tracked_with_pricing(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/moderations records a non-zero cost when pricing exists."""
+    """POST /api/v1/moderations records a non-zero cost when pricing exists."""
     client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -362,7 +362,7 @@ def test_moderations_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations records auditable charge lines alongside cost."""
+    """POST /api/v1/moderations records auditable charge lines alongside cost."""
     client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -431,7 +431,7 @@ def test_moderations_no_warning_when_pricing_missing(
     api_key_header: dict[str, str],
     caplog: Any,
 ) -> None:
-    """POST /v1/moderations does not emit the 'No pricing configured' warning."""
+    """POST /api/v1/moderations does not emit the 'No pricing configured' warning."""
     mock_resp = _mock_moderation_response()
     with caplog.at_level(logging.WARNING, logger="gateway"):
         with patch(

--- a/tests/integration/test_oauth_api.py
+++ b/tests/integration/test_oauth_api.py
@@ -309,7 +309,7 @@ def test_a_deactivated_identity_cannot_sign_in_with_a_provider_either(
 ) -> None:
     # Deactivating somebody has to close every road in, or OAuth becomes the
     # door left open behind them. Flipped in the database because this edition
-    # exposes no route that deactivates a tenancy identity; `/v1/users` is the
+    # exposes no route that deactivates a tenancy identity; `/api/v1/users` is the
     # request-plane spend identity, which is a different table.
     add_member(client, master_key_header, email="ada@example.com")
     identity = _identity(db_session, "ada@example.com")

--- a/tests/integration/test_oauth_live_provider.py
+++ b/tests/integration/test_oauth_live_provider.py
@@ -28,7 +28,7 @@ To run it for Google::
     #      OTARI_OAUTH_GOOGLE_CLIENT_ID=...
     #      OTARI_OAUTH_GOOGLE_CLIENT_SECRET=...
     #      OTARI_DATABASE_URL=...   (the same one this test will read)
-    # 2. Call GET /v1/auth/oauth/google/authorize with curl -c so the flow
+    # 2. Call GET /api/v1/auth/oauth/google/authorize with curl -c so the flow
     #    cookie (otari_oauth_flow) it sets is kept, open the URL it returns and
     #    complete the consent screen. The browser lands on
     #    /#/auth/google/callback?code=...&state=...; copy both out of the

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -334,7 +334,7 @@ def test_a_ceiling_on_an_unknown_scope_is_refused(
     """Refused rather than created, because a scope naming nothing never binds.
 
     A ceiling on a typo is created, listed, and silently unenforced, with nothing
-    anywhere to surface it. Same rule ``POST /v1/scoped-budgets`` states.
+    anywhere to surface it. Same rule ``POST /api/v1/scoped-budgets`` states.
     """
     budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
 
@@ -447,7 +447,7 @@ def test_the_deployment_budget_list_is_not_this_one(
     """A budget defined here is the organization's, and one defined there is not.
 
     The two surfaces share the table, so this pins the filter rather than
-    assuming it: ``/v1/budgets`` sees everything, and this list sees only rows
+    assuming it: ``/api/v1/budgets`` sees everything, and this list sees only rows
     carrying the caller's organization.
     """
     deployment = client.post(f"{API_ROOT}/budgets", json={"name": "Deployment wide"}, headers=master_key_header)
@@ -463,7 +463,7 @@ def test_the_deployment_budget_list_is_not_this_one(
         tenant["budget_id"],
     }
     # And each row says which it is, so the operator's assignment control can
-    # withhold the one `POST /v1/users` would refuse.
+    # withhold the one `POST /api/v1/users` would refuse.
     owners = {row["budget_id"]: row["organization_id"] for row in everything}
     assert owners[deployment.json()["budget_id"]] is None
     assert owners[tenant["budget_id"]] == tenant["organization_id"]
@@ -1054,7 +1054,7 @@ async def test_an_explicit_null_clears_the_cap_as_the_schema_says(async_db: Asyn
 async def test_a_delete_is_refused_while_a_gateway_user_holds_the_budget(async_db: AsyncSession) -> None:
     """The hold the assignment sites no longer create, and still have to refuse.
 
-    Since otari#881 neither `/v1/users` site will point a gateway user at a
+    Since otari#881 neither `/api/v1/users` site will point a gateway user at a
     tenant's budget, so a row in this shape was assigned before that. Seeded
     directly for the same reason. `Budget.users` is a plain relationship, so an
     unchecked delete does not fail on it: the ORM nulls the column out, and an

--- a/tests/integration/test_organization_guardrail_enforcement.py
+++ b/tests/integration/test_organization_guardrail_enforcement.py
@@ -2,7 +2,7 @@
 
 The management surface is covered in ``test_organization_guardrails.py``; this is
 the other half of otari#654's Definition of Done, the request path enforcing what
-the configuration says. Every case goes through ``/v1/messages`` with the
+the configuration says. Every case goes through ``/api/v1/messages`` with the
 provider call patched out and the guardrails service stubbed with an
 ``httpx.MockTransport``, so what is asserted is admission: whether a check ran at
 all, what it was sent, and what the verdict did to the request.

--- a/tests/integration/test_organization_member_keys.py
+++ b/tests/integration/test_organization_member_keys.py
@@ -1,8 +1,8 @@
 """The member-scoped key surface touches the caller's own keys and no more.
 
-``/v1/keys`` is deployment-wide and operator-only (otari-ai#1880), which left a
+``/api/v1/keys`` is deployment-wide and operator-only (otari-ai#1880), which left a
 hosted organization member with no way to mint a key (mozilla-ai/otari-ai#1941).
-``/v1/organizations/me/keys`` is the tenant's half of it, and the whole of its
+``/api/v1/organizations/me/keys`` is the tenant's half of it, and the whole of its
 correctness is that ownership and workspace scope are decided by the caller's
 identity and memberships rather than by anything the request carries. So the
 suite is written against a world holding two organizations, two members sharing
@@ -276,7 +276,7 @@ def test_an_omitted_workspace_refuses_a_caller_outside_the_default_one(client: T
 def test_a_revoked_spend_identity_cannot_mint_its_way_back(
     client: TestClient, world: _World, master_key_header: dict[str, str]
 ) -> None:
-    """``DELETE /v1/users`` is the operator's revocation, and this surface must not undo it.
+    """``DELETE /api/v1/users`` is the operator's revocation, and this surface must not undo it.
 
     That route soft-deletes the spend identity and deactivates every key it
     holds, and the data plane refuses a request whose owner is deleted.
@@ -393,7 +393,7 @@ def test_a_key_the_member_owns_but_did_not_mint_is_theirs_to_manage(
     """Ownership is the billing row, however the key got there.
 
     The handed-over case the docstrings promise, which no request can set up:
-    ``POST /v1/keys`` names an owner but mints into the *operator's* organization,
+    ``POST /api/v1/keys`` names an owner but mints into the *operator's* organization,
     so the row is written directly into alpha instead. What is asserted is the
     owner predicate on its own, and that it carries the whole lifecycle rather
     than the list alone.

--- a/tests/integration/test_organization_pricing_routes.py
+++ b/tests/integration/test_organization_pricing_routes.py
@@ -288,7 +288,7 @@ def test_repeated_tier_thresholds_are_refused(
     """Two rates for one threshold is a question with no answer.
 
     The cost core resolves a tie by taking the first applicable entry, so which
-    rate applied would depend on JSON array order. ``POST /v1/pricing`` and
+    rate applied would depend on JSON array order. ``POST /api/v1/pricing`` and
     ``GatewayConfig`` already refuse it; this surface has to as well.
     """
     response = client.post(

--- a/tests/integration/test_organization_routing_policies_scope.py
+++ b/tests/integration/test_organization_routing_policies_scope.py
@@ -1,9 +1,9 @@
 """The organization-scoped routing-policy read sees the caller's own workspaces and no more.
 
-``/v1/routing/policies`` is deployment-wide and operator-only, and stays that
+``/api/v1/routing/policies`` is deployment-wide and operator-only, and stays that
 way: its ``workspace_id`` parameter is a filter the client supplies, so nothing
 but the operator gate stands between a signed-in member and another
-organization's routing. ``/v1/organizations/me/routing-policies`` is the
+organization's routing. ``/api/v1/organizations/me/routing-policies`` is the
 tenant's View half of it (otari-ai#1942), shaped like the usage scope
 (otari#837), and this suite is that file's shape over the ``routing_policies``
 table: two organizations with policies in both, and every assertion names the
@@ -229,7 +229,7 @@ def test_a_member_of_no_workspace_reads_no_stored_rows_rather_than_a_refusal(
 
 
 def test_a_superuser_reads_their_active_organization_and_not_every_tenant(client: TestClient, world: _World) -> None:
-    """This route is scoped even for an operator; ``/v1/routing/policies`` is where they read across tenants."""
+    """This route is scoped even for an operator; ``/api/v1/routing/policies`` is where they read across tenants."""
     listed = _stored_names(client, world, "superuser")
     assert listed == set(_BETA_POLICIES)
     assert listed.isdisjoint(_ALPHA_ONE_POLICIES)

--- a/tests/integration/test_organization_usage_scope.py
+++ b/tests/integration/test_organization_usage_scope.py
@@ -1,6 +1,6 @@
 """The organization-scoped usage reads see the caller's own organization and no more.
 
-``/v1/usage`` is deployment-wide and operator-only since #821. These routes are
+``/api/v1/usage`` is deployment-wide and operator-only since #821. These routes are
 the tenant's half of it (otari#837), and the whole of their correctness is that
 the row set is decided by the caller's membership rather than by anything the
 request carries. So the suite is written against a world holding *two*
@@ -358,7 +358,7 @@ def test_a_suspended_workspace_membership_stops_granting_the_workspace(
 
 
 def test_a_superuser_reads_their_active_organization_and_not_every_tenant(client: TestClient, world: _World) -> None:
-    """This router is scoped even for an operator; ``/v1/usage`` is where they read across tenants."""
+    """This router is scoped even for an operator; ``/api/v1/usage`` is where they read across tenants."""
     listed = _models_listed(client, world, "superuser")
     assert listed == set(_BETA_MODELS)
     assert listed.isdisjoint(_ALPHA_ONE_MODELS)
@@ -488,7 +488,7 @@ def test_an_unauthenticated_request_is_refused(client: TestClient, world: _World
 
 
 def test_the_context_reports_whether_the_caller_operates_the_deployment(client: TestClient, world: _World) -> None:
-    """`deployment_operator` is the answer `GET /v1/admin/access` gives, on a read the shell already makes.
+    """`deployment_operator` is the answer `GET /api/v1/admin/access` gives, on a read the shell already makes.
 
     Carried here so the sidebar has no window in which it shows a row it is about
     to retract (otari#836), and so the roster can say which authority its role

--- a/tests/integration/test_pagination_bounds.py
+++ b/tests/integration/test_pagination_bounds.py
@@ -6,37 +6,37 @@ from gateway.core.config import API_ROOT
 
 
 def test_users_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/users rejects limit > 1000."""
+    """Test that /api/v1/users rejects limit > 1000."""
     response = client.get(f"{API_ROOT}/users?limit=10000", headers=master_key_header)
     assert response.status_code == 422
 
 
 def test_users_list_rejects_negative_skip(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/users rejects negative skip."""
+    """Test that /api/v1/users rejects negative skip."""
     response = client.get(f"{API_ROOT}/users?skip=-1", headers=master_key_header)
     assert response.status_code == 422
 
 
 def test_users_list_rejects_zero_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/users rejects limit=0."""
+    """Test that /api/v1/users rejects limit=0."""
     response = client.get(f"{API_ROOT}/users?limit=0", headers=master_key_header)
     assert response.status_code == 422
 
 
 def test_keys_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/keys rejects limit > 1000."""
+    """Test that /api/v1/keys rejects limit > 1000."""
     response = client.get(f"{API_ROOT}/keys?limit=10000", headers=master_key_header)
     assert response.status_code == 422
 
 
 def test_budgets_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/budgets rejects limit > 1000."""
+    """Test that /api/v1/budgets rejects limit > 1000."""
     response = client.get(f"{API_ROOT}/budgets?limit=10000", headers=master_key_header)
     assert response.status_code == 422
 
 
 def test_pricing_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Test that /v1/pricing rejects limit > 1000."""
+    """Test that /api/v1/pricing rejects limit > 1000."""
     response = client.get(f"{API_ROOT}/pricing?limit=10000", headers=master_key_header)
     assert response.status_code == 422
 

--- a/tests/integration/test_passthrough_enforcement.py
+++ b/tests/integration/test_passthrough_enforcement.py
@@ -5,7 +5,7 @@ audio transcription, audio speech) resolves a billed user and reserves budget
 *before* the provider call. These tests lock that in: a blocked user and an
 over-budget user must be rejected with 403 on every one of those routes, before
 any provider is reached. This is the guard that would have caught the
-``/v1/batches`` enforcement bypass (nothing asserted a given route actually runs
+``/api/v1/batches`` enforcement bypass (nothing asserted a given route actually runs
 the budget gate).
 
 The provider entrypoint for each route is patched to raise if it is ever
@@ -172,7 +172,7 @@ def test_batches_rejects_blocked_user(
     master_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """``/v1/batches`` rejects a blocked user with 403 before the provider.
+    """``/api/v1/batches`` rejects a blocked user with 403 before the provider.
 
     Batches bills the API key's owner when no ``user`` body field is sent. A key
     created without a user_id owns the shared "default" user, so we block that and

--- a/tests/integration/test_pricing_config.py
+++ b/tests/integration/test_pricing_config.py
@@ -251,7 +251,7 @@ def test_set_pricing_persists_cache_rates(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """Cache rates round-trip through /v1/pricing and are stored on the row."""
+    """Cache rates round-trip through /api/v1/pricing and are stored on the row."""
     resp = client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -389,7 +389,7 @@ def test_pricing_history_endpoint_returns_entries(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/pricing/{model_key}/history returns versions in descending order."""
+    """GET /api/v1/pricing/{model_key}/history returns versions in descending order."""
 
     model_key = "openai:gpt-4"
     first_effective = datetime(2025, 1, 1, tzinfo=UTC)
@@ -421,7 +421,7 @@ def test_get_pricing_respects_as_of(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/pricing/{model_key} returns the effective price at a timestamp."""
+    """GET /api/v1/pricing/{model_key} returns the effective price at a timestamp."""
 
     model_key = "anthropic:claude-3"
     early = datetime(2025, 3, 1, tzinfo=UTC)

--- a/tests/integration/test_provider_credentials_api.py
+++ b/tests/integration/test_provider_credentials_api.py
@@ -1,4 +1,4 @@
-"""Integration tests for the /v1/provider-credentials CRUD + test endpoints.
+"""Integration tests for the /api/v1/provider-credentials CRUD + test endpoints.
 
 Covers the security-critical behavior: keys are write-only and never echoed,
 storing a key requires OTARI_SECRET_KEY, updates are optimistic, and every route

--- a/tests/integration/test_provider_error_classification.py
+++ b/tests/integration/test_provider_error_classification.py
@@ -26,7 +26,7 @@ _RAW = "raw upstream message SECRET-9f3a"
 # The upstream OpenAI rejection for function tools + a non-'none' reasoning_effort.
 _REASONING_TOOLS_MSG = (
     "Function tools with reasoning_effort are not supported for gpt-5.6-sol in "
-    f"{API_ROOT}/chat/completions. To use function tools, use /v1/responses or set "
+    "/v1/chat/completions. To use function tools, use /v1/responses or set "
     "reasoning_effort to 'none'."
 )
 

--- a/tests/integration/test_providers_endpoint.py
+++ b/tests/integration/test_providers_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the GET /v1/providers endpoint."""
+"""Tests for the GET /api/v1/providers endpoint."""
 
 from collections.abc import Generator
 from typing import Any

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -1,4 +1,4 @@
-"""Integration tests for the POST /v1/rerank endpoint."""
+"""Integration tests for the POST /api/v1/rerank endpoint."""
 
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -64,7 +64,7 @@ RERANK_PAYLOAD: dict[str, Any] = {
 
 
 def test_rerank_requires_auth(client: TestClient) -> None:
-    """POST /v1/rerank requires authentication."""
+    """POST /api/v1/rerank requires authentication."""
     resp = client.post(f"{API_ROOT}/rerank", json=RERANK_PAYLOAD)
     assert resp.status_code == 401
 
@@ -73,7 +73,7 @@ def test_rerank_with_api_key(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank works with API key authentication."""
+    """POST /api/v1/rerank works with API key authentication."""
     with patch(
         "gateway.api.routes.rerank.arerank",
         new_callable=AsyncMock,
@@ -91,7 +91,7 @@ def test_rerank_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank with master key requires 'user' field."""
+    """POST /api/v1/rerank with master key requires 'user' field."""
     with patch(
         "gateway.api.routes.rerank.arerank",
         new_callable=AsyncMock,
@@ -107,7 +107,7 @@ def test_rerank_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/rerank with master key + user field succeeds."""
+    """POST /api/v1/rerank with master key + user field succeeds."""
     payload = {**RERANK_PAYLOAD, "user": test_user["user_id"]}
     with patch(
         "gateway.api.routes.rerank.arerank",
@@ -122,7 +122,7 @@ def test_rerank_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank returns 502 when the provider fails."""
+    """POST /api/v1/rerank returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.rerank.arerank",
         new_callable=AsyncMock,
@@ -139,7 +139,7 @@ def test_rerank_logs_usage(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/rerank creates a usage log entry."""
+    """POST /api/v1/rerank creates a usage log entry."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -166,7 +166,7 @@ def test_rerank_logs_error_on_failure(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/rerank logs an error entry when the provider fails."""
+    """POST /api/v1/rerank logs an error entry when the provider fails."""
     user_id = api_key_obj["user_id"]
 
     with patch(
@@ -189,7 +189,7 @@ def test_rerank_empty_documents_422(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank returns 422 when documents list is empty."""
+    """POST /api/v1/rerank returns 422 when documents list is empty."""
     payload = {**RERANK_PAYLOAD, "documents": []}
     resp = client.post(f"{API_ROOT}/rerank", json=payload, headers=api_key_header)
     assert resp.status_code == 422
@@ -199,7 +199,7 @@ def test_rerank_top_n_zero_422(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank returns 422 when top_n is 0."""
+    """POST /api/v1/rerank returns 422 when top_n is 0."""
     payload = {**RERANK_PAYLOAD, "top_n": 0}
     resp = client.post(f"{API_ROOT}/rerank", json=payload, headers=api_key_header)
     assert resp.status_code == 422
@@ -209,7 +209,7 @@ def test_rerank_top_n_negative_422(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank returns 422 when top_n is negative."""
+    """POST /api/v1/rerank returns 422 when top_n is negative."""
     payload = {**RERANK_PAYLOAD, "top_n": -1}
     resp = client.post(f"{API_ROOT}/rerank", json=payload, headers=api_key_header)
     assert resp.status_code == 422
@@ -222,7 +222,7 @@ def test_rerank_optional_fields_forwarded(
     extra_field: str,
     value: int,
 ) -> None:
-    """POST /v1/rerank forwards top_n and max_tokens_per_doc to the SDK."""
+    """POST /api/v1/rerank forwards top_n and max_tokens_per_doc to the SDK."""
     mock = AsyncMock(return_value=_mock_rerank_response())
     payload = {**RERANK_PAYLOAD, extra_field: value}
     with patch("gateway.api.routes.rerank.arerank", mock):
@@ -238,7 +238,7 @@ def test_rerank_cost_tracked_with_pricing(
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """POST /v1/rerank calculates cost when model pricing exists."""
+    """POST /api/v1/rerank calculates cost when model pricing exists."""
     client.post(
         f"{API_ROOT}/pricing",
         json={
@@ -272,7 +272,7 @@ def test_rerank_billing_meters_tracked_with_pricing(
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank records auditable charge lines alongside cost."""
+    """POST /api/v1/rerank records auditable charge lines alongside cost."""
     client.post(
         f"{API_ROOT}/pricing",
         json={

--- a/tests/integration/test_responses_endpoint.py
+++ b/tests/integration/test_responses_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the /v1/responses gateway endpoint."""
+"""Tests for the /api/v1/responses gateway endpoint."""
 
 import json
 from typing import Any, AsyncIterator

--- a/tests/integration/test_responses_route_dispatch.py
+++ b/tests/integration/test_responses_route_dispatch.py
@@ -1,4 +1,4 @@
-"""Route-level tests for the /v1/responses endpoint wiring.
+"""Route-level tests for the /api/v1/responses endpoint wiring.
 
 Mirror of :mod:`tests.integration.test_messages_route_dispatch` for the OpenAI
 Responses API surface: tool extraction, mutual-exclusivity validation,

--- a/tests/integration/test_routing_policies.py
+++ b/tests/integration/test_routing_policies.py
@@ -62,7 +62,7 @@ def _completion(model: str) -> ChatCompletion:
 
 
 def _message_response() -> Any:
-    """A minimal valid Anthropic Message, for the /v1/messages dispatch path."""
+    """A minimal valid Anthropic Message, for the /api/v1/messages dispatch path."""
     from any_llm.types.messages import MessageResponse, MessageUsage, TextBlock
 
     return MessageResponse(
@@ -1426,7 +1426,7 @@ def test_messages_endpoint_fails_over(client: TestClient, stream: bool) -> None:
                 "max_tokens": 16,
                 "stream": stream,
                 "messages": [{"role": "user", "content": "hi"}],
-                # /v1/messages takes the billed user in metadata, not a top-level field.
+                # /api/v1/messages takes the billed user in metadata, not a top-level field.
                 "metadata": {"user_id": "test-user"},
             },
             headers=HEADERS,

--- a/tests/integration/test_scoped_budgets.py
+++ b/tests/integration/test_scoped_budgets.py
@@ -701,7 +701,7 @@ def test_a_budget_can_be_relaxed_back_to_the_states_creation_allows(
     A null ``max_budget`` is a budget that meters and admits everything; a null
     ``budget_duration_sec`` is one that never resets. Both are creatable, so
     testing the value rather than whether the field was sent would make a cadence
-    addable and never removable. On ``/v1/budgets`` now, with the cadence.
+    addable and never removable. On ``/api/v1/budgets`` now, with the cadence.
 
     ``max_budget`` is the exception and stays value-tested, which is pre-existing
     behavior this change does not touch: clearing a limit is still done by
@@ -757,7 +757,7 @@ def test_a_ceiling_on_a_scope_that_does_not_exist_is_refused(
     Resolution matches a ceiling by id, so one naming a workspace that does not
     exist is created, listed, and never applied, with nothing anywhere to say
     so. That is what a mis-mapped id in a bulk import produces, and it fails in
-    the permissive direction. ``POST /v1/keys`` already refuses an unknown
+    the permissive direction. ``POST /api/v1/keys`` already refuses an unknown
     workspace; this matches it.
     """
     missing = client.post(
@@ -864,7 +864,7 @@ def test_a_budget_cannot_be_created_with_both_kinds_of_period(
     """The state the table's CHECK refuses is answered as a request error, not a
     database error.
 
-    On ``/v1/budgets`` now, because that is where a period lives.
+    On ``/api/v1/budgets`` now, because that is where a period lives.
     """
     response = client.post(
         f"{API_ROOT}/budgets",

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -1,4 +1,4 @@
-"""Integration tests for the POST /v1/search endpoint.
+"""Integration tests for the POST /api/v1/search endpoint.
 
 The provider adapter is stubbed at ``run_search`` so these exercise the route's
 own job: auth, tool selection, budget reservation and settlement, and the usage
@@ -53,7 +53,7 @@ def test_config(postgres_url: str) -> GatewayConfig:
 def _search_rows(client: TestClient, headers: dict[str, str], user_id: str) -> list[dict[str, Any]]:
     """The user's search usage rows, from the admin view that exposes every column.
 
-    ``/v1/users/{id}/usage`` omits ``counts_toward_budget``, which the refusal
+    ``/api/v1/users/{id}/usage`` omits ``counts_toward_budget``, which the refusal
     rows below have to assert on.
     """
     resp = client.get(
@@ -75,13 +75,13 @@ def _mock_search(outcome: SearchOutcome | None = None, *, side_effect: Exception
 
 
 def test_search_requires_auth(client: TestClient) -> None:
-    """POST /v1/search requires authentication."""
+    """POST /api/v1/search requires authentication."""
     resp = client.post(f"{API_ROOT}/search", json={**SEARCH_PAYLOAD, "search_tool_name": "exa-search"})
     assert resp.status_code == 401
 
 
 def test_search_with_api_key(client: TestClient, api_key_header: dict[str, str]) -> None:
-    """POST /v1/search returns normalized results for an authenticated key."""
+    """POST /api/v1/search returns normalized results for an authenticated key."""
     with _mock_search():
         resp = client.post(
             f"{API_ROOT}/search",
@@ -103,7 +103,7 @@ def test_search_with_api_key(client: TestClient, api_key_header: dict[str, str])
 
 
 def test_search_by_path_selects_the_tool(client: TestClient, api_key_header: dict[str, str]) -> None:
-    """POST /v1/search/{tool} runs against the tool named in the path."""
+    """POST /api/v1/search/{tool} runs against the tool named in the path."""
     mock = AsyncMock(return_value=SearchOutcome(results=_HITS))
     with patch("gateway.api.routes.search.run_search", mock):
         resp = client.post(f"{API_ROOT}/search/exa-fast", json=SEARCH_PAYLOAD, headers=api_key_header)
@@ -164,7 +164,7 @@ def test_search_unknown_tool_is_400(client: TestClient, api_key_header: dict[str
 
 
 def test_search_master_key_requires_user(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """POST /v1/search with the master key requires a 'user' field."""
+    """POST /api/v1/search with the master key requires a 'user' field."""
     with _mock_search():
         resp = client.post(f"{API_ROOT}/search/exa-search", json=SEARCH_PAYLOAD, headers=master_key_header)
     assert resp.status_code == 400
@@ -176,7 +176,7 @@ def test_search_master_key_with_user(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """POST /v1/search with the master key plus a user field succeeds."""
+    """POST /api/v1/search with the master key plus a user field succeeds."""
     payload = {**SEARCH_PAYLOAD, "user": test_user["user_id"]}
     with _mock_search():
         resp = client.post(f"{API_ROOT}/search/exa-search", json=payload, headers=master_key_header)

--- a/tests/integration/test_search_tools_api.py
+++ b/tests/integration/test_search_tools_api.py
@@ -1,7 +1,7 @@
-"""Integration tests for the /v1/search-tools CRUD endpoints.
+"""Integration tests for the /api/v1/search-tools CRUD endpoints.
 
 A search tool used to be declarable only in a config file, so a deployment
-configured through the dashboard could not use POST /v1/search at all (issue
+configured through the dashboard could not use POST /api/v1/search at all (issue
 #601). These cover the route in: keys are write-only, the same rules startup
 validation applies are applied here, config-file tools stay honored and
 read-only, and a tool added at runtime is immediately dispatchable.
@@ -230,7 +230,7 @@ def test_provider_catalog_reports_what_each_provider_needs(
 def test_stored_tool_is_immediately_dispatchable(
     client: TestClient, master_key_header: dict[str, str], api_key_header: dict[str, str]
 ) -> None:
-    """The whole point of issue #601: a dashboard-added tool serves /v1/search."""
+    """The whole point of issue #601: a dashboard-added tool serves /api/v1/search."""
     assert _create(client, master_key_header).status_code == 201
     outcome = SearchOutcome(results=[SearchHit(url="https://example.com", title="Example")])
     mock = AsyncMock(return_value=outcome)

--- a/tests/integration/test_session_model_catalog_scope.py
+++ b/tests/integration/test_session_model_catalog_scope.py
@@ -1,4 +1,4 @@
-"""``GET /v1/models`` shows a tenant only the providers their organization reaches.
+"""``GET /api/v1/models`` shows a tenant only the providers their organization reaches.
 
 The roles matrix wants a member's model list narrowed to the providers they have
 access to (otari-ai#1969). The narrowing reuses the allow-list machinery an API

--- a/tests/integration/test_settings_toggle.py
+++ b/tests/integration/test_settings_toggle.py
@@ -1,4 +1,4 @@
-"""Tests for the writable runtime settings endpoint (PATCH /v1/settings)."""
+"""Tests for the writable runtime settings endpoint (PATCH /api/v1/settings)."""
 
 import asyncio
 from collections.abc import AsyncGenerator, Generator

--- a/tests/integration/test_streaming_precommit_refund.py
+++ b/tests/integration/test_streaming_precommit_refund.py
@@ -2,10 +2,10 @@
 
 A streaming request whose upstream provider call fails *before the first chunk*
 ("pre-commit") must release the budget pre-debit hold, the same as the
-non-streaming handlers do. Previously ``/v1/messages`` and ``/v1/responses``
+non-streaming handlers do. Previously ``/api/v1/messages`` and ``/api/v1/responses``
 logged the error but left ``users.reserved`` inflated (a leak that was never
 released, since a budget-period reset zeroes ``spend`` but not ``reserved``).
-``/v1/chat/completions`` already refunded here; it is covered too as a parity
+``/api/v1/chat/completions`` already refunded here; it is covered too as a parity
 guard so all three endpoints stay consistent.
 """
 

--- a/tests/integration/test_tenancy_api.py
+++ b/tests/integration/test_tenancy_api.py
@@ -78,7 +78,7 @@ def _add_identity(
 def _other_tenant(session_factory: Callable[[], Session]) -> tuple[uuid.UUID, uuid.UUID]:
     """Insert a second organization with a workspace, and return both ids.
 
-    Written directly rather than through ``POST /v1/organizations``, which makes
+    Written directly rather than through ``POST /api/v1/organizations``, which makes
     the caller its owner: these rows exist to be the organization the operator
     is *not* in, which is what every cross-tenant assertion here points at.
     """
@@ -123,9 +123,9 @@ def test_context_reports_whether_provider_keys_can_be_encrypted(
     monkeypatch: pytest.MonkeyPatch,
     configured: bool,
 ) -> None:
-    """The context carries the fact, so a tenant never has to read /v1/settings for it.
+    """The context carries the fact, so a tenant never has to read /api/v1/settings for it.
 
-    ``GET /v1/settings`` reports the same thing as ``secret_key_configured`` and
+    ``GET /api/v1/settings`` reports the same thing as ``secret_key_configured`` and
     is operator-only, so the provider-key pages inferred it from a query that
     403s for every organization owner (#839).
     """

--- a/tests/integration/test_tenancy_attribution.py
+++ b/tests/integration/test_tenancy_attribution.py
@@ -4,7 +4,7 @@ Keys, budgets, and usage hang off the gateway's string-keyed ``users`` table;
 members are UUID-keyed ``user`` rows. Nothing joins them, so before this a member
 could be added to the roster and then not be given a key. These cover the bridge:
 that adding a member mints the owner row, that the id the roster reports is one
-``POST /v1/keys`` actually accepts, and that re-adding someone reuses their row
+``POST /api/v1/keys`` actually accepts, and that re-adding someone reuses their row
 rather than minting a second or resurrecting a clean one.
 """
 

--- a/tests/integration/test_tool_settings_tenant_read.py
+++ b/tests/integration/test_tool_settings_tenant_read.py
@@ -1,4 +1,4 @@
-"""``GET /v1/tool-settings`` answers a tenant, without the service endpoints in it.
+"""``GET /api/v1/tool-settings`` answers a tenant, without the service endpoints in it.
 
 The roles matrix has the Tools pages at View for a member, and mozilla-ai/otari#867
 deferred this one read because the fields are deployment infrastructure rather

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -211,6 +211,6 @@ def test_auth_commit_failure_does_not_break_verification(
             headers={API_KEY_HEADER: f"Bearer {api_key}"},
         )
         # Auth should not crash with 500 from the commit failure.
-        # The /v1/users endpoint requires master key, so we may get 401
+        # The /api/v1/users endpoint requires master key, so we may get 401
         # (API key not accepted as master key), but crucially not 500.
         assert resp.status_code != 500

--- a/tests/integration/test_usage_admin.py
+++ b/tests/integration/test_usage_admin.py
@@ -403,7 +403,7 @@ def test_set_price_by_filter_prices_the_named_models_only(
 def test_by_filter_rejects_more_values_than_the_read_endpoints_accept(
     client: TestClient, master_key_header: dict[str, str]
 ) -> None:
-    """The destructive body stops where /v1/usage/count stops.
+    """The destructive body stops where /api/v1/usage/count stops.
 
     The count an operator confirms comes from the read endpoints, which 422 past
     MAX_FILTER_VALUES. A body that accepted more would delete over a filter set no

--- a/tests/integration/test_usage_endpoint.py
+++ b/tests/integration/test_usage_endpoint.py
@@ -501,10 +501,10 @@ def test_list_usage_still_returns_bare_list(
     master_key_header: dict[str, str],
     db_session: Session,
 ) -> None:
-    """Contract guard: /v1/usage must stay a bare JSON array, not an envelope.
+    """Contract guard: /api/v1/usage must stay a bare JSON array, not an envelope.
 
     External billing/analytics consumers depend on the top-level array; the
-    paginated UI's total count is served by /v1/usage/count instead.
+    paginated UI's total count is served by /api/v1/usage/count instead.
     """
     _make_log(db_session, user_id="contract", timestamp=datetime(2025, 9, 5, 12, 0, tzinfo=UTC))
     db_session.commit()

--- a/tests/integration/test_usage_status_code.py
+++ b/tests/integration/test_usage_status_code.py
@@ -181,7 +181,7 @@ def test_status_code_filters_the_list_and_the_count(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """``status_code`` narrows both /v1/usage and /v1/usage/count, so a paginated
+    """``status_code`` narrows both /api/v1/usage and /api/v1/usage/count, so a paginated
     "show me the 429s" view agrees with its own total."""
     for upstream in (429, 429, 500):
         with _upstream_fails(_StatusError(upstream)):
@@ -341,7 +341,7 @@ def test_batch_create_failure_records_the_upstream_status(
     master_key_header: dict[str, str],
     test_user: dict[str, Any],
 ) -> None:
-    """``POST /v1/batches`` classifies its provider failure on its own error row.
+    """``POST /api/v1/batches`` classifies its provider failure on its own error row.
 
     Batches write usage through ``log_batch_usage`` instead of the chat pipeline's
     writer, so this is the second independent stamp that a refactor could drop

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -133,7 +133,7 @@ def test_soft_deleted_user_not_in_list(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """Soft-deleted users should not appear in GET /v1/users."""
+    """Soft-deleted users should not appear in GET /api/v1/users."""
     client.post(f"{API_ROOT}/users", json={"user_id": "list-del-user"}, headers=master_key_header)
     client.delete(f"{API_ROOT}/users/list-del-user", headers=master_key_header)
 
@@ -166,7 +166,7 @@ def test_recreate_soft_deleted_user(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/users with a previously soft-deleted user_id should restore the user with spend=0."""
+    """POST /api/v1/users with a previously soft-deleted user_id should restore the user with spend=0."""
     client.post(
         f"{API_ROOT}/users",
         json={"user_id": "revive-user", "alias": "Original"},
@@ -215,7 +215,7 @@ def test_get_user_usage_after_soft_delete(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """GET /v1/users/{user_id}/usage should still return logs after the user is soft-deleted."""
+    """GET /api/v1/users/{user_id}/usage should still return logs after the user is soft-deleted."""
     client.post(f"{API_ROOT}/users", json={"user_id": "usage-del-user"}, headers=master_key_header)
     key_resp = client.post(
         f"{API_ROOT}/keys",

--- a/tests/integration/test_web_search_config_enforcement.py
+++ b/tests/integration/test_web_search_config_enforcement.py
@@ -2,9 +2,9 @@
 
 The management surface is covered in ``test_workspace_web_search.py``; this is
 the other half of #656's Definition of Done, the request path honoring what the
-row says. The in-loop cases go through ``/v1/messages`` with the search backend
+row says. The in-loop cases go through ``/api/v1/messages`` with the search backend
 and the tool loop patched out, so what is asserted is admission and the values
-handed to the backend, not any search. The last few cover ``POST /v1/search``,
+handed to the backend, not any search. The last few cover ``POST /api/v1/search``,
 the other door into the same capability.
 """
 
@@ -609,7 +609,7 @@ def test_the_direct_search_endpoint_honors_the_same_veto(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """`POST /v1/search` is the other door into web search, and it must not stay open.
+    """`POST /api/v1/search` is the other door into web search, and it must not stay open.
 
     A workspace that has turned search off has turned it off; leaving this
     endpoint unguarded would make the switch bypassable by any key in that

--- a/tests/integration/test_web_search_interception.py
+++ b/tests/integration/test_web_search_interception.py
@@ -1,6 +1,6 @@
-"""End-to-end web-search interception over /v1/chat/completions.
+"""End-to-end web-search interception over /api/v1/chat/completions.
 
-The `/v1/messages` side (including the native server-tool blocks, which only
+The `/api/v1/messages` side (including the native server-tool blocks, which only
 Anthropic has a vocabulary for) is covered in
 ``test_messages_route_dispatch.py``. This file covers the other half of the
 contract: a provider-named declaration on the OpenAI-shaped endpoint reaches the

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -299,7 +299,7 @@ async def test_reapplying_an_active_assignment_does_not_rematerialize_a_deleted_
     naming the same workspace); only a row that was actually inactive is a
     real join. Without the status gate, re-applying the assignment would
     resurrect a per-member ceiling an admin deliberately deleted through
-    `/v1/scoped-budgets`.
+    `/api/v1/scoped-budgets`.
     """
     org = await _organization(async_db, slug="acme-reapply")
     owner = await _member(async_db, org, role="owner", full_name="Owner")
@@ -481,7 +481,7 @@ async def test_materialize_batch_recovers_from_a_missed_collision(async_db: Asyn
     Reproduces the shape of the race `_insert_member_budgets` exists to
     survive: by the time the insert runs, a ceiling already exists for one of
     the ids in the batch (standing in for a concurrent direct
-    ``POST /v1/scoped-budgets`` for that member, which the batch's own
+    ``POST /api/v1/scoped-budgets`` for that member, which the batch's own
     existence check, run a moment earlier, would not yet have seen).
     Called directly rather than through `materialize_for_default`, which
     otherwise wraps the same existence check around every id and would just

--- a/tests/integration/test_workspace_scope.py
+++ b/tests/integration/test_workspace_scope.py
@@ -281,8 +281,8 @@ def test_a_members_workspace_ceiling_goes_with_the_workspace(
 #
 # A workspace belongs to exactly one organization, so scoping the request plane
 # to a workspace only holds up if the management plane cannot reach across one.
-# Before otari-ai#1880 it could: `POST /v1/keys` validated `workspace_id` for
-# existence and every `/v1/keys/{id}` route loaded by id alone, so a key minted
+# Before otari-ai#1880 it could: `POST /api/v1/keys` validated `workspace_id` for
+# existence and every `/api/v1/keys/{id}` route loaded by id alone, so a key minted
 # into another organization's workspace resolved that organization's BYO
 # provider credential and billed it.
 
@@ -343,7 +343,7 @@ def test_a_key_cannot_be_minted_into_another_organizations_workspace(
 
     Deliberately not a 403: a distinct status would confirm that the id names a
     real workspace somewhere on the deployment, which is the enumeration
-    ``GET /v1/keys`` used to hand over outright.
+    ``GET /api/v1/keys`` used to hand over outright.
     """
     home = _default_workspace(client, master_key_header)
     other = _second_organization(client, master_key_header)
@@ -372,7 +372,7 @@ def test_another_organizations_key_is_neither_listed_nor_reachable_by_id(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """Every `/v1/keys/{id}` route, including the rotate that returned a live secret.
+    """Every `/api/v1/keys/{id}` route, including the rotate that returned a live secret.
 
     Rotation is the sharpest of the four: it answered with the new plaintext key,
     so an unscoped load by id was direct theft of any credential on the

--- a/tests/integration/test_workspace_scope_survivals.py
+++ b/tests/integration/test_workspace_scope_survivals.py
@@ -166,7 +166,7 @@ def test_deleting_an_alias_in_the_wrong_workspace_is_a_404(
 def test_an_alias_cannot_be_written_into_a_workspace_that_does_not_exist(
     client: TestClient, master_key_header: dict[str, str]
 ) -> None:
-    """Checked rather than left to the foreign key, matching POST /v1/keys.
+    """Checked rather than left to the foreign key, matching POST /api/v1/keys.
 
     The id comes from the caller, so an unknown one is a bad request; reaching
     the constraint would answer 500 "Database error" for a value they can fix.
@@ -325,7 +325,7 @@ def test_the_master_key_still_sees_every_workspaces_files(
     """The operator acting deployment-wide, which is what keeps their tooling working.
 
     Narrowable with ``workspace_id`` rather than narrowed by default, matching
-    ``GET /v1/keys``.
+    ``GET /api/v1/keys``.
     """
     platform = _make_workspace(client, master_key_header, "Platform team")
     there = _key_header(client, master_key_header, api_key_header, workspace_id=platform, user_id="ada")

--- a/tests/unit/test_alias_service.py
+++ b/tests/unit/test_alias_service.py
@@ -217,7 +217,7 @@ def test_cached_aliases_returns_one_scope_at_a_time() -> None:
 def test_overriding_a_config_alias_drops_its_target_from_that_users_map() -> None:
     """The catalog withholds alias *targets*, so an override un-hides one.
 
-    /v1/models hides every value in this map. When a user's alias replaces a
+    /api/v1/models hides every value in this map. When a user's alias replaces a
     config name, the configured target is no longer a value here, so it stops
     being withheld and reappears in that user's listing. Subtle enough to be
     worth pinning, and it inverts the usual "an alias hides its target" rule.

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -148,7 +148,7 @@ def test_bootstrap_needs_no_credential(tmp_path: Path) -> None:
 
     with TestClient(app) as client:
         anonymous = client.get(f"{API_ROOT}/bootstrap")
-        # Named to contrast with /v1/settings, which the same client cannot read.
+        # Named to contrast with /api/v1/settings, which the same client cannot read.
         settings = client.get(f"{API_ROOT}/settings")
 
     assert anonymous.status_code == 200
@@ -214,9 +214,9 @@ def test_mail_ready_turns_on_only_with_a_transport_and_a_public_url(tmp_path: Pa
         assert client.get(f"{API_ROOT}/bootstrap").json()["mail_ready"] is True
 
 
-# A surface names its router's ``/v1/`` prefix, so the prefix is derived from the
+# A surface names its router's ``/api/v1/`` prefix, so the prefix is derived from the
 # name. One is nested rather than top-level and cannot be: the organization's own
-# provider keys hang off ``/v1/organizations``, and naming them ``organizations``
+# provider keys hang off ``/api/v1/organizations``, and naming them ``organizations``
 # would collapse them into the roster surface, which is a different page with
 # different access. Listed here rather than in the surface tuple itself so the
 # tuple stays the plain list of names the dashboard gates on.
@@ -250,7 +250,7 @@ def test_every_surface_names_a_route_the_gateway_mounts(
 
     for surface in surfaces:
         prefix = SURFACE_ROUTE_PREFIXES.get(surface, f"{API_ROOT}/{surface}")
-        assert any(path.startswith(prefix) for path in mounted), f"surface {surface!r} names no mounted /v1/ route"
+        assert any(path.startswith(prefix) for path in mounted), f"surface {surface!r} names no mounted /api/v1/ route"
 
 
 
@@ -553,7 +553,7 @@ def test_a_blank_legal_url_is_an_unset_one(field: str) -> None:
 def test_a_link_url_carrying_a_credential_is_refused_at_load(field: str, configured: str) -> None:
     """The refusal ``data_plane_url`` already made, for the same reason.
 
-    ``GET /v1/bootstrap`` is unauthenticated, so a credential written into any
+    ``GET /api/v1/bootstrap`` is unauthenticated, so a credential written into any
     of these link fields would reach every browser that asked for it, which no
     redaction in the operator-gated config viewer would cover. ``docs_url`` is
     covered too: it rides the same validator and the same response.
@@ -619,7 +619,7 @@ def test_standalone_never_publishes_a_data_plane_url(tmp_path: Path) -> None:
     """A standalone gateway is its own data plane, so the browser's origin is right.
 
     Configured or not, it answers null: the address that reached this page is an
-    address that reaches ``/v1/chat/completions``, which is more reliable than
+    address that reaches ``/api/v1/chat/completions``, which is more reliable than
     anything this process could report about itself from behind a proxy.
     """
     config = _standalone(tmp_path)
@@ -670,7 +670,7 @@ def test_a_data_plane_url_that_is_not_an_http_link_is_refused_at_load(configured
 def test_a_data_plane_url_carrying_a_query_or_fragment_is_refused_at_load(configured: str) -> None:
     """The one bad value an http(s) check alone would let through.
 
-    This is a base URL a client appends ``/v1/chat/completions`` to, so a query
+    This is a base URL a client appends ``/api/v1/chat/completions`` to, so a query
     string would swallow that path into a parameter value and a fragment would
     drop it after the hash. Both parse as absolute http(s) URLs and neither is
     recoverable downstream, unlike ``docs_url``, which is a link a person
@@ -687,7 +687,7 @@ def test_a_data_plane_url_carrying_a_query_or_fragment_is_refused_at_load(config
 def test_a_data_plane_url_carrying_a_credential_is_refused(configured: str) -> None:
     """Refused at load, because this value is published to anyone who asks.
 
-    ``GET /v1/bootstrap`` is unauthenticated, so a credential here would reach
+    ``GET /api/v1/bootstrap`` is unauthenticated, so a credential here would reach
     any browser that requested it, which no redaction in the operator-gated
     config viewer would cover. The snippet built from it would also put the
     whole address into a curl command somebody pastes into a shell history.
@@ -771,7 +771,7 @@ def test_a_path_that_does_not_name_v1_is_left_alone(configured: str) -> None:
 
 
 def test_a_trailing_slash_is_trimmed_from_the_data_plane_url() -> None:
-    """The dashboard suffixes this with ``/v1``, and ``//v1`` is a different path.
+    """The dashboard suffixes this with ``/api/v1``, and ``//api/v1`` is a different path.
 
     Normalized once here rather than at each consumer, since the value travels to
     a browser that builds a URL from it.

--- a/tests/unit/test_email_verification.py
+++ b/tests/unit/test_email_verification.py
@@ -219,7 +219,7 @@ def test_resend_without_mail_configured_is_refused(tmp_path: Path, caplog: pytes
         response = client.post(f"{API_ROOT}/auth/resend-verification", json={"email": "ada@example.com"})
         assert response.status_code == 503
         # Not the central tenancy handler's generic 5xx body: this refusal has
-        # to name what is missing, the same as GET /v1/settings/mail's own.
+        # to name what is missing, the same as GET /api/v1/settings/mail's own.
         assert "mail_transport" in response.json()["detail"]
 
 

--- a/tests/unit/test_files_route_streaming.py
+++ b/tests/unit/test_files_route_streaming.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``/v1/files`` route's streaming helpers.
+"""Unit tests for the ``/api/v1/files`` route's streaming helpers.
 
 Covers ``_prime`` in isolation (no FastAPI app/DB needed): it has no
 dependency on request/db/config, so it's tested directly rather than through

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -598,7 +598,7 @@ class TestDiscoveryStallGuards:
     async def test_concurrent_callers_share_one_upstream_call(self) -> None:
         """Concurrent discoveries of the same provider dial it once (single-flight).
 
-        This is what stops /v1/models and /v1/models/discoverable from each firing
+        This is what stops /api/v1/models and /api/v1/models/discoverable from each firing
         a full fanout when the Models page mounts both at once.
         """
         config = self._config({"openai": {"api_key": "sk-test"}})
@@ -682,7 +682,7 @@ class TestDiscoveryStallGuards:
     async def test_one_provider_raising_does_not_sink_the_listing(self) -> None:
         """A provider whose discovery raises is dropped/surfaced, never propagated.
 
-        discover_models_with_status feeds the operator's /v1/models/discoverable,
+        discover_models_with_status feeds the operator's /api/v1/models/discoverable,
         which awaits it with no guard, so an escaped exception must not 500 it.
         """
         config = self._config({"good": {"api_key": "x"}, "bad": {"api_key": "y"}})

--- a/tests/unit/test_gateway_root_page.py
+++ b/tests/unit/test_gateway_root_page.py
@@ -240,7 +240,7 @@ def test_hybrid_mode_serves_the_dashboard_at_root(tmp_path: Path, monkeypatch: p
     """Hybrid boots to the landing page, which is the same bundle standalone serves.
 
     Which surfaces exist is the browser's question to ask once, of
-    ``/v1/bootstrap``, rather than something this process answers by withholding
+    ``/api/v1/bootstrap``, rather than something this process answers by withholding
     files: the page renders the data-plane landing page from that answer. Serving
     the tutorial here instead would leave a hybrid operator with no status page at
     all.
@@ -291,7 +291,7 @@ def test_hybrid_mode_serves_no_install_manifest(tmp_path: Path, monkeypatch: pyt
 def test_hybrid_root_carries_no_platform_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The two things a hybrid gateway hands an unauthenticated browser.
 
-    The landing page reads its deployment from ``/v1/bootstrap`` and its status
+    The landing page reads its deployment from ``/api/v1/bootstrap`` and its status
     from ``/health``, and neither may carry the credential this gateway calls the
     platform with. The page itself is checked alongside them because it is served
     to the same anonymous browser and is now served in this mode at all.

--- a/tests/unit/test_guardrails_interceptor.py
+++ b/tests/unit/test_guardrails_interceptor.py
@@ -47,7 +47,7 @@ def test_latest_user_text_picks_last_user_message() -> None:
 
 
 def test_latest_user_text_handles_non_dict_items() -> None:
-    # /v1/responses `input` can be a list of arbitrary (non-dict) items; the
+    # /api/v1/responses `input` can be a list of arbitrary (non-dict) items; the
     # no-user-message fallback must not raise AttributeError (Copilot review).
     assert latest_user_text(["just a string"]) == ""
     assert latest_user_text([{"type": "x"}]) == ""

--- a/tests/unit/test_mail.py
+++ b/tests/unit/test_mail.py
@@ -142,7 +142,7 @@ def test_readiness_never_depends_on_a_validator_having_run() -> None:
 def test_config_and_transport_never_disagree_about_whether_mail_exists() -> None:
     """The two readers of "is mail configured" must not be able to drift apart.
 
-    ``/v1/bootstrap`` reads the config property and the invitation path asks the
+    ``/api/v1/bootstrap`` reads the config property and the invitation path asks the
     mailer; if those could differ, the dashboard would offer an affordance the
     request path refuses. Exhaustive over the settings that decide it, because
     the states that broke this before were the ones nobody thinks to write a
@@ -161,7 +161,7 @@ def test_config_and_transport_never_disagree_about_whether_mail_exists() -> None
                     state = (transport, host, sender, url)
                     assert config.mail_enabled == (select_transport(config) is not None), state
                     assert config.mail_ready == Mailer(config).can_send_links, state
-                    # "Empty exactly when ready" is the contract GET /v1/settings/mail
+                    # "Empty exactly when ready" is the contract GET /api/v1/settings/mail
                     # publishes, so it holds for every state and not just the tidy ones.
                     assert (config.missing_mail_settings == ()) == config.mail_ready, state
 

--- a/tests/unit/test_maintenance_mode.py
+++ b/tests/unit/test_maintenance_mode.py
@@ -6,13 +6,13 @@ name does not do this (it swaps a view in the browser *after* login and its
 `login.tsx` checks nothing), so what is asserted here is the behavior the issue
 describes rather than a ported one:
 
-* while it is on, ``POST /v1/auth/session`` refuses both credentials with 503;
+* while it is on, ``POST /api/v1/auth/session`` refuses both credentials with 503;
 * a session already minted keeps working, so the operator who flipped the switch
   is not locked out of the dashboard by it;
 * the master key through the header is never frozen, which is what guarantees a
   way back out even from a fresh browser;
 * the data plane and the rest of the management API are untouched;
-* ``GET /v1/bootstrap`` publishes it, so the sign-in screen can say what is
+* ``GET /api/v1/bootstrap`` publishes it, so the sign-in screen can say what is
   happening rather than presenting a form that can only be refused.
 
 Unit rather than integration: all of it is route and service behavior that runs

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -1,4 +1,4 @@
-"""``POST /v1/mcp/execute``: the caller-orchestrated execution contract.
+"""``POST /api/v1/mcp/execute``: the caller-orchestrated execution contract.
 
 Otari executes one exact call an application has already authorized. It proves
 no approval and claims none (R-AUTH-4); what it enforces is authentication,

--- a/tests/unit/test_mcp_tools_endpoint.py
+++ b/tests/unit/test_mcp_tools_endpoint.py
@@ -1,4 +1,4 @@
-"""``GET /v1/mcp/servers/{id}/tools``: the stored-server discovery contract.
+"""``GET /api/v1/mcp/servers/{id}/tools``: the stored-server discovery contract.
 
 An application calls this once per server when it prepares a model or workflow
 run, and every proposed call from that server reuses the answer. The response is

--- a/tests/unit/test_model_catalog_service.py
+++ b/tests/unit/test_model_catalog_service.py
@@ -134,7 +134,7 @@ async def test_stale_read_retries_a_failed_fetch_on_the_negative_ttl() -> None:
 
     The refresh cadence is the *success* cadence (``models_dev_cache_ttl_seconds``,
     a day by default). Serving a failure at any age would leave the dashboard
-    without enrichment until the next tick, and ``/v1/models/metadata`` has no
+    without enrichment until the next tick, and ``/api/v1/models/metadata`` has no
     ``refresh`` flag to escape it. The 60s negative TTL still governs a failure.
     """
     mcs.clear_catalog_cache()

--- a/tests/unit/test_password_reset.py
+++ b/tests/unit/test_password_reset.py
@@ -291,7 +291,7 @@ def test_request_reset_without_mail_configured_is_refused(tmp_path: Path, caplog
         response = client.post(f"{API_ROOT}/auth/password/reset", json={"email": "ada@example.com"})
         assert response.status_code == 503
         # Not the central tenancy handler's generic 5xx body: this refusal has
-        # to name what is missing, the same as GET /v1/settings/mail's own.
+        # to name what is missing, the same as GET /api/v1/settings/mail's own.
         assert "mail_transport" in response.json()["detail"]
 
 

--- a/tests/unit/test_password_sign_in.py
+++ b/tests/unit/test_password_sign_in.py
@@ -769,7 +769,7 @@ def test_a_malformed_stored_address_is_not_reported_as_the_caller_s_mistake(tmp_
 def _add_a_password(tmp_path: Path, email: str, password: str) -> None:
     """Give an existing identity a usable password, the way signup does.
 
-    Written straight to the row rather than through ``POST /v1/auth/signup``,
+    Written straight to the row rather than through ``POST /api/v1/auth/signup``,
     which needs a configured mailer: what these tests are about is the column,
     not the flow that fills it. ``email_verified_at`` is stamped alongside so
     the identity can actually sign in, which is the state signup leaves it in
@@ -845,7 +845,7 @@ def test_an_identity_that_arrived_with_a_password_does_not_claim_the_deployment(
 
     Platform identities carry ``hashed_password`` already, so a backfilled
     deployment would otherwise read as claimed before anyone had claimed it:
-    ``/v1/bootstrap`` would publish ``["password"]`` and the sign-in screen
+    ``/api/v1/bootstrap`` would publish ``["password"]`` and the sign-in screen
     would ask the operator holding the master key for credentials that are not
     theirs.
     """

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -34,7 +34,6 @@ from gateway.api.routes._pipeline import (
 )
 from gateway.api.routes._platform import _provider_failure_http_exc, upstream_retry_after
 from gateway.api.routes._schema_derive import SENSITIVE_PARAM_FIELDS
-from gateway.core.config import API_ROOT
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
 from gateway.services.upstream_redaction import MAX_EXPOSED_DETAIL_CHARS, redact_upstream_message
 
@@ -43,7 +42,7 @@ _RAW = "raw provider detail SECRET token=abc123"
 # The exact upstream OpenAI message for the tools + reasoning_effort rejection.
 _REASONING_TOOLS_MSG = (
     "Function tools with reasoning_effort are not supported for gpt-5.6-sol in "
-    f"{API_ROOT}/chat/completions. To use function tools, use /v1/responses or set "
+    "/v1/chat/completions. To use function tools, use /v1/responses or set "
     "reasoning_effort to 'none'."
 )
 

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``POST /v1/search`` backend.
+"""Unit tests for the ``POST /api/v1/search`` backend.
 
 Covers tool resolution against ``config.search_tools`` and the Exa and SearXNG
 adapters: request translation from the LiteLLM-shaped request to each

--- a/tests/unit/test_secret_fields.py
+++ b/tests/unit/test_secret_fields.py
@@ -6,7 +6,7 @@ are places a real credential legitimately lives: standalone Bedrock keeps its
 never forwards ``api_key`` into the boto3 client it builds. ``OrgProviderKey``
 has masked its own since it shipped; otari-ai#1880 is the other two, where
 ``ProviderCredential.client_args`` returned a live AWS secret to anyone who
-could reach ``GET /v1/provider-credentials``.
+could reach ``GET /api/v1/provider-credentials``.
 
 Masking on read creates the other half of the problem, so it is asserted here
 too: an editor that loads a row and saves it back would otherwise store the mask

--- a/tests/unit/test_signup.py
+++ b/tests/unit/test_signup.py
@@ -219,7 +219,7 @@ def test_signup_without_mail_configured_is_refused_and_writes_nothing(tmp_path: 
         response = _signup(client, email="ada@example.com")
         assert response.status_code == 503
         # Not the central tenancy handler's generic 5xx body: this refusal has
-        # to name what is missing, the same as GET /v1/settings/mail's own.
+        # to name what is missing, the same as GET /api/v1/settings/mail's own.
         assert "mail_transport" in response.json()["detail"]
 
     engine = create_engine(f"sqlite:///{tmp_path / 'signup-test.db'}")

--- a/tests/unit/test_tool_settings_endpoint.py
+++ b/tests/unit/test_tool_settings_endpoint.py
@@ -1,4 +1,4 @@
-"""Endpoint tests for /v1/tool-settings (sqlite-backed TestClient)."""
+"""Endpoint tests for /api/v1/tool-settings (sqlite-backed TestClient)."""
 
 from collections.abc import Callable, Iterator
 from pathlib import Path

--- a/tests/unit/test_tools_endpoint.py
+++ b/tests/unit/test_tools_endpoint.py
@@ -1,4 +1,4 @@
-"""Endpoint tests for GET /v1/tools (gateway-run tool discovery)."""
+"""Endpoint tests for GET /api/v1/tools (gateway-run tool discovery)."""
 
 from collections.abc import Iterator
 from pathlib import Path

--- a/tests/unit/test_usage_filter_bounds.py
+++ b/tests/unit/test_usage_filter_bounds.py
@@ -3,7 +3,7 @@
 The date query params and selection bodies advertise ISO 8601, so a caller that
 omits the offset hands in a naive datetime. asyncpg encodes ``timestamptz`` with
 ``astimezone``, which reads a naive value as the process's local time, so the same
-bound would select a different set of rows per deployment. `/v1/usage/summary`
+bound would select a different set of rows per deployment. `/api/v1/usage/summary`
 routes through `_resolve_window` and was already pinned; the list, count, and bulk
 mutation paths do not, so they pin the bound themselves.
 

--- a/tests/unit/test_web_search_backend_route.py
+++ b/tests/unit/test_web_search_backend_route.py
@@ -1,4 +1,4 @@
-"""Endpoint tests for GET /v1/web-search/search.
+"""Endpoint tests for GET /api/v1/web-search/search.
 
 The search backend a data-plane gateway calls when the deployment holding the
 search credential is a different process. Covers what is mounted, who may call

--- a/tests/unit/test_weighted_router.py
+++ b/tests/unit/test_weighted_router.py
@@ -304,7 +304,7 @@ def test_a_weighted_decision_is_not_logged_per_request() -> None:
 
 def test_a_weighted_policy_is_not_a_consumer_of_routing_memory() -> None:
     # A weighted policy names a router, but it reads no examples, so the routing
-    # memory surfaces must not claim it. `/v1/routing/status` would report it under
+    # memory surfaces must not claim it. `/api/v1/routing/status` would report it under
     # a warmth it never uses, and `rank` would let its pool decide which score keys
     # a user may teach, refusing the examples a learned policy is being prepared with.
     from gateway.api.routes.routing_memory import ScoredExample, _learned_policies, _validated_scores


### PR DESCRIPTION
## Description

Otari's REST API moved from `/v1` to `/api/v1` in an earlier release, and every description a caller can read (the OpenAPI document, the Postman collection, the dashboard) was updated with it. What was left behind was internal prose: comments and docstrings that only a person reading the source sees. Many of them still named routes at the old root, so a reader would be told to look for an endpoint that no longer exists at that address.

This change rewrites that prose to name routes where they are actually served. Nothing changes for someone using Otari: no route, response, error message, or generated document is different. The one configuration description that spelled the root out twice now takes it from the constant that owns it, so it cannot drift again.

Some mentions of `/v1` are left exactly as they were, because they do not name a route of this deployment: the usage-log labels that are frozen so old rows stay comparable with new ones, the OpenAI Batch API's own wire value, the OpenTelemetry signal paths under the OTLP root, LiteLLM's and Anthropic's contracts named as such, a peer service's health route, provider base URLs in test fixtures, and the rule that refuses a data-plane URL carrying a `/v1` segment. Prose below the route layer (services, models, ports, repositories) is a separate follow-up that removes route names from those docstrings rather than updating them.

A few touched comments were tightened while open rather than only re-rooted: one comment dropped a route name the surrounding code already gives, the section banners in the batches test lost their em dashes per the writing style rule, and two docstrings were corrected where review found a false claim or an unmarked frozen label.

## How to test it locally

Run `make lint` and `make typecheck`. Run the API prefix contract test, which walks every published description and fails on one that names a moved path, and confirms no route file spells either root:

```
uv run pytest tests/integration/test_api_prefix_contract.py
```

Regenerate the OpenAPI document and the Postman collection and confirm neither changes:

```
uv run python scripts/generate_openapi.py && make postman && make openapi-check && make postman-check
```

To eyeball the residue, search the source for `/v1` that is not preceded by `/api` or `/otlp` and confirm each remaining line is one of the classes listed above.

No test is added: the change is prose, and the existing contract test is what holds published descriptions. Locally, lint, typecheck, the contract test and every test file touched here were run in a clean worktree; the full suite is left to CI.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #1026, #1050, #1064 and #1069.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code

**Any additional AI details you'd like to share:**

The design, the plan and the review are human. AI was used to apply the rewrites file by file and to draft the commit messages and this description.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated internal comments, docstrings, and test descriptions to use Otari’s current `/api/v1` API root.
- Updated one configuration description to derive endpoint paths from the shared API root constant.
- Removed an inaccurate invitations comparison and clarified the intentional historical spelling of the search usage-log label.
- Preserved runtime behavior, routes, responses, errors, and generated API documents.
- Retained intentional `/v1` references for external contracts, provider paths, fixtures, validation rules, and fixed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
