### PR TITLE
security(guardrails): mask secret organization guardrail parameters

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -79,7 +79,7 @@ organization owner or admin), and each one carries:
 | `mode`, `on_unavailable` | The same two settings a request-body entry has, with the same meanings. |
 | `url` | An endpoint of the organization's own. Omit it to use the deployment's `guardrails_url`. |
 | `credential` | Sent to that endpoint as `Authorization: Bearer`. Requires `url`, which must then be `https`, so the credential is never sent to the deployment URL, which may be a plain-http sidecar. Encrypted at rest, never returned. |
-| `validate_kwargs` | Forwarded to the guardrails service `/validate` call. |
+| `validate_kwargs` | Forwarded to the guardrails service `/validate` call. A parameter whose name looks credential-shaped (it contains `key`, `secret`, `token`, `password`, `authorization` or `credential`) is read back as `***` rather than its stored value. Sending `***` back keeps what is stored, so editing the rest of an entry does not overwrite the parameter you were never shown. |
 | `enabled` | `false` stops the guardrail everywhere without discarding the entry. |
 | `applies_to_all_workspaces` | `true` runs it in every workspace, including any created later. |
 | `workspace_ids` | The workspaces it runs in, when it does not apply to all of them. |

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -7426,7 +7426,7 @@
         "type": "object"
       },
       "OrganizationGuardrailPublic": {
-        "description": "The API-facing shape. Never carries the credential, only whether one is set.",
+        "description": "The API-facing shape. Never carries the credential, nor a credential-shaped parameter.\n\n``validate_kwargs`` is the second place a credential lives on this row, and\nthe one with no column of its own: a guardrail class can take a vendor key\nas a parameter, so the form offers a box for it and whatever is typed there\nis stored as plain JSON. It is masked the way\n``org_provider_keys.client_args`` is, by the *name* of the entry rather than\nby what the guardrail catalog says about it, so the mask still applies when\nthe guardrails service is down and no catalog can be read.",
         "properties": {
           "applies_to_all_workspaces": {
             "title": "Applies To All Workspaces",
@@ -7491,6 +7491,7 @@
                 "type": "null"
               }
             ],
+            "description": "Extra kwargs forwarded to the guardrails service /validate call. A parameter whose name looks credential-shaped comes back as *** rather than its stored value; sending that *** back keeps what is stored",
             "title": "Validate Kwargs"
           },
           "workspace_ids": {
@@ -7592,6 +7593,7 @@
                 "type": "null"
               }
             ],
+            "description": "Replaces the stored kwargs whole. A parameter sent as *** keeps the value stored under that name, which is how a credential-shaped one survives an edit of the rest of the entry",
             "title": "Validate Kwargs"
           },
           "workspace_ids": {

--- a/src/gateway/models/secret_fields.py
+++ b/src/gateway/models/secret_fields.py
@@ -1,14 +1,21 @@
 """Masking credential-shaped entries in a free-form settings dict.
 
-Three tables carry arbitrary operator-supplied JSON that a provider SDK is
+Four tables carry arbitrary operator-supplied JSON that something downstream is
 handed as keyword arguments: ``org_provider_keys.client_args``,
-``provider_credentials.client_args``, and ``search_tool_credentials.options``.
-All three are places a real credential legitimately lives (standalone Bedrock
-needs ``aws_secret_access_key`` in ``client_args``; ``services/
-bedrock_gateway_auth.py`` explains why), and none of them may echo one back
-over the API. A leaf module rather than a helper on one of the three models, so
-the second and third serializers share the first's rules instead of carrying a
-copy that drifts.
+``provider_credentials.client_args`` and ``search_tool_credentials.options``,
+which reach a provider SDK, and ``organization_guardrails.validate_kwargs``,
+which reaches the guardrails service. All four are places a real credential
+legitimately lives (standalone Bedrock needs ``aws_secret_access_key`` in
+``client_args``, ``services/bedrock_gateway_auth.py`` explains why; a guardrail
+class can take its vendor key as a parameter), and none of them may echo one
+back over the API. A leaf module rather than a helper on one of the models, so
+the later serializers share the first's rules instead of carrying a copy that
+drifts.
+
+Masking keys off the entry's *name*, which is what lets it hold for a guardrail
+parameter whose catalog entry cannot be read at all: the guardrails service is
+what says which parameters are secret, and the mask has to apply while it is
+down.
 """
 
 from typing import Any

--- a/src/gateway/services/tenancy/organization_guardrail_service.py
+++ b/src/gateway/services/tenancy/organization_guardrail_service.py
@@ -61,6 +61,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.models.entities import OrganizationGuardrail, OrganizationGuardrailWorkspace
 from gateway.models.guardrails import GuardrailConfig
+from gateway.models.secret_fields import redact_secret_like_values, restore_redacted_values
 from gateway.models.tenancy import User
 from gateway.repositories.tenancy import WorkspaceRepository
 from gateway.services.secret_box import (
@@ -243,7 +244,14 @@ class OrganizationGuardrailUpdate(BaseModel):
     credential: str | None = Field(default=None, max_length=8192)
     mode: Literal["block", "monitor"] | SkipJsonSchema[None] = None
     on_unavailable: Literal["block", "monitor"] | SkipJsonSchema[None] = None
-    validate_kwargs: dict[str, Any] | None = None
+    validate_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Replaces the stored kwargs whole. A parameter sent as *** keeps the value stored "
+            "under that name, which is how a credential-shaped one survives an edit of the rest "
+            "of the entry"
+        ),
+    )
     enabled: bool | SkipJsonSchema[None] = None
     applies_to_all_workspaces: bool | SkipJsonSchema[None] = None
     workspace_ids: list[uuid.UUID] | None = Field(default=None, max_length=MAX_SCOPED_WORKSPACES)
