### PR TITLE
fix(dashboard): let the tools pages fill the page column

### DIFF
--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -243,6 +243,20 @@ describe("ToolsGuardrailsPage", () => {
     )
   })
 
+  it("leaves the page column to the shell rather than capping its own", async () => {
+    mockApi()
+    const { container } = renderWithClient(
+      <ToolsGuardrailsPage only="web_search" />,
+    )
+    await screen.findByLabelText(WEB_SEARCH_URL)
+
+    // `<main>` supplies the page column and centers it, so a cap here is not a
+    // readable measure: it is the whole page pushed against the left edge with
+    // the rest of a wide viewport left empty (otari-ai#2124). Every other page
+    // in the tree opens with `flex flex-col` and no cap of its own.
+    expect(container.firstElementChild?.className).not.toMatch(/\bmax-w-/)
+  })
+
   it("saves a URL change on blur, with no Save button on the page", async () => {
     const fetchMock = mockApi()
     const user = userEvent.setup()

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -323,7 +323,7 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
   const narrowed = only ? shown[0] : undefined
 
   return (
-    <div className="flex max-w-[56rem] flex-col gap-10 pb-10">
+    <div className="flex flex-col gap-10 pb-10">
       <PageIntro
         title={narrowed?.label ?? "Tools & Guardrails"}
         docsHref={toolsDocs(narrowed?.docsAnchor)}


### PR DESCRIPTION
## Description

The Web search, Code execution and Guardrails pages (and the combined Tools page behind them) were noticeably narrower than every other page in the dashboard. They filled a little over half of a wide window and sat hard against the left edge, so the right-hand third of the screen was empty. Nothing else in the product looks like that, which made the three pages read as unfinished rather than as a deliberate narrow measure.

They now run the full page column, the same width as Settings, MCP servers, Providers and the rest, so their settings rows line up with the grammar used everywhere else. Nothing about what the pages do, save, or read has changed; this is width only.

Fixes mozilla-ai/otari-ai#2124

## How to test it locally

1. `make dashboard`, then run a standalone gateway and sign in.
2. Open **Tools → Web search**, **Code execution** and **Guardrails** on a wide window (1600px or more). The settings groups should reach the same right-hand edge as the page title's column, with no empty band down the right side, and should look the same width as **Settings** in the organization rail.
3. Narrow the window to phone width. Each row still stacks its control under its label, as before.

Already covered by automation:

- `pnpm --dir web test` (5669 tests). `ToolsGuardrailsPage.test.tsx` gains one case asserting the page root carries no width cap; it fails against the previous markup.
- `pnpm --dir web run lint` and `pnpm --dir web run typecheck`.
- The on-demand screenshot suite was run locally for `screenshots-desktop-large-light` to see the result at 1920px.

No backend file changed, so there is no OpenAPI or Postman regeneration here and no Python check to run.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2124

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the three above that need one: the change is dashboard-only, so the checks run were the dashboard's (`pnpm --dir web run lint`, `run typecheck`, `test`); no documentation describes this page's width, and `web/design/layout.md` already says a page opens with no wrapper of its own; and the API contract did not change, so nothing was regenerated.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The fix was written and verified by the agent: it read the issue's screenshots, traced the width to the one page root in the tree that caps itself, checked the result against the other pages' captures, and added the regression test.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
