### PR TITLE
feat(auth): always offer password sign-in, and open signup where configured

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -172,9 +172,18 @@ unknown address does depends on `open_signup`:
   its own. Use it where the deployment serves many tenants.
 
 Either way the response says the same thing whether the address was unknown,
-already claimed, or genuinely just claimed, so the endpoint cannot be used to
-enumerate the roster. Signup needs mail configured, because an account that
-cannot verify its address cannot sign in.
+already claimed, or genuinely just claimed, so its body discloses nothing about
+the address. Response *timing* still does, because the eligible path sends mail
+before it answers; that is [otari#720](https://github.com/mozilla-ai/otari/issues/720)
+and it applies to both postures.
+
+Signup needs mail configured, because an account that cannot verify its address
+cannot sign in.
+
+Open signup puts tenant creation on an unauthenticated route. The per-IP
+throttle on the public auth routes is the only bound on it today, and nothing
+expires the organization an unverified signup leaves behind, so run it behind
+whatever edge controls the deployment has.
 
 ## Invitations
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -129,6 +129,11 @@ opaque, HttpOnly session cookie. After the operator sets an email and password,
 the dashboard uses that identity for sign-in; the master key remains an API
 credential and recovery path.
 
+Email and password sign-in is offered whenever any active identity holds a
+password, not only once the operator has claimed the deployment. A member added
+to the roster and signed up before that point signs in on the same screen, which
+offers the master-key box beside the form while both credentials still work.
+
 Sessions are revocable and expire after `dashboard_session_ttl_hours`. Password
 changes, master-key rotation, sign-out, and identity deactivation revoke relevant
 sessions.
@@ -153,6 +158,23 @@ secret. Register this redirect URI with the provider:
 
 OAuth signs in an existing Otari identity whose email the provider verifies. It
 does not provision arbitrary provider accounts.
+
+### Signup
+
+Signup sets a password for an address and sends a verification link. What an
+unknown address does depends on `open_signup`:
+
+- `false` (default): signup only completes an identity an owner or admin already
+  added or invited by address. An address nobody has added gets no account. This
+  is the posture a single-tenant deployment wants, since anyone who can reach the
+  dashboard can reach the form.
+- `true`: an unknown address is registered, with an organization and workspace of
+  its own. Use it where the deployment serves many tenants.
+
+Either way the response says the same thing whether the address was unknown,
+already claimed, or genuinely just claimed, so the endpoint cannot be used to
+enumerate the roster. Signup needs mail configured, because an account that
+cannot verify its address cannot sign in.
 
 ## Invitations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,20 @@ Those messages can contain invitation or password-reset tokens, so never use it
 where logs are shared. Test delivery from Settings or
 `POST /api/v1/settings/mail/test`.
 
+## Signup
+
+Signup is closed by default: only an address an owner or admin already added or
+invited can set a password. Open it where the deployment serves many tenants and
+each new address should arrive with an organization of its own:
+
+```yaml
+open_signup: true
+```
+
+Mail has to be configured for either posture, since signup sends a verification
+link. See [Access control](access-control.md) for what each posture does with an
+address nobody has added.
+
 ## Built-in tools and guardrails variables
 
 The Tools pages and `GET /api/v1/tool-settings` show effective sandbox, web-search,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -45,6 +45,11 @@ from Account settings. After that, the sign-in page uses the password rather tha
 the master key. The master key remains valid for management API calls and can
 reset the operator password.
 
+The sign-in page offers the email and password form as soon as any identity holds
+a password, which can be before the operator claims the deployment: a member
+added to the roster and signed up signs in there. While both credentials still
+work, the page offers the master-key box beside the form.
+
 ## First-run walkthrough
 
 1. Start Otari in standalone mode.
@@ -132,9 +137,11 @@ workspace roles. Deployment-wide operations require an operator. See
 
 ## Authentication options
 
-Password sign-in is always tied to an existing identity. Optional passkeys,
-Google OAuth, and GitHub OAuth add ways for that identity to sign in; they do not
-make an unknown account a member. OAuth requires `public_base_url` plus the
+Password sign-in is tied to an existing identity, unless the deployment sets
+`open_signup: true`, which lets an unknown address register itself with an
+organization of its own. Optional passkeys, Google OAuth, and GitHub OAuth add
+ways for an existing identity to sign in; they do not make an unknown account a
+member. OAuth requires `public_base_url` plus the
 provider's client ID and secret. Passkeys can instead use `public_base_url`, or
 an explicit `webauthn_rp_id` and `webauthn_allowed_origins` pair.
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3512,6 +3512,11 @@
             "title": "Oauth Providers",
             "type": "array"
           },
