### PR TITLE
refactor(dashboard): derive isDirty from the seeded snapshot in every form

### DIFF
--- a/web/src/design-system/forms/Select.tsx
+++ b/web/src/design-system/forms/Select.tsx
@@ -100,10 +100,7 @@ export function Select({
       {/* No manual "*": HeroUI marks a required field's label through CSS, so
           adding one renders two. */}
       <Label className="text-body">{label}</Label>
-      <HeroSelect.Trigger
-        // biome-ignore lint/a11y/noAutofocus: a form's first field takes it; see feedback.md
-        autoFocus={autoFocus}
-      >
+      <HeroSelect.Trigger autoFocus={autoFocus}>
         <HeroSelect.Value>
           {({ selectedText }) => selectedText ?? placeholder}
         </HeroSelect.Value>

--- a/web/src/design-system/forms/useDirtySnapshot.test.tsx
+++ b/web/src/design-system/forms/useDirtySnapshot.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from "@testing-library/react"
+import { act, render, renderHook } from "@testing-library/react"
+import { useRef } from "react"
 import { describe, expect, it } from "vitest"
 import { useDirtySnapshot } from "./useDirtySnapshot"
 
@@ -81,6 +82,31 @@ describe("useDirtySnapshot", () => {
     rerender({ workspaceIds: ["ws-1"] })
 
     expect(result.current.isDirty).toBe(false)
+  })
+
+  it("corrects the same render a reset(next) was called in", () => {
+    // The precondition that used to be hidden: held in a ref, the seed fixed
+    // nothing already rendered, and a caller that reseeded during render stayed
+    // armed unless it happened to set other state in the same block. The seed
+    // is state now, so this render is re-run and the `isDirty` the caller
+    // receives is the corrected one, with no other update in the block.
+    const seen: boolean[] = []
+    function Host({ landed }: { landed: string[] }) {
+      const { isDirty, reset } = useDirtySnapshot({ workspaceIds: landed })
+      const first = useRef(true)
+      if (first.current && landed.length > 0) {
+        first.current = false
+        reset({ workspaceIds: landed })
+      }
+      seen.push(isDirty)
+      return null
+    }
+
+    const { rerender } = render(<Host landed={[]} />)
+    rerender(<Host landed={["ws-1"]} />)
+
+    // The last render the caller was handed reads clean.
+    expect(seen.at(-1)).toBe(false)
   })
 
   it("seeds an explicit draft, for a default that lands after mount", () => {

--- a/web/src/design-system/forms/useDirtySnapshot.ts
+++ b/web/src/design-system/forms/useDirtySnapshot.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react"
+import { useCallback, useRef, useState } from "react"
 
 /**
  * Whether a form's draft still matches what it was seeded with.
@@ -18,10 +18,14 @@ import { useCallback, useRef } from "react"
  * explicit draft instead, which is what a form whose own default lands after
  * mount needs: that default is part of the seed rather than a change, and the
  * code that computes it holds the new value while the render it is in still
- * holds the old one. Seed it there, during the render that applies it, and not
- * from an effect: a ref write after the commit re-seeds nothing that has
- * already been rendered, so the guard stays armed until something else
- * re-renders.
+ * holds the old one. Call it there, during the render that applies the default:
+ * the seed is state, so a reset during render re-runs the component and the
+ * `isDirty` the caller receives is the corrected one. From an effect it also
+ * works, one render later.
+ *
+ * A reset during render has to be guarded by whatever made the default arrive
+ * (`if (!seeded && rows.length > 0)`), the same as any other set-state-while-
+ * rendering: unconditional, it is an endless render.
  *
  * `reset`'s identity is stable, so an effect may depend on it; a `reset` that
  * changed every render would re-seed on every render and the form would never
@@ -32,13 +36,22 @@ export function useDirtySnapshot(draft: unknown): {
   reset: (next?: unknown) => void
 } {
   const snapshot = JSON.stringify(draft)
-  const seeded = useRef(snapshot)
+  // State rather than a ref, so a reset during render corrects that render.
+  // Held in a ref it corrected nothing already rendered, and the two callers
+  // that appeared to work did so only because they set other state in the same
+  // block, which is what re-ran the component.
+  const [seed, setSeed] = useState(snapshot)
   // Read by `reset`, which has no dependencies and so cannot close over the
   // current render's snapshot.
   const latest = useRef(snapshot)
   latest.current = snapshot
+  // Not reflexive memoization, which the frontend standards rule out: the
+  // compiler memoizes nothing in this hook (it bails with "Cannot access refs
+  // during render" on the `latest` read above, measured with
+  // babel-plugin-react-compiler 1.0.0 against both this version and the one
+  // before it), so this `useCallback` is what actually keeps `reset` stable.
   const reset = useCallback((next?: unknown) => {
-    seeded.current = next === undefined ? latest.current : JSON.stringify(next)
+    setSeed(next === undefined ? latest.current : JSON.stringify(next))
   }, [])
-  return { isDirty: snapshot !== seeded.current, reset }
+  return { isDirty: snapshot !== seed, reset }
 }

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -1,5 +1,5 @@
 import { Button, Chip } from "@heroui/react"
-import { useRef, useState } from "react"
+import { useState } from "react"
 
 import type {
   CreateOrganizationDomainRequest,
@@ -13,6 +13,7 @@ import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Field } from "@/design-system/forms/Field"
 import { Select } from "@/design-system/forms/Select"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
@@ -83,8 +84,7 @@ function ClaimForm({
   // "differs from what was seeded", and a field added to the form is added here
   // or the guard cannot see it. A predicate of the fields had already forgotten
   // `role`, so changing who joins and pressing Escape discarded it unguarded.
-  const draft = JSON.stringify({ domain, role })
-  const seededDraft = useRef(draft)
+  const { isDirty } = useDirtySnapshot({ domain, role })
 
   const submit = () => {
     const body: CreateOrganizationDomainRequest = {
@@ -107,7 +107,7 @@ function ClaimForm({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={domain.trim() === ""}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
       error={create.error}
     >
       <Field

--- a/web/src/features/organization/OrganizationMembersPage.test.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.test.tsx
@@ -46,6 +46,10 @@ function mockApi(opts: {
   context?: OrganizationContext
   members?: OrganizationMember[]
   workspaces?: Workspace[]
+  // Holds the workspace roster in flight, so the dialog can be typed into
+  // before its default lands: `fetchAllPaged` walks every page, so on a cold
+  // cache that is the real order.
+  workspacesGate?: Promise<unknown>
   inviteResult?: unknown
   // The gateway's spend rows. The roster joins them on `attribution_user_id`
   // to show what a member may call and what they have spent, neither of which
@@ -106,6 +110,7 @@ function mockApi(opts: {
       return jsonResponse(roster[0] ?? {})
     }
     if (url.includes(`${API_ROOT}/workspaces`)) {
+      if (opts.workspacesGate) await opts.workspacesGate
       return jsonResponse({ data: workspaces, count: workspaces.length })
     }
     if (url.includes(`${API_ROOT}/users`)) {
@@ -419,6 +424,37 @@ describe("OrganizationMembersPage", () => {
     ).toBeDisabled()
     expect(
       screen.getByText(/Only organization owners and admins/),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps an address typed before the roster lands inside the guard", async () => {
+    // The default workspace is part of the seed; what the operator has already
+    // typed is not. Seeding the fields as they stand when the roster answers
+    // made the guard forget an address typed in the meantime, and Escape then
+    // closed without asking.
+    let release = () => {}
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    mockApi({
+      members: [OWNER],
+      workspaces: [workspace({ id: "ws-1", name: "Production" })],
+      workspacesGate: gate,
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Add member" }))
+    await user.type(screen.getByLabelText("Email address"), "ada@example.com")
+
+    // Now the roster answers and seeds the workspace default.
+    release()
+    expect(await screen.findByLabelText("Production")).toBeChecked()
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(
+      await screen.findByRole("button", { name: "Discard" }),
     ).toBeInTheDocument()
   })
 

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import { useMemo, useRef, useState } from "react"
+import { useMemo, useState } from "react"
 
 import type {
   User as ApiUser,
@@ -26,6 +26,7 @@ import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
 import { Select } from "@/design-system/forms/Select"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
@@ -191,8 +192,11 @@ function AddMemberForm({
   // Everything the operator can change, against what the form was seeded with.
   // A list of fields drifts: this one read the address alone, so a role or a
   // workspace change with no address typed closed unguarded.
-  const draft = JSON.stringify({ email, role, workspaceIds })
-  const seededDraft = useRef(draft)
+  const { isDirty, reset: reseed } = useDirtySnapshot({
+    email,
+    role,
+    workspaceIds,
+  })
   if (!seeded && rows && rows.length > 0) {
     setSeeded(true)
     // The workspace the shell is on, when it is one of this organization's.
@@ -205,12 +209,9 @@ function AddMemberForm({
     setWorkspaceIds(defaults)
     // Part of the seed, not a change: this lands after mount, so a snapshot
     // taken at first render would report the form dirty the moment the roster
-    // answers, and Escape would ask before closing an untouched form.
-    seededDraft.current = JSON.stringify({
-      email,
-      role,
-      workspaceIds: defaults,
-    })
+    // answers, and Escape would ask before closing an untouched form. Seeded
+    // with the explicit value, because this render still holds the old list.
+    reseed({ email, role, workspaceIds: defaults })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>
@@ -250,7 +251,7 @@ function AddMemberForm({
       onSubmit={submit}
       isPending={add.isPending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
       error={add.error}
     >
       <div className="grid gap-4 sm:grid-cols-2">
@@ -329,8 +330,11 @@ function InviteMemberForm({
   const rows = workspaces.data
   const [seeded, setSeeded] = useState(false)
   // Same snapshot as the add form beside it, and the same reason.
-  const draft = JSON.stringify({ email, role, workspaceIds })
-  const seededDraft = useRef(draft)
+  const { isDirty, reset: reseed } = useDirtySnapshot({
+    email,
+    role,
+    workspaceIds,
+  })
   if (!seeded && rows && rows.length > 0) {
     setSeeded(true)
     const preferred = rows.find(
@@ -340,12 +344,9 @@ function InviteMemberForm({
     setWorkspaceIds(defaults)
     // Part of the seed, not a change: this lands after mount, so a snapshot
     // taken at first render would report the form dirty the moment the roster
-    // answers, and Escape would ask before closing an untouched form.
-    seededDraft.current = JSON.stringify({
-      email,
-      role,
-      workspaceIds: defaults,
-    })
+    // answers, and Escape would ask before closing an untouched form. Seeded
+    // with the explicit value, because this render still holds the old list.
+    reseed({ email, role, workspaceIds: defaults })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>
@@ -423,7 +424,7 @@ function InviteMemberForm({
       onSubmit={submit}
       isPending={invite.isPending}
       isSubmitDisabled={trimmed === ""}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
       error={invite.error}
     >
       <div className="grid gap-4 sm:grid-cols-2">

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -209,9 +209,13 @@ function AddMemberForm({
     setWorkspaceIds(defaults)
     // Part of the seed, not a change: this lands after mount, so a snapshot
     // taken at first render would report the form dirty the moment the roster
-    // answers, and Escape would ask before closing an untouched form. Seeded
-    // with the explicit value, because this render still holds the old list.
-    reseed({ email, role, workspaceIds: defaults })
+    // answers, and Escape would ask before closing an untouched form.
+    //
+    // The mount values, not `email` and `role` as they stand: the roster pages
+    // through `fetchAllPaged`, so on a cold cache this can fire after the
+    // operator has typed an address, and seeding what they typed would make the
+    // guard forget it.
+    reseed({ email: "", role: "member", workspaceIds: defaults })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>
@@ -344,9 +348,13 @@ function InviteMemberForm({
     setWorkspaceIds(defaults)
     // Part of the seed, not a change: this lands after mount, so a snapshot
     // taken at first render would report the form dirty the moment the roster
-    // answers, and Escape would ask before closing an untouched form. Seeded
-    // with the explicit value, because this render still holds the old list.
-    reseed({ email, role, workspaceIds: defaults })
+    // answers, and Escape would ask before closing an untouched form.
+    //
+    // The mount values, not `email` and `role` as they stand: the roster pages
+    // through `fetchAllPaged`, so on a cold cache this can fire after the
+    // operator has typed an address, and seeding what they typed would make the
+    // guard forget it.
+    reseed({ email: "", role: "member", workspaceIds: defaults })
   }
 
   const toggleWorkspace = (id: string, checked: boolean) =>

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import { useRef, useState } from "react"
+import { useState } from "react"
 
 import type {
   CreateOrgProviderKeyRequest,
@@ -16,6 +16,7 @@ import { InfoBanner } from "@/design-system/feedback/InfoBanner"
 import { Checkbox } from "@/design-system/forms/Checkbox"
 import { Field } from "@/design-system/forms/Field"
 import { SecretField } from "@/design-system/forms/SecretField"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
@@ -139,8 +140,7 @@ function KeyForm({
   const pending = create.isPending || update.isPending
   // The whole draft against what the form was seeded with, so a guard cannot
   // miss a field the form grows later.
-  const seeded = useRef(JSON.stringify(draft))
-  const isDirty = JSON.stringify(draft) !== seeded.current
+  const { isDirty } = useDirtySnapshot(draft)
   const canSubmit =
     parsedClientArgs.ok &&
     Object.keys(credentialErrors).length === 0 &&

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -17,6 +17,7 @@ import { errorMessage } from "@/design-system/feedback/errorMessage"
 import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import { SecretField } from "@/design-system/forms/SecretField"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
 import { Section } from "@/design-system/layout/Section"
@@ -190,7 +191,7 @@ function KnownProviderForm({
   // client options and every typed credential (a Bedrock region) were invisible
   // to the guard and went on Escape with nothing asked. `key={addOpenCount}`
   // reseeds it per open. See feedback.md.
-  const draft = JSON.stringify({
+  const { isDirty } = useDirtySnapshot({
     providerId,
     apiKey,
     name,
@@ -198,7 +199,6 @@ function KnownProviderForm({
     clientArgsText,
     credentials,
   })
-  const seededDraft = useRef(draft)
   const canSubmit =
     providerId !== "" &&
     !nameHasDelimiter &&
@@ -249,7 +249,7 @@ function KnownProviderForm({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={!canSubmit}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
       error={create.error}
       footerStart={
         <ConnectionTestButton test={test} getPayload={buildPayload} />
@@ -374,14 +374,13 @@ function CustomProviderForm({
   const nameHasDelimiter = /[:/]/.test(name)
   // Same snapshot as the known tab, for the same reason: this list had missed
   // `providerType` and the client options.
-  const draft = JSON.stringify({
+  const { isDirty } = useDirtySnapshot({
     name,
     providerType,
     apiBase,
     apiKey,
     clientArgsText,
   })
-  const seededDraft = useRef(draft)
   const canSubmit =
     name.trim() !== "" &&
     !nameHasDelimiter &&
@@ -415,7 +414,7 @@ function CustomProviderForm({
       onSubmit={submit}
       isPending={create.isPending}
       isSubmitDisabled={!canSubmit}
-      isDirty={draft !== seededDraft.current}
+      isDirty={isDirty}
       error={create.error}
       footerStart={
         <ConnectionTestButton

--- a/web/src/features/routing/PolicyForm.tsx
+++ b/web/src/features/routing/PolicyForm.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Link } from "@tanstack/react-router"
-import { type RefObject, useMemo, useRef, useState } from "react"
+import { type RefObject, useMemo, useState } from "react"
 
 import type { PolicyGuardrail, PolicySpec, User } from "@/client"
 import { Button } from "@/design-system/actions/Button"
@@ -17,6 +17,7 @@ import { FormDialog } from "@/design-system/feedback/FormDialog"
 import { Field } from "@/design-system/forms/Field"
 import { FieldAction } from "@/design-system/forms/FieldAction"
 import { ControlField } from "@/design-system/forms/FieldMessages"
+import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Tab, TabRow } from "@/design-system/navigation/TabRow"
 import { ModelComboBox } from "@/features/models/ModelComboBox"
 import { useMemberAttributionLabels } from "@/features/organization/attribution"
@@ -528,7 +529,7 @@ export function PolicyForm({
   // Everything the operator can change, against what it was seeded with. A guard
   // that watched only the name would be worse than none on a form this long,
   // where a stray Escape can land ten minutes into building a fallback chain.
-  const draft = JSON.stringify({
+  const { isDirty } = useDirtySnapshot({
     name,
     userIds,
     target,
@@ -540,8 +541,6 @@ export function PolicyForm({
     backend,
     weights,
   })
-  const seeded = useRef(draft)
-  const isDirty = draft !== seeded.current
 
   // An alias has exactly one target, so growing one a chain, a condition, or a
   // guardrail makes it a policy. Saving it as a policy alone would leave the alias


### PR DESCRIPTION
## Description

Seven create and edit forms each carried their own copy of the same four lines:
stringify the whole draft, keep the first one in a ref, compare the two. That is
the shape `feedback.md` prescribes and `useDirtySnapshot` already implements, and
each of the seven predates the hook by a few hours. This converts them: the
domain claim form, both organization member forms, the organization provider-key
form, both add-provider tabs, and the routing policy form.

Nothing an operator can see changes. What changes is that the rule lives in one
place, so the next form to grow a field cannot forget to tell its guard.

The hook gained two things the second caller needed:

- `reset` keeps one identity across renders, so an effect may depend on it. One
  that changed every render would re-seed on every render and no form would ever
  read dirty.
- `reset(next)` seeds an explicit draft. A form whose own default arrives after
  mount (the member forms seed a workspace from the roster) has to say "this is
  the seed" in the render that applies it. Doing it from an effect does not work
  and the PR proves why: a ref written after the commit re-seeds nothing already
  rendered, so the form arrived armed and Escape asked before closing something
  nobody had touched. The reopened-clean test caught it.

## How to test it locally

`pnpm --dir web test` covers it, and the point of this PR is that the existing
guards are the proof rather than new tests.

The check I ran, and the one to repeat if you want to see the refactor held:
make the hook report `isDirty: false` and run the suite. **22 cases fail** across
the seven forms and the hook's own file, among them

- providers: "guards an Advanced rename on the known tab", "guards client options typed on the custom tab"
- members: "guards a role change on the add form", "guards an unticked workspace on the invite form, and reopens clean"
- domains: "guards a changed role on the way out, with nothing typed"
- organization provider keys: "opens on a blank draft after a create", "does not carry a refused create's banner into the next open"
- routing: "guards a half-built policy against a stray Escape"
- budgets, keys, workspaces: the converted callers already on `main`, which this PR does not touch

One flake to disclose rather than have you find: `App.test.tsx`'s "shows a
loading state while the current route loads" failed once in a full run here and
passed on its own and on a second full run (5654 passing both times). It touches
none of these files.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Follow-up to the form-dialog series (#1031), deliberately not linked to it:
that issue tracks pages moving into `FormDialog`, and this is the shape of the
guard they all ended up needing.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      Three cases on the hook for what it grew (stable `reset`, `reset()` to the
      latest draft, `reset(next)` to an explicit one). The conversions are covered
      by the guards listed above, which is the point.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `pnpm --dir web test`.
- [x] Documentation was updated where necessary.
      `feedback.md` already names the hook as the shape; nothing to change.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      No API change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.
