### PR TITLE
feat(dashboard): give every table row action a glyph instead of a word

### DIFF
--- a/web/design/actions.md
+++ b/web/design/actions.md
@@ -1,7 +1,8 @@
 # Buttons
 
 Use a `Button` for an action. Navigation that looks like a button is a `Link`.
-An action inside a table row is a `RowAction`, not a `Button`.
+An action inside a table row is a `RowAction`, not a `Button`, and it wears a
+glyph rather than its word (see [A row's actions are glyphs](#a-rows-actions-are-glyphs)).
 
 ## Three variants. Nothing else exists.
 
@@ -141,6 +142,74 @@ written the same way.
 control *is*, not where it sits: `CopyButton` renders in tables, panels, banners and
 bare pages, so no container can reach it.
 
+## A row's actions are glyphs
+
+**Pass `icon` and `label` to a `RowAction`.** A lane of words is prose the reader
+has to parse before they can act, and it repeats on every row: four words per row
+is four words to re-read down the length of the table (otari-ai#2123). Four shapes
+are recognized instead.
+
+`label` is not optional beside an icon, and it is not a caption either: it is the
+accessible name *and* the tooltip, so the word is still read aloud, still matched
+by speech input, and still spelled out on hover. A glyph with no name is anonymous
+to a screen reader and unreachable by voice.
+
+```tsx
+// Correct
+<RowActionRow>
+  <RowAction icon={FiClock} label="History" onPress={toggleHistory} />
+  <RowAction icon={FiEdit2} label="Edit" onPress={openEdit} />
+  <RowAction icon={FiTrash2} label="Delete" onPress={() => setPendingDelete(row)} />
+</RowActionRow>
+
+// Incorrect: the glyph is named nowhere, so the control has no name at all
+<RowAction icon={FiTrash2} ariaLabel="" onPress={remove} />
+```
+
+Where the text form is still right: **the armed half of a confirm**, whose whole
+job is to name the consequence of the next press, and a lane whose actions have
+no convention to borrow. A lane does not go half words and half glyphs, so if one
+action in it has no glyph, ask whether the lane wants words.
+
+The glyphs, so the same act does not arrive as two shapes on two pages:
+
+| Act | Glyph | Act | Glyph |
+| --- | --- | --- | --- |
+| Edit, Rename | `FiEdit2` | Delete | `FiTrash2` |
+| Remove from a group | `FiUserMinus` | Remove a grant | `FiUserX` |
+| Revoke an invitation | `FiXCircle` | Grant operator access | `FiShield` |
+| Block, Deactivate | `FiSlash` | Unblock, Reactivate | `FiCheckCircle` |
+| Disable | `FiPause` | Enable | `FiPlay` |
+| Regenerate | `FiRefreshCw` | Archive | `FiArchive` |
+| Restore | `FiRotateCcw` | Make default | `FiStar` |
+| History | `FiClock` | Examples | `FiList` |
+| Test | `FiActivity` | | |
+
+Two splits in there are the vocabulary rather than a coincidence, and both are
+worth keeping: **an X takes something away, a strike turns something off.** So
+removing operator access is `FiUserX` while deactivating the account is `FiSlash`,
+and `FiSlash` then means the same thing on Accounts (Deactivate) as it does on the
+roster (Block). A toggle carries its state in the glyph, not only in the label,
+which is what lets a reader see which rows are stopped without reading a lane.
+
+**The geometry is 32px of visual and 44px of target**, the pair `CopyButton`
+already uses in these rows: the `before:` bleed is the device
+[motion-and-access.md](motion-and-access.md) names for keeping a small glyph
+reachable, and 6px each way is under half `RowActionRow`'s 16px pitch, so no two
+targets overlap. `RowAction` owns both, and the glyph's size with them, so a lane
+cannot be built out of step with the next one.
+
+**A disabled glyph gets a native `title` as well as its name.** A disabled control
+takes neither hover nor focus, so react-aria's tooltip never opens on one, and the
+pointer is the one reader an `aria-label` does not reach. `RowAction` adds it for
+the disabled case only: on a pressable action the browser's tooltip and the
+product's would open on the same hover and say the same thing.
+
+An `actions` column's width is the widest lane it can reach, and for a lane with a
+two-step confirm in it that is the **armed** state rather than the glyphs: arming
+one row must not reflow the table. `.otari-provider-keys-table` is the one sized
+that way.
+
 ## Deleting a record: a dialog, never an in-place confirm
 
 **Every delete of a record goes through `ConfirmDialog`** (otari-ai#2110), whether
@@ -198,6 +267,9 @@ The resting trigger is **neutral** and the armed confirm is danger. The first cl
 is safe, so spending the loudest signal in the product on it wastes it; the danger
 hue marks the irreversible step.
 
+In a row the trigger is a glyph and the armed half is words, which makes the
+escalation structural before it is chromatic: a shape becomes a sentence.
+
 Label the two steps differently: the trigger names the object, the armed confirm
 names the consequence.
 
@@ -222,11 +294,11 @@ hides.
 
 | Component | Props | Use for |
 | --- | --- | --- |
-| `RowAction` | `onPress`, `isDanger?`, `isDisabled?`, `ariaLabel?`, children | An action in a table row. Caption-sized, not a `Button` |
+| `RowAction` | `icon` + `label`, or children; `onPress`, `isDanger?`, `isDisabled?`, `ariaLabel?` | An action in a table row. A glyph by default, not a `Button` |
 | `RowActionRow` | children | The trailing lane those sit in. **Use this one** |
 | `RowActions` | children | A near-duplicate with a tighter gap, on 2 call sites. Do not reach for it in new code |
 | `ConfirmButton` | `confirmLabel`, `onConfirm`, `isPending?`, children | The page-level two-step confirm, for a destructive action that deletes nothing |
-| `ConfirmRowAction` | `confirmLabel`, `onConfirm`, `isPending?`, children | The same two-step inside a row. It supplies its own `isDanger` and its own Cancel. Not for a delete |
+| `ConfirmRowAction` | `confirmLabel`, `onConfirm`, `isPending?`, and `icon` + `label` or children | The same two-step inside a row. Its trigger takes a glyph; its armed half stays words. It supplies its own `isDanger` and its own Cancel. Not for a delete |
 | `RefreshButton` | `onRefresh`, `isFetching?`, `updatedAt?`, `label?` | A refetch, with its own freshness caption. Pass `updatedAt` or the caption reads nothing |
 | `CopyButton` | `value`, `label` | Copy one value. Icon-only, 44x44 hit area |
 | `CopyField` | `label`, `value`, `multiline?`, `concealed?`, `action?` | A readonly field of a value to paste elsewhere. `concealed` is what it shows until the operator asks for the value, for a credential: Copy copies the real one either way, so a key is handed over without being read off the screen |

--- a/web/design/overlays.md
+++ b/web/design/overlays.md
@@ -34,21 +34,46 @@ Anything an operator needs in order to *act* goes on the page. A description
 under a field, a caption under a value, or a `Badge` on the row: all three are
 readable on a phone and none of them needs a pointer.
 
-It wraps its trigger rather than taking one as a prop, so the trigger keeps its
-own type: an `IconButton` inside one is still an `IconButton`, with its required
-label and its 44px box intact.
+It takes its trigger as `children` rather than as a prop, so the trigger keeps
+its own type: an `IconButton` inside one is still an `IconButton`, with its
+required label and its 44px box intact.
+
+**Which of the two forms you want depends on whether the trigger takes DOM
+props.** HeroUI's own trigger is a `div` the library gives `role="button"` and
+`tabIndex=0`, which is what makes a non-interactive trigger reachable at all and
+is wrong around a real `<button>`: it announces "Delete button" inside "Delete
+button", takes a tab stop of its own, and gives every `getByRole("button")` two
+matches instead of one. Hand the function form a native control instead, and it
+spreads the props it is given onto that control, so the trigger and the control
+are one element. `RowAction`'s glyph is the worked example.
+
+A HeroUI `Button` (so `IconButton` too) is the exception and keeps the wrapper:
+its props are react-aria's rather than the DOM's, so the trigger's `onClick` and
+`onPointerEnter` do not typecheck against it, let alone reach an element. Its 44px
+box and required label are unharmed by the wrapper; the duplicate name is the
+cost, and #2123 is where that is written down rather than solved.
 
 ```tsx
-// Correct: the tooltip repeats the button's own accessible name
-<Tooltip content="Delete this key">
-  <IconButton label="Delete this key" variant="danger">
-    <FiTrash2 aria-hidden className="size-4" />
-  </IconButton>
+// Correct: a native control takes the trigger's props rather than a wrapper
+<Tooltip content="Delete">
+  {(props) => (
+    <button {...props} type="button" aria-label="Delete">
+      <FiTrash2 aria-hidden className="h-3.5 w-3.5" />
+    </button>
+  )}
+</Tooltip>
+
+// Correct: a node that is not a control is wrapped, which is what gives it the
+// keyboard reach it has none of on its own
+<Tooltip content="2026-09-11 14:02:11 UTC">
+  <span className="text-caption">6m ago</span>
 </Tooltip>
 
 // Incorrect: the reason a control is refused has to be reachable without a
 // pointer, and a disabled control takes no focus, so this reaches nobody who
-// needs it. Put it in the accessible name (see RowAction's ariaLabel).
+// needs it. Put it in the accessible name (see RowAction's ariaLabel), which is
+// what `RowAction` does for its own glyphs, with a native `title` beside it for
+// the pointer the tooltip cannot reach.
 <Tooltip content="An organization owner manages this key">
   <RowAction isDisabled onPress={revoke}>Revoke</RowAction>
 </Tooltip>

--- a/web/src/app/nav/WorkspaceSwitcher.test.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.test.tsx
@@ -148,6 +148,35 @@ async function openMenu() {
   return { user, menu: await screen.findByRole("dialog") }
 }
 
+describe("the product mark in the scope switcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("sits in its lane with nothing painted behind it", async () => {
+    // The lane used to carry `bg-surface-subtle`, which is the fill a SELECTED
+    // nav row wears, so the mark read as a logo on a gray box and as the one
+    // row in the rail that was chosen (otari-ai#2123). The 28px lane stays,
+    // because that is what keeps the mark where a nav row's icon sits.
+    mockApi()
+    await renderSwitcher()
+
+    const trigger = await screen.findByRole("button", {
+      name: /^Switch workspace/,
+    })
+    const lane = trigger.querySelector("svg")?.parentElement as HTMLElement
+    expect(lane).toBeTruthy()
+    expect([...lane.classList]).toContain("h-7")
+    expect(lane.className).not.toContain("bg-")
+  })
+})
+
 describe("the organization half of the scope switcher", () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -169,10 +169,13 @@ export function WorkspaceSwitcher({
         >
           {/* The mark is the switcher's hero, as in the prototype: the product
             name is not repeated in the header, so this is where it lives. */}
-          {/* A 28px square on the active-control fill, which is what the
-              artboard draws: the mark sits in a tile the way a nav row's icon
-              sits in its lane, rather than floating at its own size. */}
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center bg-surface-subtle">
+          {/* A 28px lane, so the mark sits where a nav row's icon sits rather
+              than floating at its own size. No fill: the lane used to paint
+              `bg-surface-subtle`, which is the fill a SELECTED nav row wears,
+              so the product mark read both as a logo on a gray box and as the
+              one row in the rail that was chosen. The alignment was the half
+              worth keeping (otari-ai#2123). */}
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center">
             {/* Width only: the mark is 273 by 250, so a height of its own would
                 stretch it. It fills the tile's width and centers on the short
                 axis, which is why the tile is a flex box rather than a square

--- a/web/src/design-system/actions/ConfirmRowAction.stories.tsx
+++ b/web/src/design-system/actions/ConfirmRowAction.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { FiArchive, FiEdit2 } from "react-icons/fi"
 
 import { ConfirmRowAction } from "./ConfirmRowAction"
 import { RowAction, RowActionRow } from "./RowAction"
@@ -17,14 +18,19 @@ import { RowAction, RowActionRow } from "./RowAction"
  * 1.17:1 in light, 1.11:1 in dark, and 1.03:1 under simulated protanopia. What
  * survives is structural, a second control appearing and the row's layout
  * changing, which no color deficiency hides. Press one below to see it.
+ *
+ * The resting trigger takes a glyph like any other row action, so a lane does
+ * not go half words and half icons. The armed half stays text either way: its
+ * whole job is to name the consequence, and no glyph names one.
  */
 const meta = {
   title: "Design system/Actions/ConfirmRowAction",
   component: ConfirmRowAction,
   args: {
-    confirmLabel: "Archive",
+    confirmLabel: "Archive permanently",
     onConfirm: () => {},
-    children: "Archive",
+    icon: FiArchive,
+    label: "Archive",
   },
   parameters: { layout: "padded" },
 } satisfies Meta<typeof ConfirmRowAction>
@@ -42,6 +48,25 @@ export const Default: Story = {}
  * about what changed.
  */
 export const InALane: Story = {
+  render: () => (
+    <RowActionRow>
+      <RowAction icon={FiEdit2} label="Edit" onPress={() => {}} />
+      <ConfirmRowAction
+        icon={FiArchive}
+        label="Archive"
+        confirmLabel="Archive permanently"
+        onConfirm={() => {}}
+      />
+    </RowActionRow>
+  ),
+}
+
+/**
+ * The text form, which is what a lane with no glyph to borrow still reaches
+ * for. Both halves are words here, so the escalation is the second control
+ * appearing rather than a glyph becoming a sentence.
+ */
+export const TheTextForm: Story = {
   render: () => (
     <RowActionRow>
       <RowAction onPress={() => {}}>Edit</RowAction>

--- a/web/src/design-system/actions/ConfirmRowAction.tsx
+++ b/web/src/design-system/actions/ConfirmRowAction.tsx
@@ -1,6 +1,26 @@
 import { type ReactNode, useState } from "react"
+import type { IconType } from "react-icons"
 import { useConfirmationFocus } from "@/design-system/hooks/useConfirmationFocus"
 import { RowAction } from "./RowAction"
+
+export type ConfirmRowActionProps = {
+  confirmLabel: string
+  onConfirm: () => void
+  isPending?: boolean
+} & (
+  | {
+      /** The glyph the resting trigger wears. See `RowAction`. */
+      icon: IconType
+      /** What that glyph means: the trigger's accessible name and tooltip. */
+      label: string
+      children?: never
+    }
+  | {
+      icon?: never
+      label?: never
+      children: ReactNode
+    }
+)
 
 /**
  * A destructive row action that asks twice, in text rather than in buttons.
@@ -9,6 +29,10 @@ import { RowAction } from "./RowAction"
  * beside it. It replaces `ConfirmButton` on a table row for the same reason the
  * other actions lost their boxes; `ConfirmButton` stays for the forms and cards
  * where a destructive control is the only control and a button is right.
+ *
+ * The trigger takes a glyph like any other row action, so a lane does not go
+ * half words and half icons; the armed half stays text, because naming the
+ * consequence is the whole reason the second step exists and no glyph names it.
  *
  * Neither is for a delete: a record's deletion goes through `ConfirmDialog`,
  * because a confirmation armed inside the row reads as part of the table rather
@@ -19,13 +43,10 @@ export function ConfirmRowAction({
   confirmLabel,
   onConfirm,
   isPending,
+  icon,
+  label,
   children,
-}: {
-  confirmLabel: string
-  onConfirm: () => void
-  isPending?: boolean
-  children: ReactNode
-}) {
+}: ConfirmRowActionProps) {
   const [armed, setArmed] = useState(false)
   // Cancelling unmounts the focused Cancel button, which has no counterpart at
   // rest, and focus lands on `<body>`: the way out of a destructive action
@@ -48,6 +69,16 @@ export function ConfirmRowAction({
           Cancel
         </RowAction>
       </>
+    )
+  }
+  if (icon) {
+    return (
+      <RowAction
+        ref={triggerRef}
+        icon={icon}
+        label={label}
+        onPress={() => setArmed(true)}
+      />
     )
   }
   return (

--- a/web/src/design-system/actions/RowAction.stories.tsx
+++ b/web/src/design-system/actions/RowAction.stories.tsx
@@ -1,5 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
+import {
+  FiCheckCircle,
+  FiClock,
+  FiEdit2,
+  FiRefreshCw,
+  FiSlash,
+  FiTrash2,
+} from "react-icons/fi"
 
 import { RowAction, RowActionRow } from "./RowAction"
 
@@ -8,9 +16,15 @@ import { RowAction, RowActionRow } from "./RowAction"
  *
  * Not a `Button`, and that is the rule rather than a preference: a row of
  * buttons in every table row turns a dense table into a grid of boxes, so a row
- * action is caption-sized text. `RowActionRow` is the lane; reach for it rather
+ * action wears a bare glyph. `RowActionRow` is the lane; reach for it rather
  * than `deprecated/RowActions`, which is a near-duplicate with a tighter gap
  * still on one call site.
+ *
+ * The glyph form is what a lane should reach for, and the word is not lost to
+ * it: `label` is the accessible name and the tooltip both, so it is still read
+ * aloud, still matched by speech input, and still spelled out on hover. The
+ * text form is left for what no glyph says, which in practice is the armed half
+ * of a confirm.
  *
  * The danger prop paints the danger ink, and `src/styles/dotRamp.test.ts`
  * enforces something about it worth knowing: a row action never paints danger
@@ -24,7 +38,7 @@ import { RowAction, RowActionRow } from "./RowAction"
 const meta = {
   title: "Design system/Actions/RowAction",
   component: RowAction,
-  args: { onPress: () => {}, children: "Edit" },
+  args: { onPress: () => {}, icon: FiEdit2, label: "Edit" },
   parameters: { layout: "padded" },
 } satisfies Meta<typeof RowAction>
 
@@ -38,11 +52,48 @@ export const Default: Story = {}
 export const InALane: Story = {
   render: () => (
     <RowActionRow>
-      <RowAction onPress={() => {}}>Edit</RowAction>
-      <RowAction onPress={() => {}}>Rotate</RowAction>
-      <RowAction onPress={() => {}}>Revoke</RowAction>
+      <RowAction icon={FiClock} label="History" onPress={() => {}} />
+      <RowAction icon={FiEdit2} label="Edit" onPress={() => {}} />
+      <RowAction icon={FiRefreshCw} label="Regenerate" onPress={() => {}} />
+      <RowAction icon={FiTrash2} label="Delete" onPress={() => {}} />
     </RowActionRow>
   ),
+}
+
+/**
+ * The words the glyphs replaced, for comparison: four of them per row, re-read
+ * on every row, against four shapes that are recognized rather than read
+ * (otari-ai#2123). The text form is still what a confirm's armed half uses,
+ * which is why it is public rather than retired.
+ */
+export const TheTextFormItReplaced: Story = {
+  render: () => (
+    <RowActionRow>
+      <RowAction onPress={() => {}}>History</RowAction>
+      <RowAction onPress={() => {}}>Edit</RowAction>
+      <RowAction onPress={() => {}}>Regenerate</RowAction>
+      <RowAction onPress={() => {}}>Delete</RowAction>
+    </RowActionRow>
+  ),
+}
+
+/**
+ * A pair whose glyph carries the state as well as the act, which is what a
+ * label alone cannot do: the lane says at a glance which rows are blocked.
+ */
+export const AToggledAction: Story = {
+  render: () => {
+    const [blocked, setBlocked] = useState(false)
+    return (
+      <RowActionRow>
+        <RowAction
+          icon={blocked ? FiCheckCircle : FiSlash}
+          label={blocked ? "Unblock" : "Block"}
+          onPress={() => setBlocked(!blocked)}
+        />
+      </RowActionRow>
+    )
+  },
 }
 
 /**
@@ -53,14 +104,14 @@ export const InALane: Story = {
 export const DisabledWithReason: Story = {
   render: () => (
     <RowActionRow>
-      <RowAction onPress={() => {}}>Edit</RowAction>
+      <RowAction icon={FiEdit2} label="Edit" onPress={() => {}} />
       <RowAction
+        icon={FiSlash}
+        label="Revoke"
         onPress={() => {}}
         isDisabled
         ariaLabel="Revoke this key. Unavailable: an organization owner manages it."
-      >
-        Revoke
-      </RowAction>
+      />
     </RowActionRow>
   ),
 }
@@ -78,12 +129,18 @@ export const InContext: Story = {
             {name}
           </span>
           <RowActionRow>
-            <RowAction onPress={() => {}} ariaLabel={`Edit ${name}`}>
-              Edit
-            </RowAction>
-            <RowAction onPress={() => {}} ariaLabel={`Revoke ${name}`}>
-              Revoke
-            </RowAction>
+            <RowAction
+              icon={FiEdit2}
+              label="Edit"
+              ariaLabel={`Edit ${name}`}
+              onPress={() => {}}
+            />
+            <RowAction
+              icon={FiSlash}
+              label="Revoke"
+              ariaLabel={`Revoke ${name}`}
+              onPress={() => {}}
+            />
           </RowActionRow>
         </div>
       ))}
@@ -109,7 +166,7 @@ export const ArmedPaintsDanger: Story = {
     return (
       <div className="flex flex-col gap-3">
         <RowActionRow>
-          <RowAction onPress={() => {}}>Edit</RowAction>
+          <RowAction icon={FiEdit2} label="Edit" onPress={() => {}} />
           <RowAction isDanger={armed} onPress={() => setArmed(!armed)}>
             {armed ? "Confirm remove" : "Remove"}
           </RowAction>

--- a/web/src/design-system/actions/RowAction.test.tsx
+++ b/web/src/design-system/actions/RowAction.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { FiArchive, FiTrash2 } from "react-icons/fi"
 import { describe, expect, it, vi } from "vitest"
 import { ConfirmRowAction } from "@/design-system/actions/ConfirmRowAction"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
@@ -73,6 +74,107 @@ describe("RowAction", () => {
       }),
     ).toBeDisabled()
     expect(screen.queryByRole("button", { name: "Remove" })).toBeNull()
+  })
+})
+
+/**
+ * The glyph form, whose whole risk is the word going missing with the text. A
+ * control with no name is anonymous to a screen reader and unreachable by
+ * speech input, so `label` being required is the design and these are what
+ * hold it: the name is there, the glyph is not read twice, and the refusal
+ * still says why.
+ */
+describe("RowAction wearing a glyph", () => {
+  it("takes its accessible name from the label the glyph replaced", () => {
+    render(
+      <RowAction icon={FiTrash2} label="Delete" onPress={() => undefined} />,
+    )
+    const action = screen.getByRole("button", { name: "Delete" })
+    // The glyph is decoration once the button is named, so it must not add a
+    // second reading of the same word.
+    const glyph = action.querySelector("svg")
+    expect(glyph).not.toBeNull()
+    expect(glyph?.getAttribute("aria-hidden")).toBe("true")
+  })
+
+  it("reaches the 44px touch floor a 32px glyph does not", () => {
+    // jsdom lays nothing out, so the device is what is asserted: 32px of
+    // visual and a 6px bleed each way, which is under half `RowActionRow`'s
+    // 16px pitch and so cannot overlap the action beside it.
+    render(
+      <RowAction icon={FiTrash2} label="Delete" onPress={() => undefined} />,
+    )
+    const classes = [
+      ...screen.getByRole("button", { name: "Delete" }).classList,
+    ]
+    expect(classes).toContain("size-8")
+    expect(classes).toContain("before:-inset-1.5")
+  })
+
+  it("lets ariaLabel carry the row and the reason, as the text form does", () => {
+    render(
+      <RowAction
+        icon={FiTrash2}
+        label="Delete"
+        ariaLabel="Delete Default workspace (an organization keeps one workspace)"
+        isDisabled
+        onPress={() => undefined}
+      />,
+    )
+    const action = screen.getByRole("button", {
+      name: "Delete Default workspace (an organization keeps one workspace)",
+    })
+    expect(action).toBeDisabled()
+    // A disabled control takes neither hover nor focus, so react-aria's
+    // tooltip never opens on one: without this the glyph is nameless to a
+    // pointer, which is the one reader the accessible name does not reach.
+    expect(action).toHaveAttribute(
+      "title",
+      "Delete Default workspace (an organization keeps one workspace)",
+    )
+  })
+
+  it("leaves the native tooltip off an action that can be pressed", () => {
+    // Two tooltips over one control, the browser's and the product's, open on
+    // the same hover and say the same thing.
+    render(
+      <RowAction icon={FiTrash2} label="Delete" onPress={() => undefined} />,
+    )
+    expect(screen.getByRole("button", { name: "Delete" })).not.toHaveAttribute(
+      "title",
+    )
+  })
+
+  it("is one control, and the one the tooltip is wired to", async () => {
+    // The tooltip's trigger is the button itself rather than a wrapper around
+    // it. HeroUI's default trigger is a div it reports as a button, which
+    // around a real button doubles both the announcement and the tab stop, and
+    // gives every `getByRole("button", { name })` in the e2e suite two matches.
+    const { container } = render(
+      <RowAction icon={FiTrash2} label="Delete" onPress={() => undefined} />,
+    )
+    expect(screen.getAllByRole("button")).toHaveLength(1)
+    expect(container.firstElementChild?.tagName).toBe("BUTTON")
+    expect(container.firstElementChild).toHaveAttribute(
+      "data-slot",
+      "tooltip-trigger",
+    )
+    // The trigger's behavior, not its presentation. `.tooltip__trigger` sets
+    // `display: inline-block`, which un-centers the glyph, and answers
+    // `:focus-visible` with a box-shadow ring after zeroing `outline-style`,
+    // which motion-and-access.md forbids outright. Spreading the props
+    // wholesale is what puts it back, so its absence is the assertion.
+    expect(container.firstElementChild?.className).not.toContain(
+      "tooltip__trigger",
+    )
+  })
+
+  it("presses", async () => {
+    const user = userEvent.setup()
+    const onPress = vi.fn()
+    render(<RowAction icon={FiTrash2} label="Delete" onPress={onPress} />)
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+    expect(onPress).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -156,6 +258,29 @@ describe("ConfirmRowAction", () => {
     expect(onConfirm).not.toHaveBeenCalled()
     expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Confirm remove" })).toBeNull()
+  })
+
+  it("arms a glyph trigger into the words that name the consequence", async () => {
+    // The glyph form of the trigger, which is what a lane of icons uses. The
+    // armed half stays text in both forms: it is the step that has to say what
+    // the next press costs, and no glyph says it.
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    render(
+      <ConfirmRowAction
+        icon={FiArchive}
+        label="Archive"
+        confirmLabel="Archive permanently"
+        onConfirm={onConfirm}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: "Archive" }))
+    const confirm = screen.getByRole("button", { name: "Archive permanently" })
+    expect([...confirm.classList]).toContain("text-danger")
+    expect(confirm.querySelector("svg")).toBeNull()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument()
+    await user.click(confirm)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
   it("refuses a second confirm while the first is in flight", async () => {

--- a/web/src/design-system/actions/RowAction.tsx
+++ b/web/src/design-system/actions/RowAction.tsx
@@ -1,14 +1,66 @@
 import type { ReactNode, RefObject } from "react"
+import type { IconType } from "react-icons"
+import {
+  Tooltip,
+  type TooltipTriggerProps,
+} from "@/design-system/overlays/Tooltip"
+
+export type RowActionProps = {
+  onPress: () => void
+  isDanger?: boolean
+  isDisabled?: boolean
+  /**
+   * Forwarded to the button so a caller can move focus onto it. The two-step
+   * confirm is the only caller: its swap unmounts a focused control, and a ref
+   * is the only way to hand the caret to whatever replaced it.
+   */
+  ref?: RefObject<HTMLButtonElement | null>
+  /**
+   * Replaces the name the label would give, which is how a row action says
+   * which row it acts on and why it is refused: a disabled control takes no
+   * focus, so a tooltip reaches a pointer and nothing else, and the reason has
+   * to be in the name.
+   */
+  ariaLabel?: string
+} & (
+  | {
+      /**
+       * The glyph this action wears instead of its word. The component sizes it
+       * and hides it from assistive tech, so every lane matches and no call
+       * site can forget either.
+       */
+      icon: IconType
+      /** What the glyph means: the accessible name and the tooltip. */
+      label: string
+      children?: never
+    }
+  | {
+      icon?: never
+      label?: never
+      children: ReactNode
+    }
+)
 
 /**
- * A row's action: 13px of muted text, no border, no fill, no box.
+ * A row's action: a glyph, or 13px of muted text, with no border, fill or box.
  *
  * A row has three or four of these and boxing each one turned the last lane
  * into a control panel, louder than the row it acts on.
  *
+ * **Pass `icon` and `label` wherever a glyph says it.** A lane of words reads as
+ * prose until the pointer is already on it, and four of them repeated down a
+ * table is four words to re-read per row (otari-ai#2123). `label` is not
+ * optional beside an icon: it is the accessible name and the tooltip, so the
+ * word is still there for anyone who needs it, and a glyph with no name is
+ * anonymous to a screen reader and unreachable by speech input.
+ *
+ * The text form stays for what no glyph says: the armed half of a confirm,
+ * whose whole job is to name the consequence, and a lane whose actions have no
+ * convention to borrow.
+ *
  * `isDanger` is for the ARMED state and nothing else, which is worth spelling
  * out because it was got wrong at six sites on the first pass: a destructive
- * action at rest is the same muted text as its neighbors, and the ink arrives
+ * action at rest is the same muted ink as its neighbors, and the color arrives
  * only once the next click commits something. A row that paints Remove red
  * before anybody has touched it spends the color on a state nothing is in, and
  * by the time it means something the reader has stopped seeing it. Same rule
@@ -23,44 +75,72 @@ import type { ReactNode, RefObject } from "react"
  */
 export function RowAction({
   onPress,
+  icon: Icon,
+  label,
   isDanger,
   isDisabled,
   ariaLabel,
   ref,
   children,
-}: {
-  onPress: () => void
-  isDanger?: boolean
-  isDisabled?: boolean
-  /**
-   * Forwarded to the button so a caller can move focus onto it. The two-step
-   * confirm is the only caller: its swap unmounts a focused control, and a ref
-   * is the only way to hand the caret to whatever replaced it.
-   */
-  ref?: RefObject<HTMLButtonElement | null>
-  /**
-   * Replaces the visible label for assistive tech, which is how a row action
-   * says which row it acts on and why it is refused: a disabled control takes
-   * no focus, so a tooltip reaches a pointer and nothing else, and the reason
-   * has to be in the name.
-   */
-  ariaLabel?: string
-  children: ReactNode
-}) {
-  return (
+}: RowActionProps) {
+  const name = ariaLabel ?? label
+  // `trigger` is what the tooltip hands its control: the hover and focus
+  // handlers that open it, the `aria-describedby` that names it, and a ref to
+  // position it against. Every one of them has to reach this button, so they
+  // are spread first and only the props this component owns are written after.
+  //
+  // Its `className` is the exception and is dropped: `.tooltip__trigger` is
+  // HeroUI's presentation for a trigger it expects to have built itself, and
+  // two thirds of it are wrong here. It sets `display: inline-block`, which
+  // un-centers a glyph in a flex box, and it answers `:focus-visible` with a
+  // box-shadow ring after zeroing `outline-style`, which motion-and-access.md
+  // forbids in as many words. Nothing in it is behavioral, so nothing is lost.
+  const render = ({
+    className: _triggerClass,
+    ref: triggerRef,
+    ...trigger
+  }: TooltipTriggerProps = {}) => (
     <button
-      ref={ref}
+      {...trigger}
+      // Two refs on one element: the caller's, and the trigger's. A callback is
+      // the only shape that serves both, and dropping the trigger's would
+      // leave the tooltip anchored at the top left of the page.
+      ref={(node) => {
+        if (ref) ref.current = node
+        if (typeof triggerRef === "function") triggerRef(node)
+        else if (triggerRef) triggerRef.current = node
+      }}
       type="button"
       disabled={isDisabled}
-      aria-label={ariaLabel}
+      aria-label={name}
+      // A disabled control takes neither hover nor focus, so react-aria's
+      // tooltip never opens on one and a refused glyph would be nameless to a
+      // pointer. The native attribute is the only tooltip it has left, and it
+      // is not set on a pressable action: there the browser's tooltip and the
+      // product's would open on the same hover and say the same thing.
+      title={Icon !== undefined && isDisabled ? name : undefined}
       onClick={onPress}
-      className={`text-caption whitespace-nowrap transition-colors motion-reduce:transition-none disabled:opacity-(--disabled-opacity) ${
-        isDanger ? "text-danger" : "hover:text-foreground"
-      }`}
+      className={`text-caption transition-colors motion-reduce:transition-none disabled:opacity-(--disabled-opacity) ${
+        Icon
+          ? // 32px of visual, 44px of target, the same pair `CopyButton` uses in
+            // these very rows: the pseudo-element is the device
+            // motion-and-access.md names for keeping a small glyph reachable,
+            // and 6px each way is under half `RowActionRow`'s 16px pitch, so no
+            // two of these overlap.
+            "relative flex size-8 shrink-0 items-center justify-center before:absolute before:-inset-1.5 before:content-['']"
+          : "whitespace-nowrap"
+      } ${isDanger ? "text-danger" : "hover:text-foreground"}`}
     >
-      {children}
+      {Icon ? <Icon aria-hidden="true" className="h-3.5 w-3.5" /> : children}
     </button>
   )
+  if (Icon === undefined) return render()
+  // The tooltip is a repetition of the accessible name, which is the one job
+  // overlays.md leaves it: it spells out a glyph that is already named rather
+  // than saying anything only a pointer would learn. Through the function form,
+  // so the trigger's props land on this button rather than on a wrapper the
+  // library would also call a button.
+  return <Tooltip content={label}>{render}</Tooltip>
 }
 
 /** The lane those sit in: right-aligned, 16px apart. */

--- a/web/src/design-system/overlays/Tooltip.stories.tsx
+++ b/web/src/design-system/overlays/Tooltip.stories.tsx
@@ -13,9 +13,17 @@ import { Tooltip } from "./Tooltip"
  * `aria-label`, giving an exact timestamp beside a relative one) and wrong for
  * anything an operator needs in order to act.
  *
- * It wraps its trigger rather than taking one as a prop, so the trigger keeps
+ * It takes its trigger as `children` rather than as a prop, so the trigger keeps
  * its own type: an `IconButton` inside one is still an `IconButton`, with its
  * required label and 44px box intact.
+ *
+ * Two forms, and the pair of stories below is the whole difference. A node is
+ * wrapped in HeroUI's own trigger, a `div` the library reports as a button so a
+ * keyboard can reach something that is not a control. A **native** control is
+ * passed as a function and spreads the props it is handed, which is what keeps
+ * a real button from ending up inside something else the library also calls a
+ * button. A HeroUI `Button` cannot take those props (they are the DOM's, its
+ * are react-aria's) and so keeps the wrapper.
  */
 const meta = {
   title: "Design system/Overlays/Tooltip",
@@ -39,6 +47,29 @@ export const Default: Story = {
       <IconButton label="Delete this key" variant="danger">
         <FiTrash2 aria-hidden className="size-4" />
       </IconButton>
+    </Tooltip>
+  ),
+}
+
+/**
+ * The function form, for a native control: one element is both the button and
+ * the trigger. Tab to it and the tooltip opens; inspect it and there is a single
+ * `button`, where the wrapper form nests one inside a `div` that also reports as
+ * a button. `RowAction`'s glyph is the shipping example.
+ */
+export const AControlTakesTheTriggersProps: Story = {
+  render: () => (
+    <Tooltip content="Delete">
+      {(props) => (
+        <button
+          {...props}
+          type="button"
+          aria-label="Delete"
+          className="text-caption flex size-8 items-center justify-center hover:text-foreground"
+        >
+          <FiTrash2 aria-hidden className="h-3.5 w-3.5" />
+        </button>
+      )}
     </Tooltip>
   ),
 }

--- a/web/src/design-system/overlays/Tooltip.test.tsx
+++ b/web/src/design-system/overlays/Tooltip.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Tooltip } from "@/design-system/overlays/Tooltip"
+
+/**
+ * The two trigger forms, and the reason there are two.
+ *
+ * HeroUI's trigger is a `div` it gives `role="button"` and `tabIndex=0`, which
+ * is right for content that is not a control and wrong around one: a real
+ * button inside it is announced twice, takes two tab stops, and gives every
+ * `getByRole("button")` two matches. The function form spreads the trigger's
+ * props onto the control instead, so there is one element playing both parts.
+ */
+describe("Tooltip", () => {
+  it("wraps a plain node in the library's own trigger", () => {
+    render(
+      <Tooltip content="An exact timestamp">
+        <span>2 hours ago</span>
+      </Tooltip>,
+    )
+    const trigger = screen.getByRole("button")
+    expect(trigger.tagName).toBe("DIV")
+    expect(trigger).toHaveTextContent("2 hours ago")
+  })
+
+  it("hands a control the trigger's props instead of wrapping it", () => {
+    const { container } = render(
+      <Tooltip content="Delete">
+        {(props) => (
+          <button {...props} type="button" aria-label="Delete">
+            x
+          </button>
+        )}
+      </Tooltip>,
+    )
+    // One control, not a control inside a control. This is the assertion the
+    // wrapper form fails: it renders a div reported as a button around a
+    // button, so the name resolves twice.
+    expect(screen.getAllByRole("button")).toHaveLength(1)
+    expect(container.firstElementChild?.tagName).toBe("BUTTON")
+    // And the props reached it, which is what opens the tooltip at all: a
+    // render function that ignores them compiles, renders, and never opens.
+    expect(container.firstElementChild).toHaveAttribute(
+      "data-slot",
+      "tooltip-trigger",
+    )
+  })
+})

--- a/web/src/design-system/overlays/Tooltip.tsx
+++ b/web/src/design-system/overlays/Tooltip.tsx
@@ -1,5 +1,8 @@
 import { Tooltip as HeroTooltip } from "@heroui/react"
-import type { ReactNode } from "react"
+import type { JSX, ReactElement, ReactNode } from "react"
+
+/** The props HeroUI's trigger hands a control: focus and hover handlers, a ref, and the `aria-describedby` that names the tooltip. Spread them onto the element, all of them. */
+export type TooltipTriggerProps = JSX.IntrinsicElements["button"]
 
 /**
  * A short label revealed by hovering or focusing the thing it describes.
@@ -11,10 +14,27 @@ import type { ReactNode } from "react"
  * `aria-label`, giving an exact timestamp beside a relative one) and wrong for
  * anything an operator needs in order to act.
  *
- * It wraps the trigger rather than taking it as a prop, so the trigger keeps
- * its own type: an `IconButton` inside one is still an `IconButton`, with its
- * required label and its 44px box intact. Passing it as `trigger={<Button/>}`
- * would have made the tooltip the parent of a node it cannot type-check.
+ * Two shapes, and which one you want depends on whether the thing described is
+ * itself a control:
+ *
+ * - **A node**, for content that is not interactive. It is wrapped in HeroUI's
+ *   own trigger, which is a `div` the library gives `role="button"` and
+ *   `tabIndex=0` so a keyboard can reach it at all.
+ * - **A function**, for a native control. It receives the trigger's props and
+ *   must spread every one of them onto its own element, the `ref` included. The
+ *   wrapper's `role="button"` around a real button is the reason this form
+ *   exists: it would announce "Edit button" inside "Edit button", take a tab
+ *   stop of its own, and give every `getByRole("button")` two matches instead
+ *   of one, which is a dozen assertions in this repo's e2e suite.
+ *
+ * A HeroUI `Button` (so `IconButton`) cannot use the function form and keeps the
+ * wrapper: its props are react-aria's rather than the DOM's, so the trigger's
+ * `onClick` and `onPointerEnter` do not even typecheck against it. That is why
+ * the props are typed for a `button` here rather than generically.
+ *
+ * Either way the trigger keeps its own type, which is what a `trigger={<Button/>}`
+ * prop could not have done: the tooltip would have been the parent of a node it
+ * cannot type-check.
  */
 export function Tooltip({
   content,
@@ -24,19 +44,23 @@ export function Tooltip({
   /** The label. A phrase, not a sentence, and never the only place it is said. */
   content: ReactNode
   placement?: "top" | "bottom" | "left" | "right"
-  children: ReactNode
+  children: ReactNode | ((props: TooltipTriggerProps) => ReactElement)
 }) {
   return (
     <HeroTooltip.Root>
-      {/* `inline-flex` rather than the element override HeroUI offers: a
-          tooltip most often wraps a button sitting in a row of them, and the
-          trigger's default block display would break the row's flex layout.
-          v3 overrides an element through a `render` prop rather than `as`, and
-          routing a div's prop type onto a span to gain nothing over a display
-          utility is not worth the cast. */}
-      <HeroTooltip.Trigger className="inline-flex">
-        {children}
-      </HeroTooltip.Trigger>
+      {typeof children === "function" ? (
+        // The generic is what types the render function for a `button` rather
+        // than for the `div` HeroUI's trigger defaults to. A control wanting a
+        // tooltip is a button here; a link would need its own spelling.
+        <HeroTooltip.Trigger<"button"> render={children} />
+      ) : (
+        // `inline-flex` rather than the element override HeroUI offers: a
+        // tooltip most often wraps a button sitting in a row of them, and the
+        // trigger's default block display would break the row's flex layout.
+        <HeroTooltip.Trigger className="inline-flex">
+          {children}
+        </HeroTooltip.Trigger>
+      )}
       <HeroTooltip.Content placement={placement}>{content}</HeroTooltip.Content>
     </HeroTooltip.Root>
   )

--- a/web/src/features/admin/DeploymentAccountsPage.tsx
+++ b/web/src/features/admin/DeploymentAccountsPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { FiCheckCircle, FiShield, FiSlash, FiUserX } from "react-icons/fi"
 
 import type { DeploymentUser } from "@/client"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
@@ -139,56 +140,64 @@ export function DeploymentAccountsPage() {
           const blocked = accountLockoutReason(account)
           return (
             <RowActionRow>
-              {/* `title` reaches a mouse; the reason is folded into the
-                  control's own name so it reaches everyone else too, as the
-                  organization roster does it. A disabled control is not
-                  focusable, so an `aria-describedby` would never be announced. */}
-              <span title={account.is_superuser ? blocked : undefined}>
-                <RowAction
-                  isDisabled={
-                    (account.is_superuser && blocked !== undefined) ||
-                    update.isPending
+              {/* The reason is folded into each control's own name, as the
+                  organization roster does it: a disabled control is not
+                  focusable, so an `aria-describedby` would never be announced
+                  and the name is the only channel left. `RowAction` repeats that
+                  name on a native `title` while the action is refused, which is
+                  what reaches a mouse, so neither of these needs a wrapper of
+                  its own for it any more. */}
+              <RowAction
+                // An X for taking something away, a strike for turning
+                // something off, which is the split the pair below follows
+                // too: the shield is the grant, and a shield with a strike
+                // through it said "suspended" where this means "removed".
+                icon={account.is_superuser ? FiUserX : FiShield}
+                label={
+                  account.is_superuser ? "Remove operator" : "Make operator"
+                }
+                isDisabled={
+                  (account.is_superuser && blocked !== undefined) ||
+                  update.isPending
+                }
+                ariaLabel={
+                  account.is_superuser
+                    ? `Remove operator access from ${accountLabel(account)}${blocked ? ` (${blocked})` : ""}`
+                    : `Grant operator access to ${accountLabel(account)}`
+                }
+                onPress={() =>
+                  update.mutate({
+                    id: account.id,
+                    body: { is_superuser: !account.is_superuser },
+                  })
+                }
+              />
+              <RowAction
+                // The same strike the roster's Block wears, because it is
+                // the same act: this person's access stops, their record
+                // stays.
+                icon={account.is_active ? FiSlash : FiCheckCircle}
+                label={account.is_active ? "Deactivate" : "Reactivate"}
+                isDisabled={
+                  (account.is_active && blocked !== undefined) ||
+                  update.isPending
+                }
+                ariaLabel={
+                  account.is_active
+                    ? `Deactivate ${accountLabel(account)}${blocked ? ` (${blocked})` : ""}`
+                    : `Reactivate ${accountLabel(account)}`
+                }
+                onPress={() => {
+                  if (account.is_active) {
+                    setDeactivating(account)
+                    return
                   }
-                  ariaLabel={
-                    account.is_superuser
-                      ? `Remove operator access from ${accountLabel(account)}${blocked ? ` (${blocked})` : ""}`
-                      : `Grant operator access to ${accountLabel(account)}`
-                  }
-                  onPress={() =>
-                    update.mutate({
-                      id: account.id,
-                      body: { is_superuser: !account.is_superuser },
-                    })
-                  }
-                >
-                  {account.is_superuser ? "Remove operator" : "Make operator"}
-                </RowAction>
-              </span>
-              <span title={account.is_active ? blocked : undefined}>
-                <RowAction
-                  isDisabled={
-                    (account.is_active && blocked !== undefined) ||
-                    update.isPending
-                  }
-                  ariaLabel={
-                    account.is_active
-                      ? `Deactivate ${accountLabel(account)}${blocked ? ` (${blocked})` : ""}`
-                      : `Reactivate ${accountLabel(account)}`
-                  }
-                  onPress={() => {
-                    if (account.is_active) {
-                      setDeactivating(account)
-                      return
-                    }
-                    update.mutate({
-                      id: account.id,
-                      body: { is_active: true },
-                    })
-                  }}
-                >
-                  {account.is_active ? "Deactivate" : "Reactivate"}
-                </RowAction>
-              </span>
+                  update.mutate({
+                    id: account.id,
+                    body: { is_active: true },
+                  })
+                }}
+              />
             </RowActionRow>
           )
         },

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -11,6 +11,7 @@ import {
   useRef,
   useState,
 } from "react"
+import { FiClock, FiEdit2, FiTrash2 } from "react-icons/fi"
 import type {
   Budget,
   BudgetResetLog,
@@ -719,23 +720,27 @@ function DeploymentBudgetsPage() {
         cell: (b) => (
           <RowActionRow>
             <RowAction
+              icon={FiClock}
+              label={historyOpen === b.budget_id ? "Hide history" : "History"}
               onPress={() =>
                 setHistoryOpen((current) =>
                   current === b.budget_id ? null : b.budget_id,
                 )
               }
-            >
-              {historyOpen === b.budget_id ? "Hide history" : "History"}
-            </RowAction>
+            />
             <RowAction
+              icon={FiEdit2}
+              label="Edit"
               onPress={() => {
                 setAddOpen(false)
                 setEditing(b.budget_id)
               }}
-            >
-              Edit
-            </RowAction>
-            <RowAction onPress={() => setPendingDelete(b)}>Delete</RowAction>
+            />
+            <RowAction
+              icon={FiTrash2}
+              label="Delete"
+              onPress={() => setPendingDelete(b)}
+            />
           </RowActionRow>
         ),
       },

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from "react"
+import { FiEdit2, FiPause, FiPlay, FiRefreshCw, FiTrash2 } from "react-icons/fi"
 import type {
   ApiKey,
   CreateKeyRequest,
@@ -1165,30 +1166,34 @@ export function KeysPage() {
         cell: (k) => (
           <RowActionRow>
             <RowAction
+              icon={k.is_active ? FiPause : FiPlay}
+              label={k.is_active ? "Disable" : "Enable"}
               isDisabled={updateKey.isPending}
               onPress={() => setActive(k, !k.is_active)}
-            >
-              {k.is_active ? "Disable" : "Enable"}
-            </RowAction>
+            />
             <RowAction
+              icon={FiEdit2}
+              label="Edit"
               onPress={() => {
                 setAddOpen(false)
                 setEditing(k.id)
               }}
-            >
-              Edit
-            </RowAction>
+            />
             <RowAction
               ref={lastArmed === k.id ? triggerRef : undefined}
+              icon={FiRefreshCw}
+              label="Regenerate"
               isDanger={armed === k.id}
               onPress={() => arm(k.id)}
-            >
-              Regenerate
-            </RowAction>
+            />
             {/* Permanent delete is only offered once a key is disabled, so a live
               caller can't be broken (and its audit trail erased) in one click. */}
             {k.is_active ? null : (
-              <RowAction onPress={() => setPendingDelete(k)}>Delete</RowAction>
+              <RowAction
+                icon={FiTrash2}
+                label="Delete"
+                onPress={() => setPendingDelete(k)}
+              />
             )}
           </RowActionRow>
         ),

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -1,5 +1,12 @@
 import { Button } from "@heroui/react"
 import { useMemo, useState } from "react"
+import {
+  FiCheckCircle,
+  FiEdit2,
+  FiSlash,
+  FiUserMinus,
+  FiXCircle,
+} from "react-icons/fi"
 
 import type {
   User as ApiUser,
@@ -1122,11 +1129,11 @@ export function OrganizationMembersPage() {
             return (
               <RowActionRow>
                 <RowAction
+                  icon={FiXCircle}
+                  label="Revoke"
                   isDisabled={!manages}
                   onPress={() => setRevoking(member)}
-                >
-                  Revoke
-                </RowAction>
+                />
               </RowActionRow>
             )
           }
@@ -1142,13 +1149,15 @@ export function OrganizationMembersPage() {
             <RowActionRow>
               {manages ? (
                 <RowAction
+                  icon={FiEdit2}
+                  label="Edit"
                   onPress={() => setEditingMember(memberRowKey(member))}
-                >
-                  Edit
-                </RowAction>
+                />
               ) : null}
               {manages && spendRow ? (
                 <RowAction
+                  icon={spendRow.blocked ? FiCheckCircle : FiSlash}
+                  label={spendRow.blocked ? "Unblock" : "Block"}
                   isDisabled={updateUser.isPending}
                   onPress={() =>
                     updateUser.mutate({
@@ -1156,25 +1165,23 @@ export function OrganizationMembersPage() {
                       body: { blocked: !spendRow.blocked },
                     })
                   }
-                >
-                  {spendRow.blocked ? "Unblock" : "Block"}
-                </RowAction>
+                />
               ) : null}
-              <span title={blocked}>
-                <RowAction
-                  // See the Role cell: the reason has to be in the name, not only
-                  // in the tooltip, to reach anything but a pointer.
-                  ariaLabel={
-                    blocked
-                      ? `Remove ${memberLabel(member)} (${blocked})`
-                      : undefined
-                  }
-                  isDisabled={blocked !== undefined}
-                  onPress={() => setRemoving(member)}
-                >
-                  Remove
-                </RowAction>
-              </span>
+              <RowAction
+                icon={FiUserMinus}
+                label="Remove"
+                // See the Role cell: the reason has to be in the name, not only
+                // in the tooltip, to reach anything but a pointer. `RowAction`
+                // puts the same name on a `title` while the action is refused,
+                // which is how the pointer gets it without a wrapper here.
+                ariaLabel={
+                  blocked
+                    ? `Remove ${memberLabel(member)} (${blocked})`
+                    : undefined
+                }
+                isDisabled={blocked !== undefined}
+                onPress={() => setRemoving(member)}
+              />
             </RowActionRow>
           )
         },

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -1,5 +1,12 @@
 import { Button } from "@heroui/react"
 import { useState } from "react"
+import {
+  FiArchive,
+  FiEdit2,
+  FiRotateCcw,
+  FiStar,
+  FiTrash2,
+} from "react-icons/fi"
 
 import type {
   CreateOrgProviderKeyRequest,
@@ -395,37 +402,41 @@ export function OrganizationProviderKeysPage() {
           {row.archived_at ? (
             <>
               <RowAction
+                icon={FiRotateCcw}
+                label="Restore"
                 isDisabled={restore.isPending}
                 onPress={() => restore.mutate(row.id)}
-              >
-                Restore
-              </RowAction>
+              />
               {/* Permanent, and the only place it is offered: the API
                     accepts a delete for an archived key alone. */}
-              <RowAction onPress={() => setPendingDelete(row)}>
-                Delete
-              </RowAction>
+              <RowAction
+                icon={FiTrash2}
+                label="Delete"
+                onPress={() => setPendingDelete(row)}
+              />
             </>
           ) : (
             <>
               <RowAction
+                icon={FiStar}
+                label="Make default"
                 isDisabled={row.is_org_default || setDefault.isPending}
                 onPress={() => setDefault.mutate(row.id)}
-              >
-                Make default
-              </RowAction>
+              />
               <RowAction
+                icon={FiEdit2}
+                label="Edit"
                 onPress={() => {
                   setAdding(false)
                   setEditingId(row.id)
                 }}
-              >
-                Edit
-              </RowAction>
+              />
               {/* Archive rather than delete: it is reversible, it is what
                     clears the default, and it is the step the API requires
                     before a key can be removed for good. */}
               <ConfirmRowAction
+                icon={FiArchive}
+                label="Archive"
                 confirmLabel="Archive"
                 isPending={archive.isPending}
                 onConfirm={() =>
@@ -435,9 +446,7 @@ export function OrganizationProviderKeysPage() {
                     },
                   })
                 }
-              >
-                Archive
-              </ConfirmRowAction>
+              />
             </>
           )}
         </RowActionRow>

--- a/web/src/features/organization/RateOverridesCard.tsx
+++ b/web/src/features/organization/RateOverridesCard.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@heroui/react"
 import { useState } from "react"
+import { FiEdit2, FiTrash2 } from "react-icons/fi"
 
 import type { OrganizationPricingOverride } from "@/client"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
@@ -165,15 +166,18 @@ export function RateOverridesCard() {
         // Both controls stay mounted and disabled for a reader rather than
         // vanishing, so the page does not reflow between roles.
         <RowActionRow>
-          <RowAction isDisabled={!canEdit} onPress={() => openEdit(row)}>
-            Edit
-          </RowAction>
           <RowAction
+            icon={FiEdit2}
+            label="Edit"
+            isDisabled={!canEdit}
+            onPress={() => openEdit(row)}
+          />
+          <RowAction
+            icon={FiTrash2}
+            label="Delete"
             isDisabled={!canEdit}
             onPress={() => setPendingDelete(row)}
-          >
-            Delete
-          </RowAction>
+          />
         </RowActionRow>
       ),
     },

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -1,6 +1,7 @@
 import { Button, Spinner } from "@heroui/react"
 import { Link } from "@tanstack/react-router"
 import { type ReactNode, useEffect, useRef, useState } from "react"
+import { FiActivity, FiEdit2, FiTrash2 } from "react-icons/fi"
 import type {
   CreateStoredProviderRequest,
   ProviderHealth,
@@ -1185,26 +1186,28 @@ export function ProvidersPage() {
           <div className="flex flex-col items-end gap-1.5">
             <RowActionRow>
               <RowAction
+                icon={FiActivity}
+                label="Test"
                 // A row whose key can't be decrypted can't be tested; Edit/Delete still recover it.
                 isDisabled={
                   tests[row.instance]?.status === "pending" ||
                   row.stored?.decryptable === false
                 }
                 onPress={() => void runTest(row.instance)}
-              >
-                Test
-              </RowAction>
+              />
               <RowAction
+                icon={FiEdit2}
+                label="Edit"
                 onPress={() => {
                   setAddOpen(false)
                   setEditing(row.instance)
                 }}
-              >
-                Edit
-              </RowAction>
-              <RowAction onPress={() => setPendingDelete(row.instance)}>
-                Delete
-              </RowAction>
+              />
+              <RowAction
+                icon={FiTrash2}
+                label="Delete"
+                onPress={() => setPendingDelete(row.instance)}
+              />
             </RowActionRow>
             <TestOutcome state={tests[row.instance]} />
           </div>

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@heroui/react"
 import { useCallback, useMemo, useRef, useState } from "react"
+import { FiEdit2, FiList, FiTrash2 } from "react-icons/fi"
 
 import type { AliasResponse, PolicySpec, RoutingPolicyResponse } from "@/client"
 import { CopyableValue } from "@/design-system/actions/CopyField"
@@ -399,14 +400,14 @@ export function RoutingPage() {
           <span className="text-muted">—</span>
         ) : (
           <RowAction
+            icon={FiList}
+            label={expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
             onPress={() =>
               setExpanded((current) =>
                 current === rowKeyOf(policy) ? null : rowKeyOf(policy),
               )
             }
-          >
-            {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
-          </RowAction>
+          />
         )
         return policy.source === "config" ? (
           <RowActionRow>
@@ -418,6 +419,8 @@ export function RoutingPage() {
             {readiness}
             {isEditableInForm(policy.spec) ? (
               <RowAction
+                icon={FiEdit2}
+                label="Edit"
                 onPress={() => {
                   // `setAdding(false)` cannot fire while the create dialog is
                   // open (its backdrop covers the table and `ariaHideOutside`
@@ -427,18 +430,18 @@ export function RoutingPage() {
                   setAdding(false)
                   setEditing(policy)
                 }}
-              >
-                Edit
-              </RowAction>
+              />
             ) : (
               <span className="max-w-xs text-xs text-muted">
                 Uses options this form cannot show yet. Edit it through the API
                 so nothing is lost.
               </span>
             )}
-            <RowAction onPress={() => setPendingDelete(policy)}>
-              Delete
-            </RowAction>
+            <RowAction
+              icon={FiTrash2}
+              label="Delete"
+              onPress={() => setPendingDelete(policy)}
+            />
           </RowActionRow>
         )
       },

--- a/web/src/features/tools/WorkspaceMcpServersCard.tsx
+++ b/web/src/features/tools/WorkspaceMcpServersCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { FiEdit2, FiTrash2 } from "react-icons/fi"
 
 import type { WorkspaceMcpServer } from "@/client"
 import { Button } from "@/design-system/actions/Button"
@@ -207,8 +208,16 @@ export function WorkspaceMcpServersCard({
       header: "",
       cell: (row) => (
         <RowActionRow>
-          <RowAction onPress={() => openEdit(row)}>Edit</RowAction>
-          <RowAction onPress={() => openDelete(row)}>Delete</RowAction>
+          <RowAction
+            icon={FiEdit2}
+            label="Edit"
+            onPress={() => openEdit(row)}
+          />
+          <RowAction
+            icon={FiTrash2}
+            label="Delete"
+            onPress={() => openDelete(row)}
+          />
         </RowActionRow>
       ),
     })

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@heroui/react"
 import { type RefObject, useEffect, useMemo, useRef, useState } from "react"
+import { FiEdit2, FiTrash2 } from "react-icons/fi"
 
 import type { Budget, Workspace, WorkspaceBudgetDefault } from "@/client"
 import { RowAction, RowActionRow } from "@/design-system/actions/RowAction"
@@ -786,34 +787,32 @@ export function WorkspacesPage() {
         cell: (workspace) => (
           <RowActionRow>
             <RowAction
+              icon={FiEdit2}
+              label="Edit"
               isDisabled={!manages}
               onPress={() => {
                 setCreating(false)
                 setEditing(workspace.id)
               }}
-            >
-              Edit
-            </RowAction>
+            />
             {/* The server keeps every organization on at least one workspace
                 (`LastWorkspaceError`), and first boot is the one-workspace
                 state, so the ordinary case would be a button that always
                 refuses. Say why instead of offering the refusal. The reason
                 goes in the name, following the membership controls: a disabled
-                control takes no focus, so a tooltip would reach a pointer and
-                nothing else. */}
-            <span title={isOnlyWorkspace ? LAST_WORKSPACE_REASON : undefined}>
-              <RowAction
-                ariaLabel={
-                  isOnlyWorkspace
-                    ? `Delete ${workspace.name} (${LAST_WORKSPACE_REASON})`
-                    : undefined
-                }
-                isDisabled={!manages || isOnlyWorkspace}
-                onPress={() => setDeleting(workspace)}
-              >
-                Delete
-              </RowAction>
-            </span>
+                control takes no focus, so the name is what reaches assistive
+                tech, and `RowAction` repeats it on a `title` for the pointer. */}
+            <RowAction
+              icon={FiTrash2}
+              label="Delete"
+              ariaLabel={
+                isOnlyWorkspace
+                  ? `Delete ${workspace.name} (${LAST_WORKSPACE_REASON})`
+                  : undefined
+              }
+              isDisabled={!manages || isOnlyWorkspace}
+              onPress={() => setDeleting(workspace)}
+            />
           </RowActionRow>
         ),
       },

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2778,8 +2778,8 @@ main {
   min-width: 140px;
 }
 .otari-mcp-table .table__column[data-key="actions"] {
-  width: 160px;
-  min-width: 160px;
+  width: 96px;
+  min-width: 96px;
 }
 .otari-budgets-table .table__row .table__cell {
   height: 58px;
@@ -2794,8 +2794,8 @@ main {
   min-width: 90px;
 }
 .otari-budgets-table .table__column[data-key="actions"] {
-  width: 240px;
-  min-width: 240px;
+  width: 144px;
+  min-width: 144px;
 }
 /* The slack absorber, so the lanes after the identity stay next to it. */
 .otari-budgets-table .table__column[data-key="default-for"] {
@@ -2840,8 +2840,8 @@ main {
   min-width: 190px;
 }
 .otari-accounts-table .table__column[data-key="actions"] {
-  width: 220px;
-  min-width: 220px;
+  width: 96px;
+  min-width: 96px;
 }
 /* The slack absorber, so the lanes after the identity stay adjacent to it. */
 .otari-accounts-table .table__column[data-key="organizations"] {
@@ -2875,8 +2875,8 @@ main {
   min-width: 220px;
 }
 .otari-workspaces-table .table__column[data-key="actions"] {
-  width: 190px;
-  min-width: 190px;
+  width: 96px;
+  min-width: 96px;
 }
 .otari-workspaces-table .table__column[data-key="name"],
 .otari-workspaces-table .table__cell[data-key="name"] {
@@ -2944,8 +2944,8 @@ main {
   min-width: 130px;
 }
 .otari-rate-overrides-table .table__column[data-key="actions"] {
-  width: 160px;
-  min-width: 160px;
+  width: 96px;
+  min-width: 96px;
 }
 /* One width for both, so the model key occupies the same lane in the catalog
    and in the overrides below it. */
@@ -2990,6 +2990,10 @@ main {
   width: 120px;
   min-width: 120px;
 }
+/* The one lane whose armed state is wider than its resting one: the archive
+   confirm swaps a glyph for the word "Archive" and a Cancel beside it, and the
+   column is fixed, so the width is the armed lane's rather than the three
+   glyphs'. Sized to the words, or arming one row would reflow every column. */
 .otari-provider-keys-table .table__column[data-key="actions"] {
   width: 230px;
   min-width: 230px;
@@ -3030,8 +3034,8 @@ main {
   min-width: 120px;
 }
 .otari-members-table .table__column[data-key="actions"] {
-  width: 200px;
-  min-width: 200px;
+  width: 144px;
+  min-width: 144px;
 }
 .otari-members-table .table__column[data-key="member"],
 .otari-members-table .table__cell[data-key="member"] {
@@ -3067,7 +3071,7 @@ main {
   width: 120px;
 }
 .otari-keys-table .table__column[data-key="actions"] {
-  width: 250px;
+  width: 192px;
 }
 .otari-keys-table .otari-table .otari-detail-row > td {
   background-color: transparent;


### PR DESCRIPTION
## Description

Every action in a dashboard table row used to be a word: "History Edit Delete" on
budgets, "Edit Block Remove" on the member roster, four of them on keys. Nothing said
they were pressable, and because the words repeat on every row an operator re-reads the
same lane on the way down a table. They are now the glyphs the actions mean, with the
word kept as the control's name: a screen reader reads it, speech input matches it, and
hovering or tabbing to one spells it out in a tooltip. Ten pages and eleven lanes
convert, and the tables get the space back that the words were taking.

This is also the first version of a row action that a finger can reliably hit. The
target is 44px where the text was whatever the word happened to measure.

Two smaller things the work turned up and fixed:

The shared tooltip could not be put on a button. It wrapped whatever it was given in an
element the library reports as a button, which is right for labelling something that is
not a control and wrong around a real one: a screen reader announced the name twice,
tabbing stopped on it twice, and any test looking for the button by name found two. It
now hands a native control the trigger's own behavior instead, so there is one button.

And the Otari mark at the top left of the sidebar sat on the same gray fill a selected
sidebar row wears, so it read both as a logo on a gray box and as the one row in the
rail that had been chosen. The fill is gone; the mark keeps its place in the lane.

Three glyphs are worth naming because the vocabulary has to be consistent to be worth
anything: an X takes something away, a strike turns something off, and a toggle's glyph
carries its state. So removing someone's operator access is a user-with-an-X while
deactivating their account is the strike, which is the same strike the roster's Block
already wears.

## How to test it locally

```sh
make dashboard
uv run otari serve
```

Then sign in and look at **Keys**, **Budgets**, **Workspaces**, **Members & roles**,
**Providers**, **Routing**, **Model pricing**, **Tools > MCP servers**, **Organization >
Provider keys** and **Accounts**. In each table's trailing lane:

- the actions are glyphs, muted, with no box, and they fill in on hover
- hovering or tabbing to one names it
- a refused action stays visible, dims, and says why when you point at it (try Delete on
  the only workspace, or Remove on the last owner)
- tabbing through a lane stops once per action
- the two-step confirms still ask twice in words: Archive on Organization > Provider
  keys arms into "Archive" and a Cancel, and Regenerate on Keys still opens its strip

Also worth a look: the product mark at the top of the sidebar has no gray tile behind it
any more.

Already covered by the automated checks, so there is nothing to re-prove by hand:

- `pnpm --dir web test` (5662 tests) including new cases on `RowAction` for the
  accessible name, the glyph being hidden from assistive tech, the 44px target, the
  refusal reason reaching a pointer, and the one-control-per-action rule; new
  `Tooltip.test.tsx` covering both trigger forms; and a new `WorkspaceSwitcher` case
  pinning the mark's lane as unpainted
- `pnpm --dir web run lint` and `pnpm --dir web run typecheck`
- the behavioral e2e suite, 43 tests across the `onboarding`, `seed`, `parity` and
  `hybrid` projects, which drives these very lanes (edit a budget, disable then delete a
  key, remove a member, rename and delete a workspace, delete a policy) and passes
  unchanged, because the accessible names did not move
- the Storybook sweep, 406 stories in both themes, clean
- `make lint` (architecture check, then Ruff)

Two things a reviewer should weigh rather than verify:

A glyph's tooltip does not exist on a phone, and the dashboard's tables scroll sideways
at desktop width rather than becoming cards, so a touch operator gets the glyph and the
name but not the spelled-out label. The names are all conventional (pencil, trash,
clock, shield) and the accessible name is always present, but it is a real trade and
[motion-and-access.md](web/design/motion-and-access.md) is the rule it is traded
against.

A HeroUI `Button`, and so `IconButton`, still cannot use the tooltip's new control form:
its props are react-aria's rather than the DOM's, so the trigger's handlers do not
typecheck against it. Those call sites keep the wrapper and the duplicate name. It is
written down in [overlays.md](web/design/overlays.md) rather than solved here.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2123

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

No API contract changed here: the diff is `web/` only, so the spec, the Postman
collection, `web/src/client/schema.ts` and `web/src/routeTree.gen.ts` are all untouched
and their drift checks pass. No page was added, so no screenshot entry is owed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

The glyph choices for the Accounts page were decided by the author, not the model: the
first pass had the strike on the removal and the X on the deactivation, which is
backwards, and the swap is what set the X-takes-away / strike-turns-off rule the rest of
the vocabulary now follows.

The tooltip's duplicate-button problem was found by measuring the rendered DOM in a real
browser rather than in jsdom, where HeroUI's trigger contributes nothing and both forms
look identical. Worth knowing if anyone reaches for that component again.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