+          "open_signup": {
+            "description": "Whether POST /api/v1/auth/signup creates an account for an address nobody has added yet, each with an organization of its own, or only lets an address an admin already put on the roster set its password. The signup page reads as registration or as claiming an invitation accordingly, and the sign-in screen links to it with the wording that matches. False for a hybrid gateway, which holds no identities.",
+            "title": "Open Signup",
+            "type": "boolean"
+          },
           "passkeys_ready": {
             "description": "Whether this deployment can run a passkey ceremony at all: it has a relying-party ID (webauthn_rp_id, or derived from public_base_url) and an origin to serve one from. Distinct from 'passkey' in sign_in_methods, which is narrower and answers whether a registered passkey could sign somebody in *right now*: an operator with none yet needs this one, or the page that registers the first would be hidden from them. False for a hybrid gateway, which issues no session of its own.",
             "title": "Passkeys Ready",
@@ -3540,7 +3545,7 @@
             "type": "string"
           },
           "sign_in_methods": {
-            "description": "How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is the first-boot credential and is offered until the operator identity has a password, which is what claiming the deployment means; 'password' replaces it from then on, and the master key stays the credential for the management API. 'passkey' appears alongside either one when this deployment is configured for WebAuthn and holds at least one passkey that its current relying-party ID can assert. Empty for a hybrid gateway, which issues no session. The login page renders from this rather than trying a credential to find out.",
+            "description": "How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is the first-boot credential and is offered until the operator identity has a password, which is what claiming the deployment means; past that it stays the credential for the management API but is no longer a dashboard login. 'password' is offered while any active identity holds one, which is not the same question and not always the later half of it: a member can hold a password on a deployment whose operator never claimed it, so both typed credentials can appear together. 'passkey' appears alongside either when this deployment is configured for WebAuthn and holds at least one passkey that its current relying-party ID can assert. Empty for a hybrid gateway, which issues no session. The login page renders from this rather than trying a credential to find out.",
             "items": {
               "enum": [
                 "master_key",
@@ -3586,6 +3591,7 @@
           "maintenance_mode",
           "passkeys_ready",
           "oauth_providers",
+          "open_signup",
           "mail_ready"
         ],
         "title": "DeploymentBootstrap",
@@ -10800,10 +10806,10 @@
         "type": "object"
       },
       "SignupRequest": {
-        "description": "Claim an identity already on the roster by setting its password.",
+        "description": "Set a password for an address, claiming or registering it.",
         "properties": {
           "email": {
-            "description": "The address an admin added or invited.",
+            "description": "The address to sign in with. An address an admin added or invited where this deployment keeps signup closed; any address where the bootstrap reports open_signup.",
             "maxLength": 255,
             "title": "Email",
             "type": "string"
@@ -16775,7 +16781,7 @@
     },
     "/api/v1/auth/signup": {
       "post": {
-        "description": "Claim a roster identity, or do nothing: the response never says which.\n\nNo session is minted. A newly claimed identity is hard-blocked from\nsigning in until it verifies, so there is nothing yet to sign it into.",
+        "description": "Claim a roster identity, register a new one, or do nothing: the response never says which.\n\nWhich of the three this deployment will do is ``open_signup``, published in\nthe bootstrap so the page can say so before anyone types an address.\n\nNo session is minted. A newly claimed or registered identity is hard-blocked\nfrom signing in until it verifies, so there is nothing yet to sign it into.",
         "operationId": "auth-signup",
         "requestBody": {
           "content": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -859,7 +859,7 @@
               },
               "raw": "{\n  \"email\": \"string\",\n  \"password\": \"string\"\n}"
             },
-            "description": "Claim a roster identity, or do nothing: the response never says which.\n\nNo session is minted. A newly claimed identity is hard-blocked from\nsigning in until it verifies, so there is nothing yet to sign it into.",
+            "description": "Claim a roster identity, register a new one, or do nothing: the response never says which.\n\nWhich of the three this deployment will do is ``open_signup``, published in\nthe bootstrap so the page can say so before anyone types an address.\n\nNo session is minted. A newly claimed or registered identity is hard-blocked\nfrom signing in until it verifies, so there is nothing yet to sign it into.",
             "header": [
               {
                 "key": "Content-Type",

--- a/src/gateway/api/routes/auth_signup.py
+++ b/src/gateway/api/routes/auth_signup.py
@@ -5,10 +5,13 @@ routes: the person completing signup or opening a verification link holds no
 master key and no session yet, and the token or address in the request is
 their whole proof of anything here.
 
-Signup only ever claims an identity ``organization_service`` already put on
-the roster (an admin added or invited the address). It never creates one from
-nothing; see ``user_service.create_user_for_signup``'s own docstring for why.
-It is also enumeration-safe the same way resend and reset-request are: the
+What signup may do depends on ``open_signup``. Off, the default, it only ever
+claims an identity ``organization_service`` already put on the roster (an admin
+added or invited the address) and creates nothing from nothing. On, an address
+nobody has added is registered instead, with an organization of its own. See
+``user_service.create_user_for_signup``'s own docstring for both.
+
+Either way it is enumeration-safe the same way resend and reset-request are: the
 response never says whether the address was unknown, already claimed, or
 genuinely just claimed.
 """
@@ -43,9 +46,15 @@ _MAX_SUBMITTED_TOKEN = 512
 
 
 class SignupRequest(BaseModel):
-    """Claim an identity already on the roster by setting its password."""
+    """Set a password for an address, claiming or registering it."""
 
-    email: str = Field(max_length=MAX_EMAIL_LENGTH, description="The address an admin added or invited.")
+    email: str = Field(
+        max_length=MAX_EMAIL_LENGTH,
+        description=(
+            "The address to sign in with. An address an admin added or invited where this "
+            "deployment keeps signup closed; any address where the bootstrap reports open_signup."
+        ),
+    )
     password: str = Field(
         min_length=8,
         max_length=_MAX_SUBMITTED_PASSWORD,
@@ -77,7 +86,12 @@ class ResendVerificationResponse(BaseModel):
     message: str = Field(description="The same message whether or not the address has anything to verify.")
 
 
+# One message per posture, chosen by the deployment's setting and never by the
+# address: that is what keeps it enumeration-safe. The closed wording would
+# misdescribe an open deployment (where there is no roster to be on) and the
+# open wording would promise a closed one an account it will not create.
 _SIGNUP_MESSAGE = "If this address is on our roster and unclaimed, check your email to verify it, then sign in."
+_OPEN_SIGNUP_MESSAGE = "If this address can be signed up, check your email to verify it, then sign in."
 _RESEND_MESSAGE = "If this address is registered and unverified, a verification email is on its way."
 
 
@@ -90,10 +104,13 @@ async def signup(
     config: Annotated[GatewayConfig, Depends(get_config)],
     growth: GrowthSignalPortDep,
 ) -> SignupResponse:
-    """Claim a roster identity, or do nothing: the response never says which.
+    """Claim a roster identity, register a new one, or do nothing: the response never says which.
 
-    No session is minted. A newly claimed identity is hard-blocked from
-    signing in until it verifies, so there is nothing yet to sign it into.
+    Which of the three this deployment will do is ``open_signup``, published in
+    the bootstrap so the page can say so before anyone types an address.
+
+    No session is minted. A newly claimed or registered identity is hard-blocked
+    from signing in until it verifies, so there is nothing yet to sign it into.
     """
     throttle_public_auth(request)
     try:
@@ -120,7 +137,7 @@ async def signup(
             full_name=claimed.full_name,
             created_at=claimed.created_at,
         )
-    return SignupResponse(message=_SIGNUP_MESSAGE)
+    return SignupResponse(message=_OPEN_SIGNUP_MESSAGE if config.open_signup else _SIGNUP_MESSAGE)
 
 
 @router.post("/verify-email")

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -31,7 +31,7 @@ from gateway.api.deps import get_config, get_db_if_needed
 from gateway.core.config import API_ROOT, GatewayConfig
 from gateway.log_config import logger
 from gateway.services.maintenance_mode_service import is_maintenance_mode
-from gateway.services.tenancy.user_service import operator_has_password
+from gateway.services.tenancy.user_service import operator_has_password, password_sign_in_possible
 from gateway.services.tenancy.webauthn_service import has_any_credential
 
 router = APIRouter(prefix="/bootstrap", tags=["bootstrap"])
@@ -212,12 +212,15 @@ class DeploymentBootstrap(BaseModel):
     )
     sign_in_methods: list[SignInMethod] = Field(
         description=(
-            "How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is the "
-            "first-boot credential and is offered until the operator identity has a password, which "
-            "is what claiming the deployment means; 'password' replaces it from then on, and the "
-            "master key stays the credential for the management API. 'passkey' appears alongside "
-            "either one when this deployment is configured for WebAuthn and holds at least one "
-            "passkey that its current relying-party ID can assert. Empty for a hybrid gateway, "
+            "How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is "
+            "the first-boot credential and is offered until the operator identity has a password, "
+            "which is what claiming the deployment means; past that it stays the credential for "
+            "the management API but is no longer a dashboard login. 'password' is offered while "
+            "any active identity holds one, which is not the same question and not always the "
+            "later half of it: a member can hold a password on a deployment whose operator never "
+            "claimed it, so both typed credentials can appear together. 'passkey' appears "
+            "alongside either when this deployment is configured for WebAuthn and holds at least "
+            "one passkey that its current relying-party ID can assert. Empty for a hybrid gateway, "
             "which issues no session. The login page renders from this rather than trying a "
             "credential to find out."
         )
@@ -249,6 +252,15 @@ class DeploymentBootstrap(BaseModel):
             "refused. Additive to sign_in_methods rather than part of it: an OAuth sign-in coexists "
             "with whichever typed credential is current, the way a passkey does. Empty for a hybrid "
             "gateway, which issues no session."
+        )
+    )
+    open_signup: bool = Field(
+        description=(
+            "Whether POST /api/v1/auth/signup creates an account for an address nobody has "
+            "added yet, each with an organization of its own, or only lets an address an admin "
+            "already put on the roster set its password. The signup page reads as registration "
+            "or as claiming an invitation accordingly, and the sign-in screen links to it with "
+            "the wording that matches. False for a hybrid gateway, which holds no identities."
         )
     )
     mail_ready: bool = Field(
@@ -299,6 +311,7 @@ async def get_bootstrap(
             passkeys_ready=False,
             oauth_providers=[],
             mail_ready=False,
+            open_signup=False,
         )
     assert db is not None  # get_db_if_needed yields a session outside hybrid mode
     # Hosted is standalone's multi-tenant sibling and differs here in exactly two
@@ -324,25 +337,39 @@ async def get_bootstrap(
         passkeys_ready=config.webauthn_enabled,
         oauth_providers=list(config.oauth_providers),
         mail_ready=config.mail_ready,
+        # Gated on mail as well as on the setting, and not only because the
+        # route refuses without it: an operator who turned open signup on and
+        # has no transport would otherwise get a page inviting registrations
+        # that every visitor's submit answers with a 503.
+        open_signup=config.open_signup and config.mail_ready,
     )
 
 
 async def _sign_in_methods(db: AsyncSession, config: GatewayConfig) -> list[SignInMethod]:
     """How this deployment may be signed in to right now, sorted.
 
-    Two independent questions. Which of the two *typed* credentials
-    ``POST /api/v1/auth/session`` accepts is the first, and they are mutually
-    exclusive: the master key until the operator identity holds a password
-    (otari#702), that password from then on. Whether a passkey can sign somebody in is the second, and it
-    is additive, because ``POST /api/v1/auth/webauthn/authenticate`` is a separate
-    endpoint that does not displace either.
+    Three independent questions, and every method here is published only when it
+    could actually answer.
 
-    A passkey is published only when one could actually answer: the deployment
-    has a relying-party ID *and* holds at least one credential registered under
-    it. Advertising the method on a deployment with no passkeys would put a
-    button on the login page whose only outcome is the browser reporting that it
-    found nothing, which is the same trap the master-key box would be on a
-    claimed deployment.
+    ``master_key`` is the first-boot credential, and it is offered until the
+    operator identity holds a password (otari#702), which is what claiming the
+    deployment means. Past that point ``POST /api/v1/auth/session`` refuses it
+    with a 403, so offering it would be offering a refusal.
+
+    ``password`` is offered while some active identity holds one. Not the
+    operator's alone (otari-ai#2100): that endpoint verifies a password against
+    whichever identity the address resolves to and has never consulted the
+    operator's row, so a member who signed up on a deployment its operator never
+    claimed can sign in, and used to be shown the master-key box instead of the
+    form that would have worked. The two typed credentials are therefore
+    additive rather than exclusive, and an unclaimed deployment with members on
+    it publishes both.
+
+    ``passkey`` is the third, additive for a different reason:
+    ``POST /api/v1/auth/webauthn/authenticate`` is a separate endpoint that
+    displaces neither. It needs the deployment to have a relying-party ID *and*
+    to hold at least one credential registered under it, or the button's only
+    outcome is the browser reporting that it found nothing.
 
     A database failure answers "none" rather than propagating. This route is the
     first thing the dashboard shell fetches, so a 500 here is a blank page
@@ -353,12 +380,16 @@ async def _sign_in_methods(db: AsyncSession, config: GatewayConfig) -> list[Sign
     """
     try:
         claimed = await operator_has_password(db)
+        passwords = await password_sign_in_possible(db)
         passkeys = await has_any_credential(db, config)
     except SQLAlchemyError:
         logger.warning("Could not read which sign-in methods this deployment offers", exc_info=True)
         return []
-    typed: SignInMethod = "password" if claimed else "master_key"
-    methods: list[SignInMethod] = [typed]
+    methods: list[SignInMethod] = []
+    if not claimed:
+        methods.append("master_key")
+    if passwords:
+        methods.append("password")
     if passkeys:
         methods.append("passkey")
     return sorted(methods)

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -223,6 +223,9 @@ _DELIBERATELY_OMITTED: tuple[str, ...] = (
     "files_s3_region",
     "oauth_github_client_id",
     "oauth_google_client_id",
+    # Already published to the dashboard unauthenticated, by GET /api/v1/bootstrap,
+    # because the signup page has to read it before anyone can sign in.
+    "open_signup",
     "router_alpha",
     "router_confidence_floor",
     "router_embedding_model",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -643,6 +643,17 @@ class GatewayConfig(BaseSettings):
         ge=1,
         description="How long an organization invitation stays acceptable, in hours (default 7 days).",
     )
+    open_signup: bool = Field(
+        default=False,
+        description=(
+            "Whether POST /api/v1/auth/signup may create an identity from nothing, each with an "
+            "organization and workspace of its own. False (the default) keeps signup to claiming "
+            "an address an admin already put on the roster, which is what a single-tenant "
+            "deployment wants: anyone who could reach the dashboard could otherwise register on "
+            "it. True is the multi-tenant posture a control plane runs, and it needs mail "
+            "configured, since a self-serve account is unusable until its address is verified."
+        ),
+    )
     email_verification_expiry_hours: int = Field(
         default=48,
         ge=1,

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -651,7 +651,11 @@ class GatewayConfig(BaseSettings):
             "an address an admin already put on the roster, which is what a single-tenant "
             "deployment wants: anyone who could reach the dashboard could otherwise register on "
             "it. True is the multi-tenant posture a control plane runs, and it needs mail "
-            "configured, since a self-serve account is unusable until its address is verified."
+            "configured, since a self-serve account is unusable until its address is verified. "
+            "Turning it on puts tenant creation on an unauthenticated route: the per-IP throttle "
+            "that guards the public auth routes is the only bound on it, and nothing yet expires "
+            "the organization an unverified signup leaves behind, so run it behind whatever edge "
+            "controls the deployment has."
         ),
     )
     email_verification_expiry_hours: int = Field(

--- a/src/gateway/repositories/tenancy/user_repository.py
+++ b/src/gateway/repositories/tenancy/user_repository.py
@@ -104,6 +104,31 @@ class UserRepository(BaseRepository[User, UserCreate, UserBase]):
         await self.db.refresh(user)
         return user
 
+    async def any_active_with_password(self) -> bool:
+        """Whether some active identity on this deployment could sign in with a password.
+
+        Asked by the bootstrap so the sign-in screen offers the email and
+        password form to anyone who has one, not only once the *operator*
+        identity does (otari-ai#2100). ``POST /api/v1/auth/session`` has always
+        accepted a password from any identity; publishing the method off the
+        operator alone is what left a member who signed up on an unclaimed
+        deployment looking at a master-key box they hold no key for.
+
+        Deactivated rows are excluded because ``authenticate`` refuses them, so
+        a deployment whose only password-holder has been deactivated is one
+        where the form could not work.
+
+        A ``LIMIT 1`` existence check rather than a count: the answer is a
+        boolean and the table is unbounded.
+        """
+        result = await self.db.execute(
+            select(col(User.id))
+            .where(col(User.hashed_password).is_not(None))
+            .where(col(User.is_active).is_(True))
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def list_all(self, *, skip: int = 0, limit: int = 100) -> tuple[list[User], int]:
         """Return a page of every identity on the deployment, plus the total.
 

--- a/src/gateway/services/tenancy/organization_service.py
+++ b/src/gateway/services/tenancy/organization_service.py
@@ -174,6 +174,17 @@ def _generated_slug(name: str) -> str:
     return f"{stem or _SLUG_FALLBACK_STEM}-{secrets.token_hex(4)}"
 
 
+def _default_organization_name(email: str, full_name: str | None) -> str:
+    """What to call the organization a self-serve signup lands in.
+
+    The platform's own wording, falling back to the address's local part when no
+    name was given, because the alternative is every such organization sharing
+    one name in a switcher that shows nothing else about them.
+    """
+    who = (full_name or "").strip() or email.split("@", 1)[0]
+    return f"{who}'s organization"
+
+
 # The most workspaces a switcher seed carries. Above the repository's paging
 # default so the common deployment is never truncated, and bounded so one
 # unusually large organization cannot make every context read unbounded.
@@ -429,6 +440,67 @@ class OrganizationService:
             raise
 
         return OrganizationPublic.model_validate(organization)
+
+    async def provision_signup_tenancy(self, *, email: str, full_name: str | None) -> User:
+        """Create an identity for an address nobody has added, with a tenant of its own.
+
+        The self-serve half of signup (otari-ai#2100), reached only where
+        ``open_signup`` is on: an address an admin already put on the roster is
+        claimed by ``user_service.create_user_for_signup`` instead and nothing
+        here runs. The rows are the ones every other identity on the deployment
+        holds, which is the point: an account that arrived this way is not a
+        second kind of member, so nothing downstream has to ask how it got here.
+
+        The sibling of ``create_organization_for_user`` with the order reversed.
+        That one has a caller already and creates an organization for them; this
+        one has an address and no identity yet, and ``User.active_organization_id``
+        is not nullable, so the organization is created first and stamped with
+        its creator once the identity exists. No role check for the same reason
+        that one gives, and a stronger one: there is no organization to hold a
+        role in until this returns.
+
+        **Flushes and does not commit**, unlike every other write on this
+        service. The caller is mid-unit-of-work: signup hashes a password and
+        mints a verification token onto the row this returns, and an account
+        committed here without them would be a live, password-less,
+        unverifiable identity if the rest of that call failed.
+
+        The slug carries ``_generated_slug``'s random suffix, so two people
+        registering under the same name do not collide and the organization can
+        never be mistaken for first boot's ``default``.
+        """
+        address = _validated_email(email)
+        name = _default_organization_name(address, full_name)
+        organization = await self.organizations.create_organization(
+            name=name,
+            slug=_generated_slug(name),
+            created_by_user_id=None,
+        )
+        identity = await self.users.create_local_identity(
+            full_name=full_name,
+            email=address,
+            active_organization_id=organization.id,
+        )
+        await self.organizations.update_organization(organization, {"created_by_user_id": identity.id})
+        await self.members.create_membership(
+            organization_id=organization.id,
+            user_id=identity.id,
+            role="owner",
+        )
+        # The request-plane owner every other roster path mints beside a
+        # membership (`create_active_organization_member_for_user`), without
+        # which this identity could not hold a key in the organization it owns.
+        await get_or_create_attribution_user(self.db, user_id=str(identity.id), alias=address)
+        workspace = await self.workspace_rows.create_workspace(
+            name=DEFAULT_WORKSPACE_NAME,
+            organization_id=organization.id,
+            created_by_user_id=identity.id,
+        )
+        await self._apply_workspace_assignments(
+            user_id=identity.id,
+            assignments=[WorkspaceAssignmentRequest(workspace_id=workspace.id, role="owner")],
+        )
+        return identity
 
     async def list_organization_memberships_for_user(
         self,

--- a/src/gateway/services/tenancy/organization_service.py
+++ b/src/gateway/services/tenancy/organization_service.py
@@ -174,15 +174,29 @@ def _generated_slug(name: str) -> str:
     return f"{stem or _SLUG_FALLBACK_STEM}-{secrets.token_hex(4)}"
 
 
+# What ``_default_organization_name`` wraps its subject in, and how much of the
+# column that leaves. ``Organization.name`` holds 255 and both possible subjects
+# reach it on their own (``SignupRequest.full_name`` is capped at 255, and so is
+# an address), so an untruncated name overflows the column and fails the flush on
+# a signup that is otherwise perfectly valid.
+_DEFAULT_ORGANIZATION_NAME_SUFFIX = "'s organization"
+_DEFAULT_ORGANIZATION_SUBJECT_LIMIT = 255 - len(_DEFAULT_ORGANIZATION_NAME_SUFFIX)
+
+
 def _default_organization_name(email: str, full_name: str | None) -> str:
     """What to call the organization a self-serve signup lands in.
 
     The platform's own wording, falling back to the address's local part when no
     name was given, because the alternative is every such organization sharing
     one name in a switcher that shows nothing else about them.
+
+    Truncated to fit the column rather than validated against it: the subject is
+    a name somebody typed about themselves, not a value with a contract, so a
+    long one is shortened where refusing the signup over it would be absurd. The
+    owner can rename the organization afterwards either way.
     """
     who = (full_name or "").strip() or email.split("@", 1)[0]
-    return f"{who}'s organization"
+    return f"{who[:_DEFAULT_ORGANIZATION_SUBJECT_LIMIT].strip()}{_DEFAULT_ORGANIZATION_NAME_SUFFIX}"
 
 
 # The most workspaces a switcher seed carries. Above the repository's paging

--- a/src/gateway/services/tenancy/user_service.py
+++ b/src/gateway/services/tenancy/user_service.py
@@ -322,12 +322,21 @@ async def create_user_for_signup(
                 email=address,
                 full_name=full_name,
             )
-        except IntegrityError:
+        except IntegrityError as exc:
             # Two registrations of the same address at once. The unique index on
             # email decides, and the loser answers like every other
             # enumeration-safe path rather than reporting a 500 or admitting
             # that the address is now taken.
+            #
+            # Matched on that index rather than on "an IntegrityError happened",
+            # the same discrimination ``update_password`` already makes with
+            # this helper: the other constraints this unit of work can violate
+            # (the organization slug, a membership) are not a taken address, and
+            # swallowing one as though it were would answer a failed
+            # registration with the sentence that says it succeeded.
             await db.rollback()
+            if not _is_email_conflict(exc):
+                raise
             return None
 
     identity.full_name = identity.full_name or full_name

--- a/src/gateway/services/tenancy/user_service.py
+++ b/src/gateway/services/tenancy/user_service.py
@@ -79,6 +79,7 @@ from gateway.services.tenancy.errors import (
     UnmodifiedPasswordError,
     VerificationTokenInvalidError,
 )
+from gateway.services.tenancy.organization_service import OrganizationService
 from gateway.services.tenancy.password_reset_email import render_password_reset_email
 from gateway.services.tenancy.provisioning_service import load_bootstrap_identity
 from gateway.services.tenancy.tokens import generate_token, hash_token
@@ -244,15 +245,25 @@ async def create_user_for_signup(
     full_name: str | None = None,
     terms_accepted: bool = False,
 ) -> User | None:
-    """Claim an identity ``organization_service`` already put on the roster, or do nothing.
+    """Claim an identity ``organization_service`` already put on the roster, register a new
+    one where the deployment allows it, or do nothing.
 
-    This edition's signup only ever completes an identity an admin already
-    added or invited by address (password-less, per that service's own
-    docstrings): it never creates one from nothing. Enumeration-safe the same
-    way ``resend_verification_email`` and ``request_password_reset`` are: an
-    address nobody has touched, one that already has a password, and one whose
-    identity has been deactivated all return with nothing written and nothing
-    mailed, and only a genuinely pending identity is claimed. Deactivation is
+    Which of the three depends on ``open_signup`` (otari-ai#2100). Off, the
+    default and the single-tenant posture, this only ever completes an identity
+    an admin already added or invited by address (password-less, per
+    ``organization_service``'s own docstrings) and creates nothing from nothing,
+    because on a deployment with one tenant anybody who can reach the dashboard
+    could otherwise join it. On, an address nobody has added is registered
+    instead, with an organization and workspace of its own
+    (``OrganizationService.provision_signup_tenancy``), which is how a control
+    plane serving many tenants takes its first member of each.
+
+    Enumeration-safe the same way ``resend_verification_email`` and
+    ``request_password_reset`` are, and the setting does not change that: an
+    address that already has a password and one whose identity has been
+    deactivated return with nothing written and nothing mailed, whichever way it
+    is set, and an unknown address is either registered or ignored in silence.
+    The response never distinguishes them. Deactivation is
     checked here for the reason ``verify_email`` and ``reset_password`` already
     check it: it has to close every road in, and without this an identity
     deactivated before it ever signed up could still have a password set and a
@@ -267,10 +278,10 @@ async def create_user_for_signup(
     first means a bad password answers the same way whether or not the
     address is real.
 
-    Returns the identity that was claimed, or ``None`` on every enumeration-safe
-    path, so a caller can tell the two apart without the response doing so. That
-    is what lets the route notify ``GrowthSignalPort`` of a genuine signup and
-    stay silent otherwise.
+    Returns the identity that was claimed or registered, or ``None`` on every
+    enumeration-safe path, so a caller can tell the two apart without the
+    response doing so. That is what lets the route notify ``GrowthSignalPort`` of
+    a genuine signup and stay silent otherwise.
 
     Refuses before writing anything if this deployment cannot mail the
     verification link: a signup that could never be verified would strand the
@@ -286,7 +297,7 @@ async def create_user_for_signup(
 
     address = validated_email(email)
     identity = await UserRepository(db).get_by_email(address)
-    if identity is None or identity.hashed_password is not None or not identity.is_active:
+    if identity is not None and (identity.hashed_password is not None or not identity.is_active):
         # Pays the same bcrypt cost the claim path pays hashing a fresh
         # password, so the two cases are closer in wall-clock time than a bare
         # early return would be. Not a full equalization (the claim path also
@@ -295,6 +306,29 @@ async def create_user_for_signup(
         # address with no stored hash.
         await verify_absent_password_async(password)
         return None
+    if identity is None:
+        if not config.open_signup:
+            # The same bcrypt cost as the branch above, for the same reason: an
+            # address this deployment will not register has to answer in about
+            # the time one it would register takes.
+            await verify_absent_password_async(password)
+            return None
+        # Staged into this call's transaction rather than committed on its own,
+        # so the password and verification token below land with it: an account
+        # committed here and nowhere else would be live, password-less and
+        # unverifiable.
+        try:
+            identity = await OrganizationService(db).provision_signup_tenancy(
+                email=address,
+                full_name=full_name,
+            )
+        except IntegrityError:
+            # Two registrations of the same address at once. The unique index on
+            # email decides, and the loser answers like every other
+            # enumeration-safe path rather than reporting a 500 or admitting
+            # that the address is now taken.
+            await db.rollback()
+            return None
 
     identity.full_name = identity.full_name or full_name
     identity.hashed_password = await hash_password_async(password)
@@ -509,6 +543,24 @@ async def operator_has_password(db: AsyncSession) -> bool:
     return operator is not None and operator.hashed_password is not None
 
 
+async def password_sign_in_possible(db: AsyncSession) -> bool:
+    """Whether the email and password form could sign anybody in right now.
+
+    The companion to ``operator_has_password``, and deliberately the broad
+    question that one refuses to answer: any active identity holding a password,
+    not the operator's alone. The two are asked by the bootstrap for different
+    purposes, which is why both exist. ``operator_has_password`` decides whether
+    the *master key* is still a dashboard login, a question only the operator's
+    row can settle. This decides whether the *password* form is worth showing,
+    and every row can settle that, because ``authenticate`` has never cared
+    which identity it is verifying (otari-ai#2100).
+
+    False on a fresh deployment, where the form would be a box with no possible
+    answer, and the master-key branch of the sign-in screen is the only one.
+    """
+    return await UserRepository(db).any_active_with_password()
+
+
 def _validate_password(password: str) -> None:
     """Refuse a password bcrypt would reject or that is too short to be one."""
     if len(password) < MIN_PASSWORD_LENGTH:
@@ -562,6 +614,7 @@ __all__ = [
     "authenticate",
     "create_user_for_signup",
     "operator_has_password",
+    "password_sign_in_possible",
     "request_password_reset",
     "resend_verification_email",
     "reset_password",

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -111,6 +111,7 @@ def test_standalone_reports_a_local_operator_and_the_full_surface_set(tmp_path: 
         "passkeys_ready": False,
         "oauth_providers": [],
         "mail_ready": False,
+        "open_signup": False,
     }
 
 
@@ -212,6 +213,31 @@ def test_mail_ready_turns_on_only_with_a_transport_and_a_public_url(tmp_path: Pa
 
     with TestClient(create_app(ready)) as client:
         assert client.get(f"{API_ROOT}/bootstrap").json()["mail_ready"] is True
+
+
+def test_open_signup_is_published_only_with_mail_to_carry_the_verification(tmp_path: Path) -> None:
+    """Both halves, because the page reads this to decide whether to invite registrations.
+
+    The route refuses without a transport anyway, so publishing the setting
+    alone would advertise a form whose every submit answers 503.
+    """
+    no_mail = _standalone(tmp_path)
+    no_mail.open_signup = True
+
+    with TestClient(create_app(no_mail)) as client:
+        assert client.get(f"{API_ROOT}/bootstrap").json()["open_signup"] is False
+
+    reset_config()
+    reset_db()
+
+    ready = _standalone(tmp_path)
+    ready.open_signup = True
+    ready.smtp_host = "smtp.example.com"
+    ready.mail_from_email = "otari@example.com"
+    ready.public_base_url = "https://otari.example.com"
+
+    with TestClient(create_app(ready)) as client:
+        assert client.get(f"{API_ROOT}/bootstrap").json()["open_signup"] is True
 
 
 # A surface names its router's ``/api/v1/`` prefix, so the prefix is derived from the
@@ -347,8 +373,8 @@ def test_hybrid_reports_no_session_no_surfaces_and_the_hosted_url(monkeypatch: p
         "passkeys_ready": False,
         "oauth_providers": [],
         "mail_ready": False,
+        "open_signup": False,
     }
-
 
 
 def test_hybrid_bootstrap_leaks_no_secret(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_password_sign_in.py
+++ b/tests/unit/test_password_sign_in.py
@@ -793,6 +793,10 @@ def test_a_member_s_password_leaves_an_unclaimed_deployment_on_the_master_key(tm
     Without this, the first member to complete signup retires the dashboard
     login of an operator who never set a password, by an act of their own and
     with no way back through the UI.
+
+    ``password`` is published beside it rather than instead of it
+    (otari-ai#2100): that member can sign in with the password they just set,
+    and the screen used to offer them the master-key box alone.
     """
     with _client(tmp_path) as client:
         headers = {"Otari-Key": MASTER_KEY}
@@ -804,7 +808,7 @@ def test_a_member_s_password_leaves_an_unclaimed_deployment_on_the_master_key(tm
 
         _add_a_password(tmp_path, "member@example.com", PASSWORD)
 
-        assert client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"] == ["master_key"]
+        assert client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"] == ["master_key", "password"]
         client.cookies.clear()
         assert client.post(f"{API_ROOT}/auth/session", json={"master_key": MASTER_KEY}).status_code == 200
 
@@ -838,6 +842,57 @@ def test_a_member_changing_their_password_is_told_the_master_key_still_signs_in(
         assert changed.json() == {"email": "member@example.com", "master_key_sign_in_retired": False}
 
 
+def test_a_member_on_an_unclaimed_deployment_is_offered_the_form_that_works(tmp_path: Path) -> None:
+    """otari-ai#2100: the screen used to show them the one box they cannot fill.
+
+    ``POST /api/v1/auth/session`` verifies a password against whichever identity
+    the address resolves to and has never consulted the operator's row, so this
+    member could always sign in. Publishing the typed credentials as mutually
+    exclusive is what hid the form from them, leaving a master-key box they hold
+    no key for as the only thing on the page.
+    """
+    with _client(tmp_path) as client:
+        headers = {"Otari-Key": MASTER_KEY}
+        _sign_in_with_master_key(client)
+        added = client.post(
+            f"{API_ROOT}/organizations/me/members", json={"email": "member@example.com"}, headers=headers
+        )
+        assert added.status_code == 201, added.text
+        _add_a_password(tmp_path, "member@example.com", PASSWORD)
+        client.cookies.clear()
+
+        assert "password" in client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"]
+        signed_in = client.post(f"{API_ROOT}/auth/session", json={"email": "member@example.com", "password": PASSWORD})
+        assert signed_in.status_code == 200, signed_in.text
+
+
+def test_deactivating_the_only_password_holder_withdraws_the_form(tmp_path: Path) -> None:
+    """Published only while it could answer, the rule every method here follows.
+
+    ``authenticate`` refuses a deactivated identity, so a deployment whose one
+    password-holder has been deactivated is one where the form's only outcome is
+    a refusal.
+    """
+    with _client(tmp_path) as client:
+        headers = {"Otari-Key": MASTER_KEY}
+        _sign_in_with_master_key(client)
+        added = client.post(
+            f"{API_ROOT}/organizations/me/members", json={"email": "member@example.com"}, headers=headers
+        )
+        assert added.status_code == 201, added.text
+        _add_a_password(tmp_path, "member@example.com", PASSWORD)
+
+        engine = create_engine(f"sqlite:///{tmp_path / 'password-test.db'}")
+        with engine.begin() as connection:
+            connection.execute(
+                text('UPDATE "user" SET is_active = 0 WHERE email = :email'),
+                {"email": "member@example.com"},
+            )
+        engine.dispose()
+
+        assert client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"] == ["master_key"]
+
+
 def test_an_identity_that_arrived_with_a_password_does_not_claim_the_deployment(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -845,9 +900,10 @@ def test_an_identity_that_arrived_with_a_password_does_not_claim_the_deployment(
 
     Platform identities carry ``hashed_password`` already, so a backfilled
     deployment would otherwise read as claimed before anyone had claimed it:
-    ``/api/v1/bootstrap`` would publish ``["password"]`` and the sign-in screen
-    would ask the operator holding the master key for credentials that are not
-    theirs.
+    ``/api/v1/bootstrap`` would drop ``master_key`` and the sign-in screen would
+    ask the operator holding the master key for credentials that are not theirs.
+    ``password`` is published too, since those identities really can sign in
+    with one; what must not happen is the master key disappearing beside it.
     """
     with _client(tmp_path) as client:
         # The shape a backfill leaves behind: rows this gateway never
@@ -878,7 +934,7 @@ def test_an_identity_that_arrived_with_a_password_does_not_claim_the_deployment(
                 },
             )
 
-        assert client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"] == ["master_key"]
+        assert client.get(f"{API_ROOT}/bootstrap").json()["sign_in_methods"] == ["master_key", "password"]
 
         # And the master key is not refused as a retired login. It cannot mint a
         # session on this database either, but for the reason that actually

--- a/tests/unit/test_signup.py
+++ b/tests/unit/test_signup.py
@@ -1,4 +1,4 @@
-"""Signup: claiming an identity ``organization_service`` already put on the roster.
+"""Signup: claiming a roster identity, and registering one where the deployment allows it.
 
 Unit rather than integration, the same reasoning ``test_password_sign_in.py``
 gives: everything under test is route, service and identity behavior that runs
@@ -20,6 +20,10 @@ from sqlalchemy import create_engine, text
 from gateway.core.config import API_ROOT, GatewayConfig
 from gateway.log_config import logger as gateway_logger
 from gateway.main import create_app
+from gateway.services.tenancy.provisioning_service import (
+    DEFAULT_ORGANIZATION_SLUG,
+    DEFAULT_WORKSPACE_NAME,
+)
 
 MASTER_KEY = "sk-test-master"
 PASSWORD = "a-real-password"  # pragma: allowlist secret
@@ -27,18 +31,33 @@ PASSWORD = "a-real-password"  # pragma: allowlist secret
 _TOKEN_IN_LINK = re.compile(r"token=([\w-]+)")
 
 
-def _config(tmp_path: Path, *, mail_ready: bool = True) -> GatewayConfig:
+def _config(tmp_path: Path, *, mail_ready: bool = True, open_signup: bool = False) -> GatewayConfig:
     return GatewayConfig(
         database_url=f"sqlite:///{tmp_path / 'signup-test.db'}",
         master_key=MASTER_KEY,
         require_pricing=False,
         mail_transport="console" if mail_ready else "none",
         public_base_url="https://gw.example.com" if mail_ready else None,
+        open_signup=open_signup,
     )
 
 
-def _client(tmp_path: Path, *, mail_ready: bool = True) -> TestClient:
-    return TestClient(create_app(_config(tmp_path, mail_ready=mail_ready)))
+def _client(tmp_path: Path, *, mail_ready: bool = True, open_signup: bool = False) -> TestClient:
+    return TestClient(create_app(_config(tmp_path, mail_ready=mail_ready, open_signup=open_signup)))
+
+
+def _identity_count(tmp_path: Path) -> int:
+    """How many identities the deployment holds, operator included."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'signup-test.db'}")
+    with engine.begin() as connection:
+        count = connection.execute(text('SELECT COUNT(*) FROM "user"')).scalar_one()
+    engine.dispose()
+    return int(count)
+
+
+def _sign_in_with_master_key(client: TestClient) -> None:
+    """Provision the operator identity, so an identity count has a stable baseline."""
+    assert client.post(f"{API_ROOT}/auth/session", json={"master_key": MASTER_KEY}).status_code == 200
 
 
 def _add_member(client: TestClient, *, email: str, role: str = "member") -> None:
@@ -234,3 +253,169 @@ def test_signup_without_mail_configured_is_refused_and_writes_nothing(tmp_path: 
         )
     assert row["hashed_password"] is None
     assert row["email_verification_token_hash"] is None
+
+
+# =============================================================================
+# Open signup: registering an address nobody put on the roster
+# =============================================================================
+
+
+def test_closed_signup_creates_no_identity_for_an_unknown_address(tmp_path: Path) -> None:
+    """The default posture, asserted on the table rather than on the response.
+
+    ``test_signup_on_an_untouched_address_is_enumeration_safe`` already asserts
+    the response says nothing. This asserts the other half, which is the one a
+    self-hoster is relying on: nobody who can reach the dashboard can join the
+    deployment's single tenant by submitting the form.
+    """
+    with _client(tmp_path) as client:
+        _sign_in_with_master_key(client)
+        before = _identity_count(tmp_path)
+
+        assert _signup(client, email="stranger@example.com").status_code == 200
+
+        assert _identity_count(tmp_path) == before
+
+
+def test_open_signup_registers_an_unknown_address_and_verification_lets_it_sign_in(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with _client(tmp_path, open_signup=True) as client:
+        token = _captured_verification_link(
+            caplog, client, email="ada@example.com", full_name="Ada Lovelace"
+        )
+
+        # Unverified, so the hard-block refuses the password that was just set,
+        # exactly as it does on the claim path.
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": PASSWORD}
+            ).status_code
+            == 403
+        )
+        assert client.post(f"{API_ROOT}/auth/verify-email", json={"token": token}).status_code == 200
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": PASSWORD}
+            ).status_code
+            == 200
+        )
+
+
+def test_open_signup_lands_the_new_account_in_an_organization_it_owns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A tenant of its own, with the workspace every organization needs to hold anything.
+
+    Not the deployment's default organization: a registration that joined it
+    would put a stranger inside the operator's tenant, which is the thing the
+    closed default exists to prevent.
+    """
+    with _client(tmp_path, open_signup=True) as client:
+        token = _captured_verification_link(
+            caplog, client, email="ada@example.com", full_name="Ada Lovelace"
+        )
+        assert client.post(f"{API_ROOT}/auth/verify-email", json={"token": token}).status_code == 200
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": PASSWORD}
+            ).status_code
+            == 200
+        )
+
+        context = client.get(f"{API_ROOT}/organizations/me").json()
+        assert context["role"] == "owner"
+        assert context["organization"]["name"] == "Ada Lovelace's organization"
+        assert context["organization"]["slug"] != DEFAULT_ORGANIZATION_SLUG
+
+        memberships = client.get(f"{API_ROOT}/organizations/me/memberships").json()["data"]
+        assert [row["role"] for row in memberships] == ["owner"]
+
+        workspaces = client.get(f"{API_ROOT}/workspaces").json()["data"]
+        assert [workspace["name"] for workspace in workspaces] == [DEFAULT_WORKSPACE_NAME]
+
+
+def test_open_signup_names_the_organization_from_the_address_when_no_name_is_given(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with _client(tmp_path, open_signup=True) as client:
+        token = _captured_verification_link(caplog, client, email="ada@example.com")
+        assert client.post(f"{API_ROOT}/auth/verify-email", json={"token": token}).status_code == 200
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": PASSWORD}
+            ).status_code
+            == 200
+        )
+
+        context = client.get(f"{API_ROOT}/organizations/me").json()
+        assert context["organization"]["name"] == "ada's organization"
+
+
+def test_open_signup_claims_a_roster_address_rather_than_registering_a_second_tenant(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The setting widens what an *unknown* address does and changes nothing else.
+
+    An address an admin added is still claimed in place, keeping the membership
+    and the organization they were added to. Registering a fresh tenant for them
+    instead would quietly undo the admin's act.
+    """
+    with _client(tmp_path, open_signup=True) as client:
+        _add_member(client, email="grace@example.com", role="admin")
+        headers = {"Otari-Key": MASTER_KEY}
+        before = client.get(f"{API_ROOT}/organizations/me/members", headers=headers).json()["data"]
+
+        _captured_verification_link(caplog, client, email="grace@example.com")
+
+        after = client.get(f"{API_ROOT}/organizations/me/members", headers=headers).json()["data"]
+        assert [row["organization_member_id"] for row in after] == [
+            row["organization_member_id"] for row in before
+        ]
+        assert next(row for row in after if row["email"] == "grace@example.com")["role"] == "admin"
+
+
+def test_open_signup_on_an_already_registered_address_is_enumeration_safe(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Registration does not become an oracle for which addresses are taken."""
+    with _client(tmp_path, open_signup=True) as client:
+        _captured_verification_link(caplog, client, email="ada@example.com")
+        before = _identity_count(tmp_path)
+
+        caplog.clear()
+        gateway_logger.addHandler(caplog.handler)
+        caplog.set_level(logging.INFO, logger="gateway")
+        try:
+            again = _signup(client, email="ada@example.com", password="a-different-password")
+            unknown = _signup(client, email="nobody-else@example.com", password=PASSWORD)
+        finally:
+            gateway_logger.removeHandler(caplog.handler)
+
+        assert again.status_code == 200
+        assert again.json() == unknown.json()
+        # The second submission wrote nothing: no mail, no second identity for
+        # the taken address, and the original password still signs in.
+        assert _identity_count(tmp_path) == before + 1  # the unknown address registered
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": "a-different-password"}
+            ).status_code
+            == 401
+        )
+
+
+def test_open_signup_without_mail_configured_registers_nobody(tmp_path: Path) -> None:
+    """The refusal that already guards the claim path guards registration too.
+
+    A registered account that can never be verified is a row nobody can sign in
+    as, so the 503 has to come before the identity is written.
+    """
+    with _client(tmp_path, mail_ready=False, open_signup=True) as client:
+        _sign_in_with_master_key(client)
+        before = _identity_count(tmp_path)
+
+        response = _signup(client, email="ada@example.com")
+
+        assert response.status_code == 503
+        assert _identity_count(tmp_path) == before

--- a/tests/unit/test_signup.py
+++ b/tests/unit/test_signup.py
@@ -352,6 +352,32 @@ def test_open_signup_names_the_organization_from_the_address_when_no_name_is_giv
         assert context["organization"]["name"] == "ada's organization"
 
 
+def test_open_signup_fits_a_long_name_into_the_organization_name_column(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A 255-character name plus the suffix would overflow a 255-character column.
+
+    ``SignupRequest.full_name`` admits exactly what ``Organization.name`` holds,
+    so the wrapper has to come out of the name rather than off the end of the
+    row: untruncated, a perfectly valid signup fails its flush.
+    """
+    with _client(tmp_path, open_signup=True) as client:
+        token = _captured_verification_link(
+            caplog, client, email="ada@example.com", full_name="A" * 255
+        )
+        assert client.post(f"{API_ROOT}/auth/verify-email", json={"token": token}).status_code == 200
+        assert (
+            client.post(
+                f"{API_ROOT}/auth/session", json={"email": "ada@example.com", "password": PASSWORD}
+            ).status_code
+            == 200
+        )
+
+        name = client.get(f"{API_ROOT}/organizations/me").json()["organization"]["name"]
+        assert len(name) == 255
+        assert name.endswith("'s organization")
+
+
 def test_open_signup_claims_a_roster_address_rather_than_registering_a_second_tenant(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/web/e2e/parity.bootstrap.spec.ts
+++ b/web/e2e/parity.bootstrap.spec.ts
@@ -63,5 +63,9 @@ test("the deployment bootstrap is served unauthenticated", async ({
     // No SMTP configured in this e2e environment, so invitations are
     // creatable but not emailed; see docs/configuration.md#mail.
     mail_ready: false,
+    // Closed, which is the default and is what mail_ready above would force
+    // anyway: signup sends a verification link, so a deployment that cannot
+    // send one registers nobody.
+    open_signup: false,
   })
 })

--- a/web/e2e/parity.hybrid.spec.ts
+++ b/web/e2e/parity.hybrid.spec.ts
@@ -66,6 +66,8 @@ test.describe("hybrid deployment", () => {
       oauth_providers: [],
       // Its control plane sends the mail that carries links back to it.
       mail_ready: false,
+      // And holds the identities, so there is nothing here to sign up to.
+      open_signup: false,
     })
   })
 

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -532,10 +532,13 @@ export interface paths {
         put?: never;
         /**
          * Signup
-         * @description Claim a roster identity, or do nothing: the response never says which.
+         * @description Claim a roster identity, register a new one, or do nothing: the response never says which.
          *
-         *     No session is minted. A newly claimed identity is hard-blocked from
-         *     signing in until it verifies, so there is nothing yet to sign it into.
+         *     Which of the three this deployment will do is ``open_signup``, published in
+         *     the bootstrap so the page can say so before anyone types an address.
+         *
+         *     No session is minted. A newly claimed or registered identity is hard-blocked
+         *     from signing in until it verifies, so there is nothing yet to sign it into.
          */
         post: operations["auth-signup"];
         delete?: never;
@@ -6065,6 +6068,11 @@ export interface components {
              */
             oauth_providers: string[];
             /**
+             * Open Signup
+             * @description Whether POST /api/v1/auth/signup creates an account for an address nobody has added yet, each with an organization of its own, or only lets an address an admin already put on the roster set its password. The signup page reads as registration or as claiming an invitation accordingly, and the sign-in screen links to it with the wording that matches. False for a hybrid gateway, which holds no identities.
+             */
+            open_signup: boolean;
+            /**
              * Passkeys Ready
              * @description Whether this deployment can run a passkey ceremony at all: it has a relying-party ID (webauthn_rp_id, or derived from public_base_url) and an origin to serve one from. Distinct from 'passkey' in sign_in_methods, which is narrower and answers whether a registered passkey could sign somebody in *right now*: an operator with none yet needs this one, or the page that registers the first would be hidden from them. False for a hybrid gateway, which issues no session of its own.
              */
@@ -6082,7 +6090,7 @@ export interface components {
             session_type: "local_operator" | "hosted_user" | "none";
             /**
              * Sign In Methods
-             * @description How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is the first-boot credential and is offered until the operator identity has a password, which is what claiming the deployment means; 'password' replaces it from then on, and the master key stays the credential for the management API. 'passkey' appears alongside either one when this deployment is configured for WebAuthn and holds at least one passkey that its current relying-party ID can assert. Empty for a hybrid gateway, which issues no session. The login page renders from this rather than trying a credential to find out.
+             * @description How POST /api/v1/auth/session may be authenticated right now, sorted. 'master_key' is the first-boot credential and is offered until the operator identity has a password, which is what claiming the deployment means; past that it stays the credential for the management API but is no longer a dashboard login. 'password' is offered while any active identity holds one, which is not the same question and not always the later half of it: a member can hold a password on a deployment whose operator never claimed it, so both typed credentials can appear together. 'passkey' appears alongside either when this deployment is configured for WebAuthn and holds at least one passkey that its current relying-party ID can assert. Empty for a hybrid gateway, which issues no session. The login page renders from this rather than trying a credential to find out.
              */
             sign_in_methods: ("master_key" | "password" | "passkey")[];
             /**
@@ -9505,12 +9513,12 @@ export interface components {
         };
         /**
          * SignupRequest
-         * @description Claim an identity already on the roster by setting its password.
+         * @description Set a password for an address, claiming or registering it.
          */
         SignupRequest: {
             /**
              * Email
-             * @description The address an admin added or invited.
+             * @description The address to sign in with. An address an admin added or invited where this deployment keeps signup closed; any address where the bootstrap reports open_signup.
              */
             email: string;
             /**

--- a/web/src/features/auth/Login.test.tsx
+++ b/web/src/features/auth/Login.test.tsx
@@ -29,12 +29,14 @@ function Mounted({
   mailReady = false,
   maintenanceMode = false,
   oauthProviders = [],
+  openSignup = false,
 }: {
   children: React.ReactNode
   signInMethods?: ("master_key" | "password" | "passkey")[]
   mailReady?: boolean
   maintenanceMode?: boolean
   oauthProviders?: string[]
+  openSignup?: boolean
 }) {
   return (
     <AppProviders>
@@ -44,6 +46,7 @@ function Mounted({
           mail_ready: mailReady,
           maintenance_mode: maintenanceMode,
           oauth_providers: oauthProviders,
+          open_signup: openSignup,
         })}
       >
         {children}
@@ -161,6 +164,108 @@ describe("Login", () => {
     expect(
       screen.getByRole("link", { name: /Set your password/ }),
     ).toBeInTheDocument()
+  })
+
+  // otari-ai#2100. A deployment publishes both typed credentials whenever a
+  // member holds a password on one its operator never claimed, and the screen
+  // used to render the pair as either/or: the master-key box, and nowhere to
+  // put the password that would have worked.
+  it("shows the password form when both typed credentials are published", () => {
+    render(
+      <Mounted signInMethods={["master_key", "password"]}>
+        <Harness />
+      </Mounted>,
+    )
+
+    expect(screen.getByLabelText("Email")).toBeInTheDocument()
+    expect(screen.getByLabelText("Password")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Master key")).toBeNull()
+  })
+
+  it("swaps to the master-key box on request, and back", async () => {
+    const user = userEvent.setup()
+    render(
+      <Mounted signInMethods={["master_key", "password"]}>
+        <Harness />
+      </Mounted>,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Use your master key" }),
+    )
+
+    expect(screen.getByLabelText("Master key")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Email")).toBeNull()
+
+    await user.click(
+      screen.getByRole("button", { name: "Use your email and password" }),
+    )
+
+    expect(screen.getByLabelText("Email")).toBeInTheDocument()
+  })
+
+  it("signs in with a member password on a deployment nobody has claimed", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ user_id: "u1" }), { status: 200 }),
+      )
+    const user = userEvent.setup()
+    render(
+      <Mounted signInMethods={["master_key", "password"]}>
+        <Harness />
+      </Mounted>,
+    )
+
+    await user.type(screen.getByLabelText("Email"), "member@example.com")
+    await user.type(screen.getByLabelText("Password"), "correct-horse")
+    await user.click(screen.getByRole("button", { name: "Sign in" }))
+
+    expect(await screen.findByText("SIGNED IN")).toBeInTheDocument()
+    const body = String(
+      (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.body,
+    )
+    expect(JSON.parse(body)).toEqual({
+      email: "member@example.com",
+      password: "correct-horse",
+    })
+  })
+
+  it("offers no swap when the gateway publishes one typed credential", () => {
+    render(
+      <Mounted signInMethods={["password"]}>
+        <Harness />
+      </Mounted>,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: /Use your master key/ }),
+    ).toBeNull()
+  })
+
+  it("offers recovery to a member holding a password on an unclaimed deployment", () => {
+    render(
+      <Mounted mailReady signInMethods={["master_key", "password"]}>
+        <Harness />
+      </Mounted>,
+    )
+
+    expect(
+      screen.getByRole("link", { name: /Forgot your password/ }),
+    ).toBeInTheDocument()
+  })
+
+  it("invites registration rather than a claim where signup is open", () => {
+    render(
+      <Mounted mailReady openSignup>
+        <Harness />
+      </Mounted>,
+    )
+
+    expect(
+      screen.getByRole("link", { name: /Create an account/ }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /Set your password/ })).toBeNull()
   })
 
   it("links to the auth-free welcome page", () => {

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -241,8 +241,8 @@ export function Login() {
   // Both are published whenever a member holds a password on a deployment its
   // operator never claimed, so which box is on screen is a choice rather than a
   // reading of the bootstrap. The password form is the default wherever it is
-  // offered: it is the credential most people on a deployment have, and the one
-  // a stranger arriving at the URL could conceivably hold.
+  // offered, because a deployment has one master key and as many passwords as
+  // it has people.
   const [typedCredential, setTypedCredential] = useState<
     "password" | "masterKey"
   >(offersPasswordForm ? "password" : "masterKey")

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -185,11 +185,21 @@ function LabelRow({
  * The sign-in screen, rendering whichever credential this deployment accepts.
  *
  * A standalone gateway takes the master key until an operator claims it by
- * setting a password, and email and password from then on
- * (mozilla-ai/otari-ai#1716). The gateway publishes which applies in the
- * bootstrap's `sign_in_methods`, so the form is chosen from that rather than
- * from a refusal: presenting the master-key box to a claimed deployment would
- * ask for the one credential its sign-in endpoint no longer takes.
+ * setting a password (mozilla-ai/otari-ai#1716), and takes a password from
+ * whichever identity holds one, whenever one does. The gateway publishes both
+ * facts in the bootstrap's `sign_in_methods`, so the form is chosen from that
+ * rather than from a refusal: presenting the master-key box to a claimed
+ * deployment would ask for the one credential its sign-in endpoint no longer
+ * takes.
+ *
+ * The two are not alternatives to each other, which is what otari-ai#2100 was
+ * about. A deployment publishes both whenever a member holds a password on one
+ * its operator never claimed, and this screen used to show the master-key box
+ * alone, so the member whose password would have worked had no form to put it
+ * in. With both published the password form is what renders, and the
+ * master-key box is one press away under the rule below it: somebody holding a
+ * key knows they hold one, and everybody else would be reading a box about a
+ * credential they have never seen.
  *
  * Below the form sit the ways in that are not a credential: claiming a rostered
  * identity, recovering a forgotten password, and asking for a fresh
@@ -197,13 +207,11 @@ function LabelRow({
  * start by sending a message, so all three are hidden on a deployment whose
  * bootstrap reports `mail_ready: false` rather than offered and then refused
  * with a 503, the way otari#648 already settled it for the invitation form.
- * Recovery is hidden on an unclaimed deployment as well: `master_key` is
- * published exactly while the operator identity holds no password (otari#702),
- * so there is nothing yet for the operator to reset, and the way back in is the
- * master key against `PUT /v1/auth/password` (see docs/access-control.md). A
- * member who signed up on a deployment its operator never claimed is the one
- * case this screen does not serve: it offers the master-key box, and they sign
- * in by calling `POST /v1/auth/session` until the operator claims it.
+ * The two recovery links need one thing more: `password` in that same list,
+ * which is the gateway saying some identity holds one. Nothing has a reset link
+ * to reset before then, and an operator who has not claimed the deployment
+ * recovers through the master key against `PUT /v1/auth/password` instead (see
+ * docs/access-control.md) rather than through a mailed link.
  *
  * A passkey signs in beside the form rather than instead of it (otari#652),
  * offered only when the gateway publishes `passkey` *and* this browser can run
@@ -221,9 +229,25 @@ function LabelRow({
 export function Login() {
   const { login, isSigningOut } = useAuth()
   const { recordEvent } = useTelemetry()
-  const { sign_in_methods, mail_ready, maintenance_mode, oauth_providers } =
-    useDeployment()
-  const usesPassword = sign_in_methods.includes("password")
+  const {
+    sign_in_methods,
+    mail_ready,
+    maintenance_mode,
+    oauth_providers,
+    open_signup,
+  } = useDeployment()
+  const offersPasswordForm = sign_in_methods.includes("password")
+  const offersMasterKeyForm = sign_in_methods.includes("master_key")
+  // Both are published whenever a member holds a password on a deployment its
+  // operator never claimed, so which box is on screen is a choice rather than a
+  // reading of the bootstrap. The password form is the default wherever it is
+  // offered: it is the credential most people on a deployment have, and the one
+  // a stranger arriving at the URL could conceivably hold.
+  const [typedCredential, setTypedCredential] = useState<
+    "password" | "masterKey"
+  >(offersPasswordForm ? "password" : "masterKey")
+  const usesPassword = typedCredential === "password"
+  const offersCredentialSwitch = offersPasswordForm && offersMasterKeyForm
   // An empty list is the gateway saying it cannot mint a session at all right
   // now. Two ways to get there: `/bootstrap` answers [] when it cannot reach
   // its database, and `normalizeBootstrap` fills the same [] in for a gateway
@@ -240,7 +264,11 @@ export function Login() {
   // signup already flips the deployment to `password`, so this is not the
   // caller who needs a resend being left without one.
   const offersSignup = mail_ready
-  const offersRecovery = mail_ready && usesPassword
+  // Off the bootstrap rather than off `usesPassword`, which now says which box
+  // is showing: whether a password can be reset is a fact about the deployment,
+  // and it does not stop being true while somebody is looking at the master-key
+  // box.
+  const offersRecovery = mail_ready && offersPasswordForm
   // Two independent conditions, and both have to hold. The gateway publishes
   // `passkey` only while some credential could actually answer, and a browser
   // that cannot run the ceremony would turn the button into a dead end.
@@ -772,7 +800,9 @@ export function Login() {
           </Button>
         </form>
 
-        {offersPasskey || oauthProviders.length > 0 ? (
+        {offersCredentialSwitch ||
+        offersPasskey ||
+        oauthProviders.length > 0 ? (
           <div className="flex flex-col gap-3">
             {/* A rule with the word on it, rather than a bare divider: these
                   are alternatives to the form above, not a second step of it,
@@ -787,6 +817,38 @@ export function Login() {
               or
               <span className="h-px flex-1 bg-border" />
             </div>
+            {/* The other typed credential, under the same rule as the passkey
+                and the provider buttons because it is the same kind of thing:
+                another way to prove who you are, not a second step of the form
+                above. Swapping the box clears whatever was typed into the one
+                being put away, so a refusal from the credential nobody is
+                looking at any more cannot stay on screen. */}
+            {offersCredentialSwitch ? (
+              <Button
+                type="button"
+                variant="ghost"
+                fullWidth
+                isDisabled={
+                  isSubmitting ||
+                  isSigningOut ||
+                  isPasskeyPending ||
+                  pendingProvider !== null
+                }
+                onPress={() => {
+                  setTypedCredential(usesPassword ? "masterKey" : "password")
+                  setEmail("")
+                  setPassword("")
+                  setMasterKey("")
+                  setError(null)
+                  setErrorField(null)
+                }}
+                className="h-11"
+              >
+                {usesPassword
+                  ? "Use your master key"
+                  : "Use your email and password"}
+              </Button>
+            ) : null}
             {offersPasskey ? (
               <Button
                 type="button"
@@ -875,9 +937,16 @@ export function Login() {
             {/* Deployment-neutral wording (otari#835): "this gateway" read as
                   a self-hosted process on a hosted control plane, where the same
                   screen is the sign-in for an invited tenant. */}
+            {/* One link, two sentences, because the page behind it does two
+                different things (`open_signup` in the bootstrap) and the wrong
+                sentence strands whoever reads it: a stranger invited to create
+                an account on a closed deployment gets nothing, and a member of
+                an open one is left waiting for an admin who is not coming. */}
             {offersSignup ? (
               <PublicAuthLink to="#/signup">
-                Invited or added by an admin? Set your password
+                {open_signup
+                  ? "New to this deployment? Create an account"
+                  : "Invited or added by an admin? Set your password"}
               </PublicAuthLink>
             ) : null}
             {offersRecovery ? (

--- a/web/src/features/auth/SignupPage.test.tsx
+++ b/web/src/features/auth/SignupPage.test.tsx
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SignupPage } from "@/features/auth/SignupPage"
 import { ApiError, apiFetch } from "@/shared/api/client"
+import { DeploymentProvider } from "@/shared/hooks/useDeployment"
 import { TELEMETRY_EVENTS } from "@/shared/telemetry/events"
+import { bootstrap } from "@/tests/fixtures"
 import { recordEvent, resetTelemetrySpy } from "@/tests/telemetry"
 
 // The network boundary, not the hooks: the real hooks, their query keys, and
@@ -26,13 +28,26 @@ vi.mock("@/shared/telemetry/overlayTelemetry", async () => {
 // `PublicAuthPage` passes the whole hash down, so the plain page is the one
 // reached from the sign-in screen and a `?email=` one is the accept page's
 // handoff (otari#835).
-function renderPage(hash = "#/signup") {
+// The page reads `open_signup` and `terms_url` off the bootstrap, so every
+// render goes through a DeploymentProvider. Closed signup and no published
+// terms is the default, matching a deployment that configured neither.
+function renderPage(
+  hash = "#/signup",
+  deployment: { openSignup?: boolean; termsUrl?: string | null } = {},
+) {
   const client = new QueryClient({
     defaultOptions: { mutations: { retry: false } },
   })
   return render(
     <QueryClientProvider client={client}>
-      <SignupPage hash={hash} />
+      <DeploymentProvider
+        value={bootstrap({
+          open_signup: deployment.openSignup ?? false,
+          terms_url: deployment.termsUrl ?? null,
+        })}
+      >
+        <SignupPage hash={hash} />
+      </DeploymentProvider>
     </QueryClientProvider>,
   )
 }
@@ -68,6 +83,59 @@ describe("SignupPage", () => {
       email: "ada@example.com",
       password: "correct-horse",
       full_name: null,
+    })
+  })
+
+  // otari-ai#2100: the same form, reading as registration where the deployment
+  // takes an address nobody added.
+  it("reads as registration where signup is open", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({ message: "…" } as never)
+    const user = userEvent.setup()
+    renderPage("#/signup", { openSignup: true })
+
+    expect(
+      screen.getByRole("heading", { name: "Create your account" }),
+    ).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText("Email"), "ada@example.com")
+    await user.type(screen.getByLabelText("Password"), "correct-horse")
+    await user.type(screen.getByLabelText("Confirm password"), "correct-horse")
+    await user.click(screen.getByRole("button", { name: "Create account" }))
+
+    await vi.waitFor(() => {
+      expect(window.location.hash).toBe("#/check-email?type=signup")
+    })
+  })
+
+  it("offers no terms checkbox on a deployment that published none", () => {
+    renderPage()
+
+    expect(screen.queryByRole("checkbox")).toBeNull()
+  })
+
+  it("requires the published terms, and records the acceptance", async () => {
+    vi.mocked(apiFetch).mockResolvedValue({ message: "…" } as never)
+    const user = userEvent.setup()
+    renderPage("#/signup", { termsUrl: "https://otari.example.com/terms" })
+
+    await user.type(screen.getByLabelText("Email"), "ada@example.com")
+    await user.type(screen.getByLabelText("Password"), "correct-horse")
+    await user.type(screen.getByLabelText("Confirm password"), "correct-horse")
+    const submit = screen.getByRole("button", { name: "Claim account" })
+    expect(submit).toBeDisabled()
+
+    expect(
+      screen.getByRole("link", { name: "terms of service" }),
+    ).toHaveAttribute("href", "https://otari.example.com/terms")
+    await user.click(screen.getByRole("checkbox"))
+    await user.click(submit)
+
+    const [, init] = vi.mocked(apiFetch).mock.calls[0] ?? []
+    expect(JSON.parse(String(init?.body))).toEqual({
+      email: "ada@example.com",
+      password: "correct-horse",
+      full_name: null,
+      terms_accepted: true,
     })
   })
 

--- a/web/src/features/auth/SignupPage.tsx
+++ b/web/src/features/auth/SignupPage.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@heroui/react"
 import { useState } from "react"
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
+import { Checkbox } from "@/design-system/forms/Checkbox"
 import { useSignup } from "@/shared/api/auth"
 import { ApiError } from "@/shared/api/client"
 import { emailFromHash } from "@/shared/helpers/hashParams"
@@ -9,6 +10,7 @@ import {
   MIN_PASSWORD_LENGTH,
   newPasswordProblem,
 } from "@/shared/helpers/password"
+import { useDeployment } from "@/shared/hooks/useDeployment"
 import { TELEMETRY_EVENTS } from "@/shared/telemetry/events"
 import { useTelemetry } from "@/shared/telemetry/overlayTelemetry"
 
@@ -20,32 +22,31 @@ import {
 } from "./PublicAuthLayout"
 
 /**
- * `#/signup`: claim the identity an admin already put on this deployment's
- * roster, by giving it a password.
+ * `#/signup`: set a password for an address, claiming or registering it.
  *
- * Two departures from the platform's own signup page, both of them the
- * gateway's behavior rather than a design preference:
+ * Which of the two is the deployment's own posture, published as `open_signup`
+ * in the bootstrap (otari-ai#2100). Closed, the default, `POST /v1/auth/signup`
+ * only ever completes an identity `organization_service` already added or
+ * invited by address and creates nothing from nothing, so the copy says so:
+ * a page reading as "create an account" would leave somebody who is not on the
+ * roster waiting for an email that is never sent. Open, an address nobody has
+ * added is registered with an organization of its own, and the same page is a
+ * registration form. The form itself is identical either way; only the wording
+ * moves, because the request is the same one.
  *
- * - **It is not registration.** `POST /v1/auth/signup` only ever completes an
- *   identity `organization_service` already added or invited by address; it
- *   creates nothing from nothing. The copy says so, because a page that reads
- *   as "create an account" would leave someone who is not on the roster
- *   waiting for an email that is never sent.
- * - **The response says nothing about the address.** It is enumeration-safe:
- *   unknown, already claimed, and genuinely just claimed all answer the same
- *   sentence. So success navigates to `#/check-email`, which is written in the
- *   conditional the server's own message uses, and nothing here branches on
- *   what came back.
+ * **The response says nothing about the address**, under either posture. It is
+ * enumeration-safe: unknown, already claimed, and genuinely just claimed all
+ * answer the same sentence. So success navigates to `#/check-email`, which is
+ * written in the conditional the server's own message uses, and nothing here
+ * branches on what came back.
  *
- * The platform's Google and GitHub buttons, its newsletter opt-in, and its
- * terms checkbox are all left behind. The first two are #651 and a hosted
- * marketing concern; the third has nothing to link to on a deployment that
- * published no terms, so the request omits `terms_accepted` rather than
- * asserting an acceptance of a document that does not exist. `terms_url` makes
- * that conditional rather than always true, and the server has carried
- * `terms_accepted` and its `terms_accepted_at` column throughout, so offering
- * the checkbox where there is a document to accept is unwired rather than
- * impossible.
+ * The platform's Google and GitHub buttons and its newsletter opt-in are left
+ * behind: the first is #651 and the second a hosted marketing concern. Its
+ * terms checkbox is here, conditionally, because the objection to it was that a
+ * deployment publishing no terms has nothing to link to; `terms_url` answers
+ * that, and the server has carried `terms_accepted` and its
+ * `terms_accepted_at` column throughout. Where there is a document, accepting
+ * it is required, which is what makes the recorded acceptance mean anything.
  *
  * `?email=…` prefills the address, which is how the accept-invitation page
  * hands an invitee straight here (otari#835). It arrives read-only, because
@@ -60,6 +61,7 @@ import {
 export function SignupPage({ hash }: { hash: string }) {
   const signup = useSignup()
   const { recordEvent } = useTelemetry()
+  const { open_signup, terms_url } = useDeployment()
   // Read straight from the prop rather than held in state: `PublicAuthPage` is
   // keyed on the whole hash, so a second link pasted into an open tab remounts
   // this page instead of re-rendering it with the first link's address.
@@ -68,10 +70,14 @@ export function SignupPage({ hash }: { hash: string }) {
   const [fullName, setFullName] = useState("")
   const [password, setPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
+  const [isTermsAccepted, setIsTermsAccepted] = useState(false)
 
   const problem = newPasswordProblem(password, confirmPassword)
   const complete =
-    email.trim() !== "" && password !== "" && confirmPassword !== ""
+    email.trim() !== "" &&
+    password !== "" &&
+    confirmPassword !== "" &&
+    (terms_url === null || isTermsAccepted)
   const canSubmit = complete && problem === null
 
   // A refusal describes a call that is no longer the one being made, so typing
@@ -101,6 +107,12 @@ export function SignupPage({ hash }: { hash: string }) {
         email: email.trim(),
         password,
         full_name: fullName.trim() || null,
+        // Present only where a document was actually shown. Omitted rather than
+        // sent as `false` on a deployment that published none, so the column
+        // records an acceptance of something rather than a decision about a
+        // checkbox nobody saw. The box below is required, so reaching here with
+        // terms published means it was ticked.
+        ...(terms_url !== null ? { terms_accepted: true } : {}),
       },
       {
         onSuccess: () => {
@@ -125,8 +137,12 @@ export function SignupPage({ hash }: { hash: string }) {
 
   return (
     <PublicAuthLayout
-      title="Claim your account"
-      description="Set a password for the address an admin invited or added. You will confirm the address by email before your first sign-in."
+      title={open_signup ? "Create your account" : "Claim your account"}
+      description={
+        open_signup
+          ? "Pick an address and a password. You will confirm the address by email before your first sign-in."
+          : "Set a password for the address an admin invited or added. You will confirm the address by email before your first sign-in."
+      }
       footer={
         <>
           <PublicAuthLink to="#/">
@@ -155,7 +171,9 @@ export function SignupPage({ hash }: { hash: string }) {
           description={
             invitedEmail
               ? "The address your invitation was sent to, which is the one it can claim."
-              : "The address an admin added or invited. Another address has nothing to claim."
+              : open_signup
+                ? "Where the verification link goes, and the address you will sign in with."
+                : "The address an admin added or invited. Another address has nothing to claim."
           }
         />
         {/* Directly under the field rather than in the footer: this is the way
@@ -199,6 +217,28 @@ export function SignupPage({ hash }: { hash: string }) {
           autoComplete="new-password"
         />
 
+        {/* Rendered only where there is a document to read, which is what the
+            deployment's `terms_url` says. Required rather than optional: an
+            acceptance the form would have submitted either way records nothing.
+            A plain anchor and not a router `Link`, because the target is an
+            address an operator configured and is usually off this origin. */}
+        {terms_url !== null ? (
+          <Checkbox isSelected={isTermsAccepted} onChange={setIsTermsAccepted}>
+            <span className="text-caption">
+              I accept the{" "}
+              <a
+                href={terms_url}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-link hover:text-link-hover"
+              >
+                terms of service
+              </a>
+              .
+            </span>
+          </Checkbox>
+        ) : null}
+
         {problem ? (
           <p role="alert" className="text-caption text-danger">
             {problem}
@@ -213,7 +253,7 @@ export function SignupPage({ hash }: { hash: string }) {
           isPending={signup.isPending}
           isDisabled={!canSubmit}
         >
-          Claim account
+          {open_signup ? "Create account" : "Claim account"}
         </Button>
       </form>
     </PublicAuthLayout>

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -77,5 +77,6 @@ export function normalizeBootstrap(wire: WireBootstrap): DeploymentBootstrap {
     maintenance_mode: wire.maintenance_mode ?? false,
     passkeys_ready: wire.passkeys_ready ?? false,
     mail_ready: wire.mail_ready ?? false,
+    open_signup: wire.open_signup ?? false,
   }
 }

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -152,6 +152,9 @@ export function bootstrap(
     // clearing a list it does not care about.
     oauth_providers: [],
     mail_ready: false,
+    // Closed, matching the default posture: the signup tests that want
+    // registration turn it on rather than every other test turning it off.
+    open_signup: false,
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

Two things change for the people signing in to an Otari dashboard.

**Anyone with a password can now sign in with it.** Until now the sign-in screen
showed one credential or the other: the master key on a deployment whose operator
had not yet set a password, and an email and password after that. The server never
worked that way. Somebody an admin added to the team, who then set a password,
could always have signed in; the screen simply never showed them a form to do it
in, only a box asking for a master key they do not hold. They now get the email
and password form, with the master-key box one press away under it, and the
"Forgot your password?" and "Need a new verification link?" links that were
hidden from them too.

**A deployment can now let people sign themselves up.** This is off by default,
and nothing changes for anyone who leaves it off: signup still only lets an
address an admin already invited set its password, which is what a single-team
deployment wants, since anybody who can reach the dashboard can reach the form.
Turned on, someone new can register, and they arrive with an organization and
workspace of their own rather than joining somebody else's. Either way the form
answers the same way whether the address was new, already taken, or just signed
up, so it cannot be used to find out who is on a deployment, and either way the
deployment needs to be able to send email, because an account that cannot confirm
its address cannot sign in.

The signup page reads as "Create your account" or "Claim your account" to match,
so nobody is invited to register somewhere that will not register them. It also
shows a terms-of-service checkbox, required, on deployments that publish a terms
address; deployments that publish none show no checkbox, as before.

Two things the issue asks for are deliberately not here, each now its own issue:
a second factor people can enroll with a phone (#1095) and a password-strength
meter (#1096).

## How to test it locally

**Signing in with a member's password.** Start a gateway with a master key, sign
in, and add a member by address from the Organization members page. Give that
address a password through the signup page (mail has to work, so the quickest
route is the console transport plus a public base URL, then open the verification
link the log prints). Sign out: the screen now shows the email and password form
with **Use your master key** below the rule, and both credentials sign in.

**Signing yourself up.** Set `open_signup: true` alongside a working mail
transport. The sign-in screen offers **New to this deployment? Create an
account**; register an address nobody has added, open the verification link, sign
in, and confirm the account lands in its own organization with its own workspace
rather than in the operator's. Set the flag back to false and repeat: the same
message comes back and no account is created.

**Already covered by tests.** Ten new backend cases (a closed deployment writes
nothing for an unknown address, an open one registers it and verification lets it
sign in, the new account owns its organization and workspace, a long name still
fits the column, an invited address is still claimed in place rather than given a
second organization, a repeat registration stays silent, an open deployment with
no mail registers nobody, a member on an unclaimed deployment is offered the form
that works, deactivating the only password holder withdraws it, and the new
setting is only published when mail can carry the verification). Nine new
dashboard cases cover the form swap, the member sign-in, the two link wordings and
the terms checkbox. Lint, typecheck, both backend suites, the dashboard suite and
the end-to-end suite are green in CI, and the OpenAPI spec, the Postman collection
and the dashboard API client are regenerated and committed.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2100

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

The retired platform's own signup service and page were read as the reference for
what a full journey covered: the organization created per new account, how it is
named, and the terms checkbox all come from there.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