@@ -268,7 +276,16 @@ class OrganizationGuardrailUpdate(BaseModel):
 
 
 class OrganizationGuardrailPublic(BaseModel):
-    """The API-facing shape. Never carries the credential, only whether one is set."""
+    """The API-facing shape. Never carries the credential, nor a credential-shaped parameter.
+
+    ``validate_kwargs`` is the second place a credential lives on this row, and
+    the one with no column of its own: a guardrail class can take a vendor key
+    as a parameter, so the form offers a box for it and whatever is typed there
+    is stored as plain JSON. It is masked the way
+    ``org_provider_keys.client_args`` is, by the *name* of the entry rather than
+    by what the guardrail catalog says about it, so the mask still applies when
+    the guardrails service is down and no catalog can be read.
+    """
 
     id: uuid.UUID
     organization_id: uuid.UUID
@@ -277,7 +294,13 @@ class OrganizationGuardrailPublic(BaseModel):
     has_credential: bool
     mode: str
     on_unavailable: str
-    validate_kwargs: dict[str, Any] | None
+    validate_kwargs: dict[str, Any] | None = Field(
+        description=(
+            "Extra kwargs forwarded to the guardrails service /validate call. A parameter whose "
+            "name looks credential-shaped comes back as *** rather than its stored value; sending "
+            "that *** back keeps what is stored"
+        ),
+    )
     enabled: bool
     applies_to_all_workspaces: bool
     # Empty for an entry that applies to every workspace, where the scope rows
@@ -299,7 +322,7 @@ class OrganizationGuardrailPublic(BaseModel):
             has_credential=guardrail.encrypted_credential is not None,
             mode=guardrail.mode,
             on_unavailable=guardrail.on_unavailable,
-            validate_kwargs=guardrail.validate_kwargs,
+            validate_kwargs=redact_secret_like_values(guardrail.validate_kwargs),
             enabled=guardrail.enabled,
             applies_to_all_workspaces=guardrail.applies_to_all_workspaces,
             workspace_ids=[] if guardrail.applies_to_all_workspaces else workspace_ids,
@@ -609,7 +632,11 @@ class OrganizationGuardrailService:
             encrypted_credential=_encrypted(credential) if credential else None,
             mode=request.mode,
             on_unavailable=request.on_unavailable,
-            validate_kwargs=request.validate_kwargs or None,
+            # Nothing stored to restore from, so this keeps whatever was sent:
+            # a ``***`` on a create is a literal the caller typed. Written as
+            # the restore anyway, so the column's rule is visible at both writes
+            # rather than only at the one where it has an effect.
+            validate_kwargs=restore_redacted_values(request.validate_kwargs, None) or None,
             enabled=request.enabled,
             applies_to_all_workspaces=request.applies_to_all_workspaces,
         )
