### PR TITLE
fix(dashboard): use Otari branding and page-specific tab titles

### DIFF
--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -715,9 +715,8 @@ def create_app(config: GatewayConfig) -> FastAPI:
         # the PNG icons it points at (index.html links them from /pwa/). Only the
         # standalone dashboard is an app worth installing: a hybrid gateway's root
         # is a status page for a control plane that lives elsewhere, and an
-        # installed icon named "Otari Dashboard" would promise the wrong thing. The
-        # index still links the manifest there, which 404s and simply means no
-        # browser offers the install.
+        # installed icon named "Otari" would promise the wrong thing. The index still
+        # links the manifest there, which 404s and means no browser offers the install.
         pwa_dir = dashboard_dir / "pwa"
         if pwa_dir.is_dir() and not config.is_hybrid_mode:
             app.mount("/pwa", StaticFiles(directory=pwa_dir), name="dashboard-pwa")

--- a/tests/unit/test_gateway_root_page.py
+++ b/tests/unit/test_gateway_root_page.py
@@ -267,8 +267,8 @@ def test_hybrid_mode_serves_no_install_manifest(tmp_path: Path, monkeypatch: pyt
     """Only the standalone dashboard is an app worth installing.
 
     A hybrid gateway's root is a status page for a control plane that lives
-    elsewhere, so an installed icon named "Otari" would promise
-    management this deployment does not have. The index still links the manifest,
+    elsewhere, so an installed icon named "Otari" would promise management this
+    deployment does not have. The index still links the manifest,
     so what stops the install offer is this 404, which must not be cached: /pwa/
     carries a day of caching for the icons it usually serves, and a day-long 404
     would outlive a switch to standalone and keep the prompt away from a

--- a/tests/unit/test_gateway_root_page.py
+++ b/tests/unit/test_gateway_root_page.py
@@ -68,7 +68,7 @@ def test_dashboard_is_served_at_root(tmp_path: Path) -> None:
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     assert '<div id="root">' in response.text
-    assert "Otari Dashboard" in response.text
+    assert "<title>Otari</title>" in response.text
 
 
 @requires_dashboard_bundle
@@ -105,7 +105,7 @@ def test_pwa_manifest_and_icons_are_served(tmp_path: Path) -> None:
     assert '<link rel="manifest" href="/pwa/manifest.webmanifest" />' in index
     assert '<link rel="apple-touch-icon" href="/pwa/apple-touch-icon.png" />' in index
 
-    assert payload["name"] == "Otari Dashboard"
+    assert payload["name"] == "Otari"
     assert payload["short_name"] == "Otari"
     assert payload["display"] == "standalone"
     # Android offers an install only with both a 192 and a 512 icon; the maskable
@@ -231,7 +231,7 @@ def _fake_bundle(tmp_path: Path) -> Path:
     bundle = tmp_path / "dashboard"
     (bundle / "assets").mkdir(parents=True)
     (bundle / "pwa").mkdir()
-    (bundle / "pwa" / "manifest.webmanifest").write_text('{"name": "Otari Dashboard"}')
+    (bundle / "pwa" / "manifest.webmanifest").write_text('{"name": "Otari"}')
     (bundle / "index.html").write_text('<html><body><div id="root"></div></body></html>')
     return bundle
 
@@ -267,7 +267,7 @@ def test_hybrid_mode_serves_no_install_manifest(tmp_path: Path, monkeypatch: pyt
     """Only the standalone dashboard is an app worth installing.
 
     A hybrid gateway's root is a status page for a control plane that lives
-    elsewhere, so an installed icon named "Otari Dashboard" would promise
+    elsewhere, so an installed icon named "Otari" would promise
     management this deployment does not have. The index still links the manifest,
     so what stops the install offer is this 404, which must not be cached: /pwa/
     carries a day of caching for the icons it usually serves, and a day-long 404

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
          would run the app shell underneath it, and the shell has no safe-area
          insets to sit out of the way. -->
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <title>Otari Dashboard</title>
+    <title>Otari</title>
     <!-- Applies the remembered theme before the first paint. `useTheme` sets the
          same three properties, but it can only do so once React has mounted,
          which is after the boot screen below has already been painted light: a

--- a/web/pwaManifest.ts
+++ b/web/pwaManifest.ts
@@ -34,7 +34,7 @@ export function buildManifest(base: string) {
   })
   return {
     id: prefix,
-    name: "Otari Dashboard",
+    name: "Otari",
     short_name: "Otari",
     description:
       "Otari admin dashboard: browse and price models, manage aliases, and toggle runtime settings.",

--- a/web/src/app/App.test.tsx
+++ b/web/src/app/App.test.tsx
@@ -46,15 +46,15 @@ describe("App", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent("Loading page…")
     expect(await screen.findByText("Lazy overview")).toBeInTheDocument()
+    expect(document.title).toBe("Overview · Otari")
   })
 
   it("asks a local-operator deployment to sign in", () => {
     // No stored session marker, so the shell is not reachable yet.
     renderApp(bootstrap())
+    expect(document.title).toBe("Sign in · Otari")
 
-    expect(
-      screen.getByRole("heading", { name: "Otari Dashboard" }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Otari" })).toBeInTheDocument()
   })
 
   it("renders the data-plane landing page for a hybrid gateway", () => {
@@ -96,9 +96,7 @@ describe("App", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       /does not know what it is connected to/,
     )
-    expect(
-      screen.queryByRole("heading", { name: "Otari Dashboard" }),
-    ).toBeNull()
+    expect(screen.queryByRole("heading", { name: "Otari" })).toBeNull()
   })
 
   it("renders the accept-invitation page ahead of the sign-in screen", async () => {
@@ -123,9 +121,8 @@ describe("App", () => {
     // Not the sign-in screen, even though no session marker is stored: the
     // token in the link is this visitor's whole credential, not a session.
     expect(await screen.findByText("Acme")).toBeInTheDocument()
-    expect(
-      screen.queryByRole("heading", { name: "Otari Dashboard" }),
-    ).toBeNull()
+    expect(document.title).toBe("Accept invitation · Otari")
+    expect(screen.queryByRole("heading", { name: "Otari" })).toBeNull()
   })
 
   it("renders a public auth page ahead of the sign-in screen", async () => {
@@ -139,9 +136,7 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { name: "Email verified" }),
     ).toBeInTheDocument()
-    expect(
-      screen.queryByRole("heading", { name: "Otari Dashboard" }),
-    ).toBeNull()
+    expect(screen.queryByRole("heading", { name: "Otari" })).toBeNull()
   })
 
   it("sends a completed OAuth sign-in on to the dashboard rather than leaving it on the callback page", async () => {
@@ -248,9 +243,7 @@ describe("a bootstrap from an older gateway", () => {
   it("still renders the sign-in screen without oauth_providers", () => {
     const { container } = renderApp(older("oauth_providers"))
 
-    expect(
-      screen.getByRole("heading", { name: "Otari Dashboard" }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Otari" })).toBeInTheDocument()
     expect(container).not.toBeEmptyDOMElement()
   })
 

--- a/web/src/app/App.test.tsx
+++ b/web/src/app/App.test.tsx
@@ -84,6 +84,7 @@ describe("App", () => {
     expect(
       screen.getByRole("link", { name: "Manage this gateway on otari.ai" }),
     ).toHaveAttribute("href", "https://otari.ai")
+    expect(document.title).toBe("Gateway · Otari")
     // The management shell is not merely hidden behind a sign-in here.
     expect(screen.queryByRole("navigation")).toBeNull()
   })

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -98,7 +98,7 @@ function DeploymentRoot({ hash }: { hash: string }) {
   // explanation is more useful here than a page that would just 404.
   if (deployment_type === "hybrid") {
     return (
-      <PublicPageTitle>
+      <PublicPageTitle page="Gateway">
         <HybridLanding />
       </PublicPageTitle>
     )

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -1,13 +1,17 @@
 import { RouterProvider } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { HybridLanding } from "@/app/HybridLanding"
+import { PublicPageTitle } from "@/app/PublicPageTitle"
 import { router } from "@/app/router"
 import { ErrorBoundary } from "@/design-system/feedback/ErrorBoundary"
 import { PageError } from "@/design-system/feedback/PageError"
 import { useAuth } from "@/features/auth/AuthContext"
 import { Login } from "@/features/auth/Login"
 import { PublicAuthPage } from "@/features/auth/PublicAuthPage"
-import { publicAuthPath } from "@/features/auth/publicAuthPaths"
+import {
+  type PublicAuthPath,
+  publicAuthPath,
+} from "@/features/auth/publicAuthPaths"
 import { AcceptInvitationPage } from "@/features/invitations/AcceptInvitationPage"
 import type { WireBootstrap } from "@/shared/helpers/bootstrap"
 import { normalizeBootstrap } from "@/shared/helpers/bootstrap"
@@ -93,7 +97,11 @@ function DeploymentRoot({ hash }: { hash: string }) {
   // is a link this deployment cannot honor, and the landing page's own
   // explanation is more useful here than a page that would just 404.
   if (deployment_type === "hybrid") {
-    return <HybridLanding />
+    return (
+      <PublicPageTitle>
+        <HybridLanding />
+      </PublicPageTitle>
+    )
   }
 
   // The one URL every visitor may reach without a session or the master key:
@@ -111,7 +119,11 @@ function DeploymentRoot({ hash }: { hash: string }) {
   // tear down and remount on any hash change under this prefix, which is what
   // makes "once" mean once per link rather than once per tab.
   if (hash.startsWith("#/accept-invitation")) {
-    return <AcceptInvitationPage key={hash} />
+    return (
+      <PublicPageTitle page="Accept invitation">
+        <AcceptInvitationPage key={hash} />
+      </PublicPageTitle>
+    )
   }
 
   // The rest of the auth surface a visitor may reach without a session
@@ -124,7 +136,11 @@ function DeploymentRoot({ hash }: { hash: string }) {
   // previous link's result.
   const publicAuth = publicAuthPath(hash)
   if (publicAuth) {
-    return <PublicAuthPage path={publicAuth} hash={hash} key={hash} />
+    return (
+      <PublicPageTitle page={PUBLIC_AUTH_TITLES[publicAuth]}>
+        <PublicAuthPage path={publicAuth} hash={hash} key={hash} />
+      </PublicPageTitle>
+    )
   }
 
   // Any deployment that issues a session needs one before the shell renders.
@@ -134,7 +150,11 @@ function DeploymentRoot({ hash }: { hash: string }) {
   // "issues this one" is what makes that bug a wrong screen instead of an
   // unauthenticated shell whose every query 401s in a loop.
   if (session_type !== "none" && !isAuthenticated) {
-    return <Login />
+    return (
+      <PublicPageTitle page="Sign in">
+        <Login />
+      </PublicPageTitle>
+    )
   }
 
   // Auth gates the router rather than living inside it: signing in is the one
@@ -150,4 +170,15 @@ function DeploymentRoot({ hash }: { hash: string }) {
       <RouterProvider router={router} />
     </SelectedWorkspaceProvider>
   )
+}
+
+const PUBLIC_AUTH_TITLES: Record<PublicAuthPath, string> = {
+  "/signup": "Create account",
+  "/check-email": "Check your email",
+  "/resend-verification": "Resend verification",
+  "/recover-password": "Recover password",
+  "/verify-email": "Verify email",
+  "/reset-password": "Reset password",
+  "/auth/google/callback": "Sign in",
+  "/auth/github/callback": "Sign in",
 }

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -230,6 +230,7 @@ describe("AppShell responsive layout", () => {
     await user.click(await screen.findByRole("link", { name: "Providers" }))
 
     expect(await screen.findByText("PROVIDERS PAGE")).toBeInTheDocument()
+    expect(document.title).toBe("Providers · Otari")
     // Navigating closes the drawer so the page it landed on is not hidden behind it.
     expect(
       screen.getByRole("button", { name: "Open navigation" }),
@@ -250,6 +251,7 @@ describe("AppShell responsive layout", () => {
     // Awaited: Providers is one of the three rows gated `operatorOnly`, so it
     // arrives with the membership context rather than with the first paint.
     const providers = await screen.findByRole("link", { name: "Providers" })
+    expect(document.title).toBe("Overview · Otari")
     expect(overview).toHaveAttribute("aria-current", "page")
     expect(providers).not.toHaveAttribute("aria-current")
 

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -55,6 +55,11 @@ import { useEntitlements } from "@/shared/hooks/useEntitlements"
 import { TELEMETRY_EVENTS } from "@/shared/telemetry/events"
 import { useTelemetry } from "@/shared/telemetry/overlayTelemetry"
 
+const CHROME_TITLES: Record<string, string | undefined> = {
+  "/docs": "Documentation",
+  "/account": "Account",
+}
+
 // One width, not a range. The rail used to be draggable between 200 and 480px
 // and to remember where it was left; it is now the design's 264px, or 72px
 // collapsed, which is also what `otari-ai/frontend`'s shell is fixed at
@@ -426,14 +431,7 @@ function AppShellChrome() {
   const isVisible = useNavVisibility()
   const recordNavigation = useRecordNavigation()
   const { pathname } = useLocation()
-  useDocumentTitle(
-    navLabelForPath(pathname) ??
-      (pathname === "/docs"
-        ? "Documentation"
-        : pathname === "/account"
-          ? "Account"
-          : undefined),
-  )
+  useDocumentTitle(navLabelForPath(pathname) ?? CHROME_TITLES[pathname])
   // A gated-off destination is still reachable by bookmark or shared URL, so the
   // shell answers those with a panel instead of a page whose every request the
   // server would refuse. An unregistered path (the guide, the 404 splat) has no

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -50,6 +50,7 @@ import { PricingWarning } from "@/features/models/PricingWarning"
 import { canManage } from "@/features/organization/roles"
 import { useOrganizationContext } from "@/shared/api/organizations"
 import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
+import { useDocumentTitle } from "@/shared/hooks/useDocumentTitle"
 import { useEntitlements } from "@/shared/hooks/useEntitlements"
 import { TELEMETRY_EVENTS } from "@/shared/telemetry/events"
 import { useTelemetry } from "@/shared/telemetry/overlayTelemetry"
@@ -425,6 +426,14 @@ function AppShellChrome() {
   const isVisible = useNavVisibility()
   const recordNavigation = useRecordNavigation()
   const { pathname } = useLocation()
+  useDocumentTitle(
+    navLabelForPath(pathname) ??
+      (pathname === "/docs"
+        ? "Documentation"
+        : pathname === "/account"
+          ? "Account"
+          : undefined),
+  )
   // A gated-off destination is still reachable by bookmark or shared URL, so the
   // shell answers those with a panel instead of a page whose every request the
   // server would refuse. An unregistered path (the guide, the 404 splat) has no

--- a/web/src/app/PublicPageTitle.tsx
+++ b/web/src/app/PublicPageTitle.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react"
+import { useDocumentTitle } from "@/shared/hooks/useDocumentTitle"
+
+export function PublicPageTitle({
+  page,
+  children,
+}: {
+  page?: string
+  children: ReactNode
+}) {
+  useDocumentTitle(page)
+  return children
+}

--- a/web/src/app/PublicPageTitle.tsx
+++ b/web/src/app/PublicPageTitle.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react"
 import { useDocumentTitle } from "@/shared/hooks/useDocumentTitle"
 
+/** Gives public pages outside the authenticated router a mounted title owner. */
 export function PublicPageTitle({
   page,
   children,

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -599,7 +599,7 @@ export function Login() {
               column starts at its left edge like every other column in the
               product. */}
         <div className="flex flex-col gap-1.5">
-          <h1 className={HEADING}>Otari Dashboard</h1>
+          <h1 className={HEADING}>Otari</h1>
           <p className="text-sm text-pretty text-muted">
             {usesPassword
               ? "Sign in to browse models, set pricing, and manage settings."

--- a/web/src/pwaManifest.test.ts
+++ b/web/src/pwaManifest.test.ts
@@ -16,6 +16,8 @@ const WEB = process.cwd()
 describe("the generated web app manifest", () => {
   it("says at the origin root exactly what the static file used to", () => {
     const manifest = buildManifest("/")
+    expect(manifest.name).toBe("Otari")
+    expect(manifest.short_name).toBe("Otari")
     expect(manifest.id).toBe("/")
     expect(manifest.start_url).toBe("/")
     expect(manifest.scope).toBe("/")

--- a/web/src/shared/hooks/useDocumentTitle.test.ts
+++ b/web/src/shared/hooks/useDocumentTitle.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from "@testing-library/react"
+import { afterEach, expect, it } from "vitest"
+import { useDocumentTitle } from "./useDocumentTitle"
+
+const originalTitle = document.title
+afterEach(() => {
+  document.title = originalTitle
+})
+
+it("updates the page title and restores the brand on unmount", () => {
+  const { rerender, unmount } = renderHook(
+    ({ page }: { page?: string }) => useDocumentTitle(page),
+    { initialProps: { page: "API Keys" } },
+  )
+  expect(document.title).toBe("API Keys · Otari")
+  rerender({ page: "Usage" })
+  expect(document.title).toBe("Usage · Otari")
+  unmount()
+  expect(document.title).toBe("Otari")
+})
+
+it("uses the brand when no page is named", () => {
+  renderHook(() => useDocumentTitle())
+  expect(document.title).toBe("Otari")
+})

--- a/web/src/shared/hooks/useDocumentTitle.ts
+++ b/web/src/shared/hooks/useDocumentTitle.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react"
 export function useDocumentTitle(page?: string) {
   useEffect(() => {
     document.title = page ? `${page} · Otari` : "Otari"
+    // An error boundary can unmount the page without mounting another title owner.
     return () => {
       document.title = "Otari"
     }

--- a/web/src/shared/hooks/useDocumentTitle.ts
+++ b/web/src/shared/hooks/useDocumentTitle.ts
@@ -1,0 +1,10 @@
+import { useEffect } from "react"
+
+export function useDocumentTitle(page?: string) {
+  useEffect(() => {
+    document.title = page ? `${page} · Otari` : "Otari"
+    return () => {
+      document.title = "Otari"
+    }
+  }, [page])
+}


### PR DESCRIPTION
## Description
Use Otari as the website and installed app name. Browser tabs now show the current page first, such as “Usage · Otari” or “Providers · Otari”, so multiple open tabs are easier to distinguish. Sign-in and public authentication pages also receive page-specific titles.

## How to test it locally
- Run `pnpm --dir web run build` and open the dashboard.
- Confirm the sign-in heading says “Otari” and its tab says “Sign in · Otari”.
- Sign in and navigate from Overview to Providers or Usage. Confirm the tab follows the page using “Page · Otari”.
- Check the installed app manifest uses “Otari”.

Validation: architecture and migration checks plus Ruff (`make lint` with the existing environment), dashboard Biome lint, TypeScript build-mode typecheck, production build, dashboard Vitest suite (5,697 tests), and the gateway root-page/build serving tests (22 tests). Dashboard binaries were invoked directly because pnpm's version bootstrap stalled in this environment. No Python behavior changed.

## PR Type
- [x] Bug Fix

## Relevant issues
Product naming decision; no linked issue.

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary (no documentation changes needed).
- [ ] If the API contract changed, I regenerated the OpenAPI spec (not applicable).

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** GPT-6 / Codex

- [x] I am an AI Agent filling out this form (check box if true)
