### PR TITLE
fix(dashboard): re-seed guardrail parameters when the profile changes

### DIFF
--- a/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.test.tsx
@@ -2,7 +2,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import type { GuardrailCatalog, OrganizationGuardrail } from "@/client"
+import type {
+  GuardrailCatalog,
+  GuardrailParameterSpec,
+  OrganizationGuardrail,
+} from "@/client"
 import { OrganizationGuardrailsCard } from "@/features/tools/OrganizationGuardrailsCard"
 import { API_ROOT } from "@/shared/api/client"
 import { organizationContext, organizationGuardrail } from "@/tests/fixtures"
@@ -54,6 +58,40 @@ const CATALOG: GuardrailCatalog = {
       model_id: "leolee99/InjecGuard",
       parameters_known: true,
       parameters: [],
+    },
+  ],
+}
+
+// Two profiles of one guardrail class differing only in the model they pin,
+// which is how an operator's guardrails configuration is ordinarily written.
+// They declare the same parameters, so nothing but the name separates them.
+const TWIN_PARAMETERS: GuardrailParameterSpec[] = [
+  {
+    name: "policy",
+    type: "string",
+    required: true,
+    secret: false,
+    description: "Natural-language policy to validate against.",
+  },
+]
+
+const TWIN_CATALOG: GuardrailCatalog = {
+  available: true,
+  reason: null,
+  profiles: [
+    {
+      profile: "house-policy-fast",
+      guardrail: "any_llm",
+      model_id: "openai/gpt-4o-mini",
+      parameters_known: true,
+      parameters: TWIN_PARAMETERS,
+    },
+    {
+      profile: "house-policy-strict",
+      guardrail: "any_llm",
+      model_id: "openai/gpt-4o",
+      parameters_known: true,
+      parameters: TWIN_PARAMETERS,
     },
   ],
 }