@@ -683,7 +710,11 @@ class OrganizationGuardrailService:
         if request.on_unavailable is not None:
             guardrail.on_unavailable = request.on_unavailable
         if "validate_kwargs" in fields:
-            guardrail.validate_kwargs = request.validate_kwargs or None
+            # ``from_model`` masks a credential-shaped entry, so an editor
+            # resubmitting the whole set sends ``***`` for the ones it was never
+            # shown; those keep their stored value.
+            restored = restore_redacted_values(request.validate_kwargs, guardrail.validate_kwargs)
+            guardrail.validate_kwargs = restored or None
         if request.enabled is not None:
             guardrail.enabled = request.enabled
         if request.applies_to_all_workspaces is not None:

--- a/tests/integration/test_organization_guardrail_enforcement.py
+++ b/tests/integration/test_organization_guardrail_enforcement.py
@@ -405,3 +405,63 @@ def test_an_entry_without_an_endpoint_uses_the_deployments_own(
     assert response.status_code == 200
     assert guardrails.calls[0]["host"] == "anyguardrails"
     assert guardrails.calls[0]["authorization"] is None
+
+
+def test_a_secret_parameter_is_masked_on_read_and_survives_an_edit_of_the_rest(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A guardrail vendor key typed into the parameter form never comes back out (otari-ai#2118)."""
+    entry = _mandate(
+        client,
+        master_key_header,
+        profile="patronus",
+        mode="monitor",
+        validate_kwargs={"threshold": 0.8, "patronus_api_key": "pat-live-key"},
+        applies_to_all_workspaces=True,
+    )
+    assert entry["validate_kwargs"] == {"threshold": 0.8, "patronus_api_key": "***"}
+
+    listed = client.get(f"{API_ROOT}/organizations/me/guardrails", headers=master_key_header)
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["data"][0]["validate_kwargs"] == {"threshold": 0.8, "patronus_api_key": "***"}
+
+    # What the dashboard sends when someone changes the threshold: the whole
+    # dict, with the mask where the credential it was never shown belongs.
+    edited = client.patch(
+        f"{API_ROOT}/organizations/me/guardrails/{entry['id']}",
+        json={"validate_kwargs": {"threshold": 0.5, "patronus_api_key": "***"}},
+        headers=master_key_header,
+    )
+    assert edited.status_code == 200, edited.text
+    assert edited.json()["validate_kwargs"] == {"threshold": 0.5, "patronus_api_key": "***"}
+
+
+def test_the_check_is_sent_the_stored_secret_parameter_and_not_the_mask(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Masking is a serialization rule, so the request path still reads the row."""
+    monkeypatch.setenv("OTARI_GUARDRAILS_URL", _DEPLOYMENT_URL)
+    entry = _mandate(
+        client,
+        master_key_header,
+        profile="patronus",
+        mode="monitor",
+        validate_kwargs={"threshold": 0.8, "patronus_api_key": "pat-live-key"},
+        applies_to_all_workspaces=True,
+    )
+    edited = client.patch(
+        f"{API_ROOT}/organizations/me/guardrails/{entry['id']}",
+        json={"validate_kwargs": {"threshold": 0.5, "patronus_api_key": "***"}},
+        headers=master_key_header,
+    )
+    assert edited.status_code == 200, edited.text
+    guardrails = _Guardrails(valid=True)
+
+    response = _post(client, api_key_header, _REQUEST, guardrails, monkeypatch)
+
+    assert response.status_code == 200
+    assert guardrails.calls[0]["validate_kwargs"] == {"threshold": 0.5, "patronus_api_key": "pat-live-key"}

--- a/tests/unit/test_secret_fields.py
+++ b/tests/unit/test_secret_fields.py
@@ -1,26 +1,31 @@
 """Credential-shaped entries in a free-form settings dict never round-trip.
 
-Three tables hand a provider SDK arbitrary operator-supplied JSON, and all three
-are places a real credential legitimately lives: standalone Bedrock keeps its
-``aws_secret_access_key`` in ``client_args``, because any-llm's BedrockProvider
-never forwards ``api_key`` into the boto3 client it builds. ``OrgProviderKey``
-has masked its own since it shipped; otari-ai#1880 is the other two, where
-``ProviderCredential.client_args`` returned a live AWS secret to anyone who
-could reach ``GET /api/v1/provider-credentials``.
+Four tables hold arbitrary operator-supplied JSON, and all four are places a
+real credential legitimately lives. Three of them hand it to a provider SDK:
+standalone Bedrock keeps its ``aws_secret_access_key`` in ``client_args``,
+because any-llm's BedrockProvider never forwards ``api_key`` into the boto3
+client it builds. ``OrgProviderKey`` has masked its own since it shipped;
+otari-ai#1880 is the other two, where ``ProviderCredential.client_args``
+returned a live AWS secret to anyone who could reach
+``GET /api/v1/provider-credentials``. The fourth is
+``organization_guardrails.validate_kwargs``, which a guardrail class can take
+its vendor key in (otari-ai#2118).
 
 Masking on read creates the other half of the problem, so it is asserted here
 too: an editor that loads a row and saves it back would otherwise store the mask
 over the credential it was never shown.
 """
 
+import uuid
 from datetime import UTC, datetime
 
-from gateway.models.entities import ProviderCredential, SearchToolCredential
+from gateway.models.entities import OrganizationGuardrail, ProviderCredential, SearchToolCredential
 from gateway.models.secret_fields import (
     REDACTED_VALUE,
     redact_secret_like_values,
     restore_redacted_values,
 )
+from gateway.services.tenancy.organization_guardrail_service import OrganizationGuardrailPublic
 
 
 class TestRedactSecretLikeValues:
@@ -111,3 +116,39 @@ class TestSerializers:
         # not turn "no options" into null.
         row = ProviderCredential(instance="openai", client_args={}, created_at=datetime.now(UTC))
         assert row.to_public_dict()["client_args"] == {}
+
+    def test_organization_guardrail_masks_its_validate_kwargs(self) -> None:
+        row = OrganizationGuardrail(
+            id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+            profile="patronus",
+            mode="block",
+            on_unavailable="block",
+            validate_kwargs={"threshold": 0.8, "patronus_api_key": "live-key"},
+            enabled=True,
+            applies_to_all_workspaces=True,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        public = OrganizationGuardrailPublic.from_model(row, workspace_ids=[])
+
+        assert public.validate_kwargs == {"threshold": 0.8, "patronus_api_key": REDACTED_VALUE}
+
+    def test_organization_guardrail_with_no_validate_kwargs_stays_null(self) -> None:
+        # The column is nullable here, unlike the two above, and null is what the
+        # API stores for "no kwargs": masking must not turn it into an object.
+        row = OrganizationGuardrail(
+            id=uuid.uuid4(),
+            organization_id=uuid.uuid4(),
+            profile="prompt-injection",
+            mode="monitor",
+            on_unavailable="block",
+            validate_kwargs=None,
+            enabled=True,
+            applies_to_all_workspaces=True,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        assert OrganizationGuardrailPublic.from_model(row, workspace_ids=[]).validate_kwargs is None

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -7956,7 +7956,15 @@ export interface components {
         };
         /**
          * OrganizationGuardrailPublic
-         * @description The API-facing shape. Never carries the credential, only whether one is set.
+         * @description The API-facing shape. Never carries the credential, nor a credential-shaped parameter.
+         *
+         *     ``validate_kwargs`` is the second place a credential lives on this row, and
+         *     the one with no column of its own: a guardrail class can take a vendor key
+         *     as a parameter, so the form offers a box for it and whatever is typed there
+         *     is stored as plain JSON. It is masked the way
+         *     ``org_provider_keys.client_args`` is, by the *name* of the entry rather than
+         *     by what the guardrail catalog says about it, so the mask still applies when
+         *     the guardrails service is down and no catalog can be read.
          */
         OrganizationGuardrailPublic: {
             /** Applies To All Workspaces */
@@ -7987,7 +7995,10 @@ export interface components {
             updated_at: string;
             /** Url */
             url: string | null;
-            /** Validate Kwargs */
+            /**
+             * Validate Kwargs
+             * @description Extra kwargs forwarded to the guardrails service /validate call. A parameter whose name looks credential-shaped comes back as *** rather than its stored value; sending that *** back keeps what is stored
+             */
             validate_kwargs: {
                 [key: string]: unknown;
             } | null;
@@ -8034,7 +8045,10 @@ export interface components {
             profile?: string;
             /** Url */
             url?: string | null;
-            /** Validate Kwargs */
+            /**
+             * Validate Kwargs
+             * @description Replaces the stored kwargs whole. A parameter sent as *** keeps the value stored under that name, which is how a credential-shaped one survives an edit of the rest of the entry
+             */
             validate_kwargs?: {
                 [key: string]: unknown;
             } | null;

--- a/web/src/features/providers/providerCredentialFields.ts
+++ b/web/src/features/providers/providerCredentialFields.ts
@@ -30,6 +30,8 @@
 // request time. `services/bedrock_gateway_auth.py` builds the same names on the
 // hybrid path, out of the platform's `extra_params` rather than out of these.
 
+import { REDACTED_SECRET } from "@/shared/helpers/redaction"
+
 /** One `client_args` entry a provider expects, and how to ask for it. */
 export interface ProviderCredentialFieldSpec {
   /** Literal SDK keyword argument, and the `client_args` key it is stored under. */
@@ -67,11 +69,9 @@ export interface ProviderCredentialSpec {
   apiKeyHelpText?: string
 }
 
-// The value the gateway substitutes for a credential-shaped `client_args`
-// entry when it serializes a key, and the value that means "keep what is
-// stored" when it is sent back. Kept in step with `REDACTED_VALUE` in
-// `src/gateway/models/secret_fields.py`.
-export const REDACTED_CLIENT_ARG = "***"
+// The mask a credential-shaped `client_args` entry comes back as, under the
+// name this feature's call sites already use.
+export const REDACTED_CLIENT_ARG = REDACTED_SECRET
 
 const AWS_REGION_PATTERN = /^[a-z0-9-]+$/
 

--- a/web/src/features/tools/guardrailParameters.test.ts
+++ b/web/src/features/tools/guardrailParameters.test.ts
@@ -9,6 +9,7 @@ import {
   profileIdentity,
   seedParameters,
 } from "@/features/tools/guardrailParameters"
+import { REDACTED_SECRET } from "@/shared/helpers/redaction"
 
 function spec(
   overrides: Partial<GuardrailParameterSpec> &
@@ -251,5 +252,65 @@ describe("parameterLabel", () => {
   it("reads a snake_case parameter name as a sentence", () => {
     expect(parameterLabel("comparison_text")).toBe("Comparison text")
     expect(parameterLabel("policy")).toBe("Policy")
+  })
+})
+
+describe("a stored secret parameter", () => {
+  // The gateway masks a credential-shaped parameter on read and restores the
+  // stored value wherever the mask comes back, so the form's only job is to
+  // carry it out and back unchanged. `validate_kwargs` is sent whole on every
+  // save, so dropping it or coercing it would delete the credential.
+  const secretString = spec({ name: "patronus_api_key", type: "string" })
+
+  it("seeds the mask into the field rather than an empty box", () => {
+    const seeded = seedParameters([secretString], {
+      patronus_api_key: REDACTED_SECRET,
+    })
+
+    expect(seeded.values.patronus_api_key).toBe(REDACTED_SECRET)
+  })
+
+  it("sends the mask back untouched when nobody edited it", () => {
+    expect(
+      buildValidateKwargs(
+        [secretString, spec({ name: "threshold", type: "number" })],
+        { patronus_api_key: REDACTED_SECRET, threshold: "0.5" },
+        "",
+      ),
+    ).toEqual({ patronus_api_key: REDACTED_SECRET, threshold: 0.5 })
+  })
+
+  it("sends a replacement the operator typed, not the mask", () => {
+    expect(
+      buildValidateKwargs([secretString], { patronus_api_key: "pat-new" }, ""),
+    ).toEqual({ patronus_api_key: "pat-new" })
+  })
+
+  it("does not type-check the mask, whatever the schema says the value is", () => {
+    const typed = [
+      spec({ name: "api_key_id", type: "integer" }),
+      spec({ name: "auth_token", type: "json" }),
+      spec({ name: "credential_tier", type: "enum", choices: ["a", "b"] }),
+    ]
+    const values = {
+      api_key_id: REDACTED_SECRET,
+      auth_token: REDACTED_SECRET,
+      credential_tier: REDACTED_SECRET,
+    }
+
+    expect(parameterErrors(typed, values)).toEqual({})
+    // Coercing would send NaN for the integer and undefined for the JSON one.
+    expect(buildValidateKwargs(typed, values, "")).toEqual(values)
+  })
+
+  it("does not read a masked boolean as off and save that over the stored value", () => {
+    const booleanSecret = spec({ name: "use_api_key", type: "boolean" })
+    const seeded = seedParameters([booleanSecret], {
+      use_api_key: REDACTED_SECRET,
+    })
+
+    expect(buildValidateKwargs([booleanSecret], seeded.values, "")).toEqual({
+      use_api_key: REDACTED_SECRET,
+    })
   })
 })

--- a/web/src/features/tools/guardrailParameters.ts
+++ b/web/src/features/tools/guardrailParameters.ts
@@ -2,6 +2,14 @@
  * Turning a guardrail profile's parameter schema into form state, and back into
  * the `validate_kwargs` dict the entry stores.
  *
+ * A stored parameter whose name looks credential-shaped reads back as
+ * `REDACTED_SECRET` rather than its value, and `validate_kwargs` is sent whole
+ * on every save, so the mask has to travel back out untouched: the gateway
+ * restores the stored value wherever it sees one, and an entry that arrived
+ * masked and left blank would delete a credential on a save of something else.
+ * That is why the three places a value is read, checked or coerced below each
+ * let the mask through ahead of anything the schema says about its type.
+ *
  * The schema comes from `GET /v1/tool-settings/guardrails/profiles`, which joins
  * the operator's own profile list to the `any_guardrail` parameter registry. So
  * a field here exists because a guardrail actually takes it, and a profile the
@@ -14,6 +22,7 @@
  */
 
 import type { GuardrailCatalog, GuardrailParameterSpec } from "@/client"
+import { REDACTED_SECRET } from "@/shared/helpers/redaction"
 
 export type ParameterValue = string | boolean
 export type ParameterValues = Record<string, ParameterValue>
@@ -79,6 +88,9 @@ function asFieldValue(
   spec: GuardrailParameterSpec,
   stored: unknown,
 ): ParameterValue {
+  // Ahead of the boolean branch, which would otherwise read a masked value as
+  // `false` and save that over the stored one.
+  if (stored === REDACTED_SECRET) return REDACTED_SECRET
   if (spec.type === "boolean") return stored === true
   if (stored === null || stored === undefined) return ""
   if (typeof stored === "object") return JSON.stringify(stored, null, 2)
@@ -178,6 +190,11 @@ export function parameterErrors(
   for (const spec of specs) {
     const value = values[spec.name]
     if (spec.type === "boolean") continue
+    // The mask stands in for a value nobody here has seen, so there is nothing
+    // to check: a secret parameter the schema types as a number or JSON would
+    // otherwise fail on the literal `***` and refuse a save of the rest of the
+    // entry.
+    if (value === REDACTED_SECRET) continue
     if (isBlank(value)) {
       if (spec.required)
         errors[spec.name] = "This guardrail needs a value here."
@@ -205,6 +222,9 @@ function coerce(
   spec: GuardrailParameterSpec,
   value: ParameterValue | undefined,
 ): unknown {
+  // Sent verbatim so the gateway can put the stored value back; coercing it
+  // would send `NaN` for a numeric secret and `undefined` for a JSON one.
+  if (value === REDACTED_SECRET) return REDACTED_SECRET
   if (spec.type === "boolean") return value === true
   const text = String(value)
   // `Number` for both, which is the parser `parameterErrors` approved the input

--- a/web/src/shared/helpers/redaction.ts
+++ b/web/src/shared/helpers/redaction.ts
@@ -1,0 +1,11 @@
+/**
+ * The value the gateway substitutes for a credential-shaped entry in a
+ * free-form settings dict, and the value that means "keep what is stored" when
+ * it is sent back.
+ *
+ * Kept in step with `REDACTED_VALUE` in `src/gateway/models/secret_fields.py`,
+ * which is the one place that decides it. Shared because more than one feature
+ * edits such a dict: provider `client_args` and an organization guardrail's
+ * `validate_kwargs` round-trip through the same rule.
+ */
+export const REDACTED_SECRET = "***"


### PR DESCRIPTION
## Description

An organization can mandate a guardrail that runs on every request from its workspaces, and each one carries a set of parameters that Otari forwards to the guardrails service. Some of those parameters are a guardrail vendor's own API key, and the dashboard form offers a masked box for them, so an operator is invited to type a credential in. Until now whatever was typed there was stored in clear text and handed straight back on every read of the organization's guardrails, so anyone who could list them could read the key.

Those parameters are now masked on the way out, exactly as a provider key's extra client settings already are: a parameter whose name looks credential-shaped (it contains `key`, `secret`, `token`, `password`, `authorization` or `credential`) comes back as `***` instead of its value. Sending `***` back keeps what is stored, so editing a guardrail's threshold no longer overwrites the credential you were never shown. The masking keys off the parameter's name rather than off the guardrails service's own description of the profile, which means it still holds when that service is down and nothing can say which parameters are secret.

Nothing changes about what the guardrails service receives. The check is still sent the real value, because the request path reads the stored row rather than the shape the API returns.

The exposure is **latent in production**: production runs no guardrails service, so no profile is offered and no secret parameter can be filled in. It is reachable on a self-hosted Otari that runs one, which is the open-source product's normal configuration.

## How to test it locally

1. Bring up a gateway with a guardrails service: `docker compose --profile guardrails up`.
2. Create an organization guardrail with a credential-shaped parameter:

   ```bash
   curl -X POST http://localhost:8000/api/v1/organizations/me/guardrails \
     -H "Authorization: Bearer <master-key>" -H "Content-Type: application/json" \
     -d '{"profile": "prompt-injection", "mode": "monitor",
          "applies_to_all_workspaces": true,
          "validate_kwargs": {"threshold": 0.8, "vendor_api_key": "live-key"}}'
   ```

   The response, and `GET /api/v1/organizations/me/guardrails`, both report `"vendor_api_key": "***"`.
3. Change the threshold the way the dashboard does, sending the whole parameter set with the mask in it:

   ```bash
   curl -X PATCH http://localhost:8000/api/v1/organizations/me/guardrails/<id> \
     -H "Authorization: Bearer <master-key>" -H "Content-Type: application/json" \
     -d '{"validate_kwargs": {"threshold": 0.5, "vendor_api_key": "***"}}'
   ```

   Send a completion afterwards and the guardrails service still receives `live-key`, not `***`.
4. In the dashboard, open Tools and Guardrails, expand an organization guardrail with a secret parameter, change an unrelated field and save. The secret parameter keeps its stored value.

Automated coverage: two route-level integration tests in `tests/integration/test_organization_guardrail_enforcement.py` (one for the mask on read and the mask echoed back through a PATCH, one proving the guardrails service is still sent the stored value), two serializer unit tests in `tests/unit/test_secret_fields.py`, and five dashboard unit tests in `web/src/features/tools/guardrailParameters.test.ts` covering the form's round trip, including a secret parameter the schema types as a number, JSON, an enum or a boolean.

Checks run locally: `make lint`, `make typecheck`, `make test`, the OSS-edition smoke gate, `make openapi-check`, `make postman-check`, and the three dashboard checks.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2118

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The issue offered three treatments and the first was chosen deliberately: mask on read, restore on write. It is the treatment `org_provider_keys.client_args`, `provider_credentials.client_args` and `search_tool_credentials.options` already get, so the rule lives in one place rather than four, and unlike refusing secret parameters or encrypting them it keys off the parameter's name rather than off the guardrail catalog, so it still holds when the guardrails service is unreachable and no catalog can be read.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Mask secret-like `organization_guardrails.validate_kwargs` values as `***` in API responses.
- Preserve stored credentials when updates send the mask.
- Keep real credentials in requests to the guardrails service.
- Update the dashboard to preserve masked values during edits.
- Add documentation and coverage for API, serializer, and dashboard behavior across data types.

## Technical notes

- Reuse shared redaction and restoration helpers.
- Apply masking based on parameter names, even when the guardrails service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->