@@ -659,6 +697,53 @@ describe("OrganizationGuardrailsCard", () => {
     expect(calls.find((call) => call.method === "POST")?.body).toMatchObject({
       profile: "pii",
     })
+  })
+
+  it("clears a typed parameter when the picker moves to a profile with the same schema", async () => {
+    // otari-ai#2119. The two profiles declare identical parameters, so a form
+    // that re-seeds on the schema alone keeps what was typed for the first and
+    // sends it under the second one's name.
+    mockApi({ catalog: TWIN_CATALOG })
+    renderCard()
+    const user = userEvent.setup()
+
+    await settledPicker()
+    await pickOption(user, "Guardrail profile", "house-policy-fast")
+    await user.type(await screen.findByLabelText("Policy"), "No personal data.")
+    await pickOption(user, "Guardrail profile", "house-policy-strict")
+
+    await waitFor(() => expect(screen.getByLabelText("Policy")).toHaveValue(""))
+  })
+
+  it("keeps what is filled in while a profile the catalog does not describe is typed", async () => {
+    // The other half of otari-ai#2119: a name typed by hand reaches the form one
+    // character at a time, and none of those characters spell a profile the
+    // catalog describes, so they have to share one identity or the form resets
+    // on every keystroke.
+    mockApi()
+    renderCard()
+    const user = userEvent.setup()
+
+    await openDialog()
+    await user.click(
+      await screen.findByRole("button", { name: "Name a profile by hand" }),
+    )
+    // The raw editor is the only place a parameter can go for a profile with no
+    // schema behind it.
+    await user.click(
+      inDialog().getByRole("button", {
+        name: /Other parameters for the new guardrail/,
+      }),
+    )
+    await user.type(
+      screen.getByLabelText("Parameters (JSON)"),
+      '{{"threshold": 0.8}',
+    )
+    await user.type(screen.getByLabelText("Guardrail profile"), "pii")
+
+    expect(screen.getByLabelText("Parameters (JSON)")).toHaveValue(
+      '{"threshold": 0.8}',
+    )
   })
 
   it("asks for no catalog from a member who cannot manage the organization", async () => {

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -31,6 +31,7 @@ import {
   parameterErrors,
   parameterSpecs,
   parseExtraJson,
+  profileIdentity,
   type SeededParameters,
   seedParameters,
 } from "@/features/tools/guardrailParameters"
@@ -177,6 +178,8 @@ function WorkspaceScope({
 function useParameterForm(
   specs: GuardrailParameterSpec[],
   stored: Record<string, unknown> | null | undefined,
+  /** From `profileIdentity`, which says what counts as a different profile. */
+  identity: string,
 ) {
   const [state, setState] = useState<SeededParameters>(() =>
     seedParameters(specs, stored),
@@ -184,13 +187,19 @@ function useParameterForm(
   const [issues, setIssues] = useState<ParameterErrors>({})
   const [rawError, setRawError] = useState<string | undefined>(undefined)
 
-  // Both dependencies are serialized, for the reason the workspace scope below
-  // is: each is a fresh object on every fetch and on every catalog read, so
-  // depending on them by reference would wipe a half-typed parameter whenever
-  // any row on the card saved. Parsed back inside the effect so nothing it
-  // touches is missing from the dependency list.
+  // Two of the three dependencies are serialized, for the reason the workspace
+  // scope below is: each is a fresh object on every fetch and on every catalog
+  // read, so depending on them by reference would wipe a half-typed parameter
+  // whenever any row on the card saved. Parsed back inside the effect so
+  // nothing it touches is missing from the dependency list.
+  //
+  // The identity is the third, because the two above cannot separate two
+  // profiles that declare the same parameters, which is the ordinary shape of a
+  // pair differing only in the model it pins. Nothing inside the effect reads
+  // it.
   const specsJson = JSON.stringify(specs)
   const storedJson = JSON.stringify(stored ?? {})
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identity is a re-seed trigger, not an input
   useEffect(() => {
     setState(
       seedParameters(
@@ -200,7 +209,7 @@ function useParameterForm(
     )
     setIssues({})
     setRawError(undefined)
-  }, [specsJson, storedJson])
+  }, [identity, specsJson, storedJson])
 
   return {
     values: state.values,
@@ -260,7 +269,11 @@ function GuardrailRow({
   const [isDeleteOpen, setDeleteOpen] = useState(false)
   const specs = parameterSpecs(catalog, guardrail.profile)
   const describedProfile = findProfile(catalog, guardrail.profile) !== undefined
-  const parameters = useParameterForm(specs, guardrail.validate_kwargs)
+  const parameters = useParameterForm(
+    specs,
+    guardrail.validate_kwargs,
+    profileIdentity(catalog, guardrail.profile),
+  )
 
   // Rehydrate from whatever the server last said, so the row never drifts from
   // the stored entry after a save.
@@ -511,9 +524,14 @@ function AddGuardrailDialog({
   // account: there is no profile yet for a raw parameter to belong to.
   const describedProfile =
     profile === "" || findProfile(catalog, profile) !== undefined
-  // Nothing stored yet, so the fields start blank and re-seed when the picker
-  // moves to a profile with a different schema.
-  const parameters = useParameterForm(specs, undefined)
+  // Nothing stored yet, so the fields start blank and re-seed whenever the
+  // picker moves to another profile the catalog describes, whether or not that
+  // profile's schema differs from the one left behind.
+  const parameters = useParameterForm(
+    specs,
+    undefined,
+    profileIdentity(catalog, profile),
+  )
 
   // Everything the operator can change, in one snapshot: a field added to this
   // form would otherwise have to be remembered in a second place, and the

--- a/web/src/features/tools/guardrailParameters.test.ts
+++ b/web/src/features/tools/guardrailParameters.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest"
 
-import type { GuardrailParameterSpec } from "@/client"
+import type { GuardrailCatalog, GuardrailParameterSpec } from "@/client"
 import {
   buildValidateKwargs,
   parameterErrors,
   parameterLabel,
   parseExtraJson,
+  profileIdentity,
   seedParameters,
 } from "@/features/tools/guardrailParameters"
 
@@ -184,6 +185,53 @@ describe("buildValidateKwargs", () => {
 
   it("reports an entry that configures nothing as null, not an empty object", () => {
     expect(buildValidateKwargs([], {}, "")).toBeNull()
+  })
+})
+
+describe("profileIdentity", () => {
+  // A pair differing only in the model they pin, which is how an operator's
+  // guardrails configuration is ordinarily written.
+  const catalog: GuardrailCatalog = {
+    available: true,
+    reason: null,
+    profiles: [
+      {
+        profile: "house-policy-fast",
+        guardrail: "any_llm",
+        model_id: "openai/gpt-4o-mini",
+        parameters_known: true,
+        parameters: [spec({ name: "policy", type: "string", required: true })],
+      },
+      {
+        profile: "house-policy-strict",
+        guardrail: "any_llm",
+        model_id: "openai/gpt-4o",
+        parameters_known: true,
+        parameters: [spec({ name: "policy", type: "string", required: true })],
+      },
+    ],
+  }
+
+  it("separates two profiles the catalog describes identically", () => {
+    expect(profileIdentity(catalog, "house-policy-fast")).not.toBe(
+      profileIdentity(catalog, "house-policy-strict"),
+    )
+  })
+
+  it("gives every name the catalog does not describe the same identity", () => {
+    // Including the prefixes of one being typed, which is what keeps the form
+    // from resetting under the operator.
+    expect(profileIdentity(catalog, "p")).toBe(profileIdentity(catalog, "pii"))
+    expect(profileIdentity(catalog, "")).toBe(profileIdentity(catalog, "pii"))
+    expect(profileIdentity(undefined, "house-policy-fast")).toBe(
+      profileIdentity(catalog, "pii"),
+    )
+  })
+
+  it("never gives a described profile an undescribed one's identity", () => {
+    expect(profileIdentity(catalog, "house-policy-fast")).not.toBe(
+      profileIdentity(catalog, "pii"),
+    )
   })
 })
 

--- a/web/src/features/tools/guardrailParameters.ts
+++ b/web/src/features/tools/guardrailParameters.ts
@@ -46,6 +46,29 @@ export function parameterSpecs(
   return findProfile(catalog, profile)?.parameters ?? []
 }
 
+/** Stands in for every profile name the catalog does not describe. */
+const UNDESCRIBED_PROFILE = "\u0000undescribed"
+
+/**
+ * What a parameter form re-seeds on, beside the schema and the stored values.
+ *
+ * Two profiles of one guardrail class differing only in the model they pin
+ * declare the same parameters, so a schema cannot tell them apart and a form
+ * keyed on it alone carries one profile's values onto the other. A name can.
+ *
+ * Every name the catalog does not describe shares one identity, because such a
+ * name is typed a character at a time: keying on it would reset the form on
+ * every keystroke, and there is no schema behind it to re-seed from anyway.
+ */
+export function profileIdentity(
+  catalog: GuardrailCatalog | undefined,
+  profile: string,
+): string {
+  return findProfile(catalog, profile) === undefined
+    ? UNDESCRIBED_PROFILE
+    : profile
+}
+
 function isBlank(value: ParameterValue | undefined): boolean {
   return (
     value === undefined || (typeof value === "string" && value.trim() === "")


### PR DESCRIPTION
## Description

An organization can mandate a guardrail, and the form for adding one offers the parameters that
guardrail accepts. Those fields kept their contents when the profile picker moved from one profile
to another that accepts exactly the same parameters, which happens whenever an operator's guardrails
service lists two profiles of the same guardrail class differing only in the model they pin. The
form then submitted the first profile's values under the second profile's name, so the mandated
guardrail ran with settings nobody chose for it.

The fields now clear when the picker moves to a different profile, whether or not the two profiles
accept the same parameters. Naming a profile by hand is unaffected: a name the guardrails service
never listed leaves the form alone while it is being typed, so nothing is lost between keystrokes.
Nothing else about mandating or editing a guardrail changes.

## How to test it locally

1. Point the deployment at a guardrails service whose configuration lists two profiles of the same
   guardrail class, for example `house-policy-fast` and `house-policy-strict`, both built from
   `any_llm` and differing only in the model.
2. Open Tools, Guardrails, then the organization guardrails card, and press "Mandate a guardrail".
3. Pick the first profile and type something into one of its parameter fields.
4. Move the picker to the second profile. The parameter fields are blank, and submitting now sends
   only what was entered for the profile actually chosen.
5. Press "Name a profile by hand", fill the raw parameters editor, then type a profile name. What is
   in the editor stays there through every keystroke.

Automated coverage: `pnpm --dir web test` runs two new cases in
`OrganizationGuardrailsCard.test.tsx`, one for the switch clearing the field and one for the by-hand
name not resetting the form, plus unit tests for the new identity helper. Both component tests were
confirmed to fail against the unfixed code, so neither is vacuous.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2119

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the two unchecked boxes: this is dashboard behavior with no documented surface of its own,
and no route, schema or docstring changed, so no OpenAPI regeneration is owed. The dashboard checks
that do apply were run: `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and
`pnpm --dir web test` (5657 tests) are green, and `make lint` (architecture check plus Ruff) passes.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

The agent read the issue, verified the described behavior against current source, wrote the fix and
the tests, and ran the dashboard and repository checks. Each new component test was checked against
the unfixed code to confirm it goes red.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Clear guardrail parameter fields when switching between catalog-listed profiles, even when their parameter schemas match.
- Preserve parameter values while users manually enter a profile name.
- Add profile identity handling and tests for profile switching and manual profile entry.
- Dashboard lint, typecheck, and tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->