### PR TITLE
fix(dashboard): give every settings row one control lane

### DIFF
--- a/web/design/layout.md
+++ b/web/design/layout.md
@@ -173,6 +173,15 @@ row draws no rule of its own, because the group divides its children. `nested`
 indents it to `pl-8`, which is how a row says it belongs to the one above it: a
 `DisclosureRow`'s panel is rows, not prose.
 
+**The lane is a fixed-width slot and the control fills it**, by the repeated-row
+rule further down this file. `w-full` on a field, `min-w-0 flex-1` on one sharing
+the lane with a trailing button, `fullWidth` on a `FilterSelect`; a number keeps
+`text-right tabular-nums` rather than a narrow box of its own. A control that
+cannot fill a lane, a toggle or a copyable chip, sits at its leading edge. **No
+row picks a control width**, for the reason it picks no field height: sized per
+control the lane is not a lane, and a URL field, a select and a two-digit number
+gave a column three different left edges.
+
 `bounded` frames the rows inside the page column instead of bleeding them, and
 the frame is also the dense place (`.otari-settings`), so its controls come out
 32px on a desk and 36px at 16px on a phone. **No row picks a field height or a

--- a/web/src/design-system/layout/SettingRow.stories.tsx
+++ b/web/src/design-system/layout/SettingRow.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 
+import { Button } from "../actions/Button"
 import { Field } from "../forms/Field"
+import { INPUT_CLASS } from "../forms/inputClass"
 import { Toggle } from "../forms/Toggle"
+import { FilterSelect } from "../navigation/FilterSelect"
 import { SettingRow } from "./SettingRow"
 import { SettingsGroup } from "./SettingsGroup"
 
@@ -16,6 +19,9 @@ import { SettingsGroup } from "./SettingsGroup"
  * **The row draws no rules of its own.** `SettingsGroup` divides its children,
  * so a border here would give every seam two lines. That is why the stories
  * below put it inside a group rather than showing it bare.
+ *
+ * **The lane is one width down the page and the control fills it.** Sized per
+ * control it was not a lane at all, which `SharedLane` below is about.
  *
  * Below `md` the control stops sharing the row and stacks full width under the
  * label, which is also where the label becomes a press target worth having, and
@@ -164,6 +170,89 @@ export const Nested: Story = {
               label="Allow image output"
               isSelected={false}
               onChange={() => {}}
+            />
+          }
+        />
+      </SettingsGroup>
+    )
+  },
+}
+
+/**
+ * Four different controls, one lane.
+ *
+ * This is the story worth looking at, because it is the one that used to be
+ * wrong: a text field, a select and a two-digit number each sized themselves,
+ * so a page of rows had a different left edge on every one of them. The lane is
+ * a fixed-width slot now, the same rule `design/layout.md` states for any
+ * repeated row, and a control fills it: `w-full` on a field, `fullWidth` on a
+ * `FilterSelect`. A control that cannot fill a lane, a toggle, sits at its
+ * leading edge rather than floating to the row's end.
+ */
+export const SharedLane: Story = {
+  render: () => {
+    const [on, setOn] = useState(true)
+    const [mode, setMode] = useState("default")
+    return (
+      <SettingsGroup bounded title="Web search">
+        <SettingRow
+          label="Backend URL"
+          configKey="web_search_url"
+          help="While unset, otari_web_search requests are rejected with 400."
+          control={
+            // The shape the lane exists for: a field beside its own button. It
+            // takes `min-w-0 flex-1` rather than `w-full` so the button keeps
+            // its size and the field gives up the difference.
+            <div className="flex items-center gap-1.5">
+              <input
+                aria-label="Backend URL"
+                defaultValue="http://searxng:8080"
+                className={`otari-machine-field min-w-0 flex-1 ${INPUT_CLASS}`}
+              />
+              <Button size="sm" className="min-w-[5.5rem] shrink-0">
+                Test
+              </Button>
+            </div>
+          }
+        />
+        <SettingRow
+          label="Max results"
+          configKey="web_search_max_results"
+          help="Cap on hits per call. A per-tool max_results still overrides it."
+          control={
+            <input
+              aria-label="Max results"
+              defaultValue="10"
+              className={`otari-machine-field w-full text-right tabular-nums ${INPUT_CLASS}`}
+            />
+          }
+        />
+        <SettingRow
+          label="Extract page content"
+          configKey="web_search_extract"
+          help="On: page text is extracted in-process. Off: snippet-only results."
+          control={
+            <FilterSelect
+              fullWidth
+              ariaLabel="Extract page content"
+              value={mode}
+              onChange={setMode}
+              options={[
+                { value: "default", label: "Default (on)" },
+                { value: "on", label: "On" },
+                { value: "off", label: "Off" },
+              ]}
+            />
+          }
+        />
+        <SettingRow
+          label="Require a price before routing"
+          help="A request to a model with no price is refused rather than served at an unknown cost."
+          control={
+            <Toggle
+              label="Require a price before routing"
+              isSelected={on}
+              onChange={setOn}
             />
           }
         />

--- a/web/src/design-system/layout/SettingRow.test.tsx
+++ b/web/src/design-system/layout/SettingRow.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import { SettingRow } from "./SettingRow"
+import { CONTROL_LANE, SettingRow } from "./SettingRow"
 
 describe("SettingRow", () => {
   it("names the control by its label and its config key together", () => {
@@ -69,6 +69,30 @@ describe("SettingRow", () => {
     expect(screen.getByLabelText("Backend URL")).toHaveAccessibleDescription(
       "Must be an http or https URL.",
     )
+  })
+
+  it("puts every control in one lane, whatever the control is", () => {
+    // Sized per control it was not a lane at all: a URL field, a select and a
+    // two-digit number came out 220px, 174px and 88px, so the column had a
+    // different left edge on every row.
+    render(
+      <>
+        <SettingRow
+          label="Backend URL"
+          control={<input aria-label="Backend URL" />}
+        />
+        <SettingRow
+          label="Max results"
+          control={<input aria-label="Max results" />}
+        />
+      </>,
+    )
+
+    for (const label of ["Backend URL", "Max results"]) {
+      expect(screen.getByLabelText(label).parentElement?.className).toContain(
+        CONTROL_LANE,
+      )
+    }
   })
 
   it("draws no rule of its own, because the group divides its children", () => {

--- a/web/src/design-system/layout/SettingRow.tsx
+++ b/web/src/design-system/layout/SettingRow.tsx
@@ -1,12 +1,38 @@
 import type { ReactNode } from "react"
 
 /**
+ * The lane every row's control sits in, from `md` up; below it the control
+ * stacks full width under its label.
+ *
+ * Exported so a loading frame standing in for a row takes the same width, which
+ * is what keeps settings arriving from moving the page.
+ *
+ * 17.5rem is what the widest cluster on a settings page needs, a field beside
+ * its own button, so widening the narrow controls to the lane is what changed
+ * rather than narrowing the wide ones. It steps down at `md`, where the shell
+ * still draws its 16.5rem sidebar beside a full-bleed row: a lane that wide
+ * there leaves a label like "Intercept provider web search" about 120px to wrap
+ * in. Both steps are one width across the whole group, so the column's edges are
+ * straight at either.
+ */
+export const CONTROL_LANE = "w-full shrink-0 md:w-[13.75rem] lg:w-[17.5rem]"
+
+/**
  * What a setting is on the left, the control that changes it on the right.
  *
  * Shared because a settings page is almost entirely this shape, and spelled by
  * hand the label size, the key caption and the control lane drift between
  * groups on the same page. The row draws no rules of its own: `SettingsGroup`
  * divides its children, and a border here would give every seam two lines.
+ *
+ * **The lane is one width down the page and the control fills it**, which is
+ * the fixed-width-slot rule `design/layout.md` states for any repeated row.
+ * Sized per control it was not a lane at all: a URL field, a select and a
+ * two-digit number came out 220px, 174px and 88px, so the column had a
+ * different left edge on every row. A field takes `w-full` (or `min-w-0 flex-1`
+ * beside a trailing button), a `FilterSelect` takes `fullWidth`, and a number
+ * keeps `text-right tabular-nums` so its digits still read against the lane's
+ * edge.
  *
  * Only an error may add a line to a row, which is what keeps the help text from
  * rewrapping under the cursor while a value is being changed.
@@ -83,7 +109,7 @@ export function SettingRow({
           </p>
         ) : null}
       </div>
-      <div className="w-full shrink-0 md:w-auto">{control}</div>
+      <div className={CONTROL_LANE}>{control}</div>
     </div>
   )
 }

--- a/web/src/design-system/navigation/FilterSelect.stories.tsx
+++ b/web/src/design-system/navigation/FilterSelect.stories.tsx
@@ -134,3 +134,34 @@ export const WithExternalLabel: Story = {
     )
   },
 }
+
+/**
+ * `fullWidth` fills whatever the trigger sits in, which is what a settings row
+ * wants: its control lane is a fixed-width slot, and a trigger sized to its own
+ * longest option gives the column a different left edge on every row. A filter
+ * bar leaves it off, because there the trigger's width naming the filter it
+ * carries is the point.
+ *
+ * A value longer than the trigger is ellipsized rather than allowed to widen
+ * it; the popover still shows each option in full.
+ */
+export const FullWidth: Story = {
+  render: () => {
+    const [value, setValue] = useState("blocked")
+    return (
+      <div className="w-[17.5rem]">
+        <FilterSelect
+          fullWidth
+          ariaLabel="Web search for this workspace"
+          value={value}
+          onChange={setValue}
+          options={[
+            { value: "default", label: "Deployment default" },
+            { value: "allowed", label: "Allowed" },
+            { value: "blocked", label: "Blocked (tool and /api/v1/search)" },
+          ]}
+        />
+      </div>
+    )
+  },
+}

--- a/web/src/design-system/navigation/FilterSelect.tsx
+++ b/web/src/design-system/navigation/FilterSelect.tsx
@@ -22,6 +22,7 @@ export function FilterSelect({
   onChange,
   options,
   disabled,
+  fullWidth,
 }: {
   id?: string
   label?: string
@@ -30,6 +31,12 @@ export function FilterSelect({
   onChange: (value: string) => void
   options: { value: string; label: string }[]
   disabled?: boolean
+  /**
+   * HeroUI's own prop, forwarded rather than renamed. On by a settings row,
+   * whose control lane is a fixed-width slot the control fills; off in a filter
+   * bar, where a trigger sized to the filter it carries is the point.
+   */
+  fullWidth?: boolean
 }) {
   // A value no option carries is a URL naming something the list does not hold
   // (`/activity?status=bogus`) or a drill-down into a key with no rows in the
@@ -47,6 +54,7 @@ export function FilterSelect({
     <Select.Root
       aria-label={label ? undefined : ariaLabel}
       isDisabled={disabled}
+      fullWidth={fullWidth}
       selectedKey={optionKey(value)}
       // A null key is react-aria clearing the selection, which no filter here
       // asks for: reporting it would push the strip of a non-string ("ll") into

--- a/web/src/features/tools/PolicyRow.tsx
+++ b/web/src/features/tools/PolicyRow.tsx
@@ -12,10 +12,11 @@ export type Parse<T> = (raw: string) => { value: T; error: string }
  * policy when the field is left.
  *
  * Both policy groups are a stance select over a handful of these, and the
- * shapes they need differ only in how the value is parsed and how wide the
- * lane is. `ToolSettingRows` is the other row family and stays separate: those
- * are keyed on a backend field descriptor and carry a config key, a
- * reachability note and a Test button, none of which a policy row has.
+ * shapes they need differ only in how the value is parsed; the lane is
+ * `SettingRow`'s and every field fills it. `ToolSettingRows` is the other row
+ * family and stays separate: those are keyed on a backend field descriptor and
+ * carry a config key, a reachability note and a Test button, none of which a
+ * policy row has.
  */
 export function PolicyRow<T>({
   label,
@@ -38,7 +39,7 @@ export function PolicyRow<T>({
   disabled: boolean
   /** Mono, for a value a machine reads. Off for a sentence a model reads. */
   machine?: boolean
-  /** A short right-aligned lane, for a number rather than a list or a phrase. */
+  /** Right-aligned digits, for a number rather than a list or a phrase. */
   numeric?: boolean
 }) {
   const [draft, setDraft] = useState(committed)
@@ -83,9 +84,7 @@ export function PolicyRow<T>({
             void save.run(() => commit(parsed.value))
           }}
           className={`w-full ${machine || numeric ? "otari-machine-field" : ""} ${
-            numeric
-              ? "text-right tabular-nums md:w-[5.5rem]"
-              : "md:w-[13.75rem]"
+            numeric ? "text-right tabular-nums" : ""
           } ${INPUT_CLASS}`}
         />
       }

--- a/web/src/features/tools/ToolSettingRows.tsx
+++ b/web/src/features/tools/ToolSettingRows.tsx
@@ -8,12 +8,14 @@ import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import { useTestService } from "@/shared/api/tools"
 import { commitOnEnter, useAutosave } from "@/shared/hooks/useAutosave"
 
-// The control lane, one width for text and one for a number, and `scroll-mt-16`
-// so a jump from the tool panel lands the field in the page rather than under
-// the 56px top bar.
-const TEXT_INPUT = `w-full scroll-mt-16 md:w-[13.75rem] ${INPUT_CLASS}`
+// Every field fills `SettingRow`'s lane rather than picking a width of its own,
+// which is what keeps the column's edges straight whether a row holds a URL, a
+// select or a two-digit number. `flex-1` rather than `w-full` because a field
+// can share the lane with a trailing button, and `scroll-mt-16` so a jump from
+// the tool panel lands it in the page rather than under the 56px top bar.
+const TEXT_INPUT = `min-w-0 flex-1 scroll-mt-16 ${INPUT_CLASS}`
 const MACHINE_INPUT = `otari-machine-field ${TEXT_INPUT}`
-const NUMBER_INPUT = `otari-machine-field w-full scroll-mt-16 text-right tabular-nums md:w-[5.5rem] ${INPUT_CLASS}`
+const NUMBER_INPUT = `otari-machine-field w-full scroll-mt-16 text-right tabular-nums ${INPUT_CLASS}`
 
 /**
  * The mono caption beside a row's label, if the key is not already the label.
@@ -224,6 +226,7 @@ function BoolRow({
       errorId={errorId}
       control={
         <FilterSelect
+          fullWidth
           ariaLabel={configKey ? `${copy.label} ${configKey}` : copy.label}
           value={current}
           onChange={(next) =>
@@ -302,6 +305,11 @@ function UrlRow({
       trailing={
         <Button
           size="sm"
+          // Wide enough for "Testing…" as well as "Test", which are 53px and
+          // 84px apart: the button shares a fixed lane with the field now, so
+          // letting it size to its label would narrow the URL under the cursor
+          // for as long as a probe is in flight.
+          className="min-w-[5.5rem] shrink-0"
           aria-label={`Test ${field.service}`}
           isDisabled={trimmed === "" || test.isPending}
           onPress={() => {
@@ -439,7 +447,7 @@ export function ToolPriceRow({
       errorId={errorId}
       control={
         <div className="flex items-center gap-1.5">
-          <span className="text-mono-overline text-subtle">USD</span>
+          <span className="shrink-0 text-mono-overline text-subtle">USD</span>
           <input
             type="text"
             inputMode="decimal"
@@ -465,7 +473,7 @@ export function ToolPriceRow({
               // 70000.00000000001 in binary floating point.
               void save.run(() => commit(Math.round(parsed * PER_MILLION)))
             }}
-            className={`otari-machine-field w-full text-right tabular-nums md:w-[7rem] ${INPUT_CLASS}`}
+            className={`otari-machine-field min-w-0 flex-1 text-right tabular-nums ${INPUT_CLASS}`}
           />
         </div>
       }

--- a/web/src/features/tools/ToolStatusGroup.tsx
+++ b/web/src/features/tools/ToolStatusGroup.tsx
@@ -12,11 +12,12 @@ import { settingInputId } from "@/features/tools/ToolSettingRows"
 /**
  * The declaration a client sends, as a value to take.
  *
- * Sized to its content rather than to the lane, which is what a full-width
- * readonly field got wrong: the value is 28 characters and the field was 800.
- * A frame rather than bare text, because it holds something to be copied
- * verbatim; the value inside it is real selectable text, since the Clipboard
- * API does not exist on the plain-HTTP origins this dashboard is served from.
+ * Sized to its content rather than filling the lane, since it is a value to
+ * take rather than a field to type in; it sits at the lane's leading edge with
+ * the controls above it. A frame rather than bare text, because it holds
+ * something to be copied verbatim; the value inside it is real selectable text,
+ * since the Clipboard API does not exist on the plain-HTTP origins this
+ * dashboard is served from.
  */
 function DeclarationChip({ tool }: { tool: ManagedTool }) {
   return (

--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -10,6 +10,7 @@ import type {
   ToolSettingsResponse,
   ToolsResponse,
 } from "@/client"
+import { CONTROL_LANE } from "@/design-system/layout/SettingRow"
 import { ToolsGuardrailsPage } from "@/features/tools/ToolsGuardrailsPage"
 import { API_ROOT } from "@/shared/api/client"
 import { organizationContext } from "@/tests/fixtures"
@@ -558,15 +559,16 @@ describe("ToolsGuardrailsPage", () => {
     await screen.findByLabelText(WEB_SEARCH_URL)
 
     for (const label of [WEB_SEARCH_URL, ENGINES, MAX_RESULTS]) {
-      expect(screen.getByLabelText(label).className).toContain("w-full")
+      const field = screen.getByLabelText(label)
+      // No field carries a width of its own: the lane owns the width, and a
+      // second one at the call site is how the column got a different left
+      // edge on every row.
+      expect(field.className).not.toMatch(/\b(md|lg):w-\[/)
+      expect(field.closest(`div[class*="${CONTROL_LANE}"]`)).not.toBeNull()
     }
-    // Only the numeric field narrows, and it does so in the same lane.
-    expect(screen.getByLabelText(MAX_RESULTS).className).toContain(
-      "md:w-[5.5rem]",
-    )
-    expect(screen.getByLabelText(ENGINES).className).toContain(
-      "md:w-[13.75rem]",
-    )
+    // The numeric field fills the lane like the rest and keeps its digits at
+    // the lane's trailing edge, which is what still reads it as a number.
+    expect(screen.getByLabelText(MAX_RESULTS).className).toContain("text-right")
   })
 })
 

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -8,6 +8,7 @@ import type {
 import { ErrorBanner } from "@/design-system/feedback/ErrorBanner"
 import { Skeleton } from "@/design-system/feedback/Skeleton"
 import { PageIntro } from "@/design-system/layout/PageIntro"
+import { CONTROL_LANE } from "@/design-system/layout/SettingRow"
 import { SettingsGroup } from "@/design-system/layout/SettingsGroup"
 import { isDeploymentOperator } from "@/features/organization/roles"
 import { OrganizationGuardrailsCard } from "@/features/tools/OrganizationGuardrailsCard"
@@ -263,13 +264,13 @@ function LoadingGroups() {
           {[0, 1, 2].map((row) => (
             <div
               key={row}
-              className="flex min-h-11 items-center gap-6 px-4 py-3"
+              className="flex min-h-11 flex-col gap-2.5 px-4 py-3 md:flex-row md:items-center md:gap-6"
             >
               <div className="flex min-w-0 flex-1 flex-col gap-1.5">
                 <Skeleton className="h-4 w-40" />
                 <Skeleton className="h-3.5 w-64" />
               </div>
-              <Skeleton className="h-8 w-[13.75rem] shrink-0" />
+              <Skeleton className={`h-8 ${CONTROL_LANE}`} />
             </div>
           ))}
         </SettingsGroup>

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
@@ -209,6 +209,7 @@ export function WorkspaceCodeExecutionPolicyCard({
         error={stanceSave.error}
         control={
           <FilterSelect
+            fullWidth
             ariaLabel="Code execution for this workspace"
             value={stance}
             onChange={(next) =>
@@ -283,6 +284,7 @@ export function WorkspaceCodeExecutionPolicyCard({
         control={
           allowedImages.length > 0 || withdrawnImage ? (
             <FilterSelect
+              fullWidth
               ariaLabel="Sandbox image for this workspace"
               value={policy?.image ?? DEPLOYMENT_IMAGE}
               onChange={(next) =>

--- a/web/src/features/tools/WorkspaceWebSearchCard.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.tsx
@@ -185,6 +185,7 @@ export function WorkspaceWebSearchCard({ docsHref }: { docsHref: string }) {
         }
         control={
           <FilterSelect
+            fullWidth
             ariaLabel="Web search for this workspace"
             value={stance}
             onChange={(next) => setStance(next as Stance)}


### PR DESCRIPTION
## Description

On pages that are mostly settings rows, the dashboard used to size each control
to whatever that control happened to be. A URL field, a dropdown and a two-digit
number came out at three different widths, so reading down a page you met a new
left edge on every row and the column looked crooked. The web-search settings
page is the clearest case, and it is what the issue reports.

Every settings row now puts its control in one lane of the same width, and the
control fills it. Nothing moves to a new place and no setting changes meaning;
the narrow controls widen so that the column has a single edge top to bottom.
A number still shows its digits at the trailing edge of its box, so it reads as
a number rather than as text. Below the tablet breakpoint each control still
stacks full width under its own label, as before.

Two smaller things come with it. The Test button beside a backend URL keeps one
width whether it says "Test" or "Testing…", so the field next to it no longer
narrows while a probe is running. And the placeholder rows shown while settings
load take that same lane, so the page does not shift when the real values
arrive.

Out of scope on purpose: the deployment settings page at `/settings` builds its
rows from a different component, and the read-only values there deliberately use
whatever width is left over. Straightening that one is a separate judgment call.

## How to test it locally

1. `make dashboard`, start the gateway, and sign in.
2. Open Tools, then Web search. Every control down the page should share one
   left edge and one right edge: the backend URL and its Test button, the
   engines list, the max-results number, the price, the two dropdowns and the
   purpose hint.
3. Do the same on Tools, then Code execution, which mixes dropdowns, numbers and
   read-only text in the same rows.
4. Narrow the window to a phone width. Each control should stack full width
   under its label.
5. Type a backend URL and press Test. The field beside the button should not
   change width while it says "Testing…".

Already covered by automation: `pnpm --dir web test` (5707 tests, including new
assertions in `SettingRow.test.tsx` and an updated layout assertion on the tools
page), `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, and the
Storybook render sweep (`pnpm --dir web exec node .storybook/smoke.mjs`, 407
stories in both themes). A new `SharedLane` story on `SettingRow` and a
`FullWidth` story on `FilterSelect` show the shape in the catalog. No page was
added, so no screenshot entry is owed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2126

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

The change is dashboard-only, so the backend `make` targets and the OpenAPI spec
are untouched; the dashboard's own three checks are the ones that apply and are
listed above. `web/design/layout.md` gained the rule this implements.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The lane width was chosen against measurements rather than by eye: the widest
cluster a settings row has is a field beside its own button, and the Test button
was measured at 53px for "Test" and 84px for "Testing…". The two-step lane
(13.75rem at `md`, 17.5rem at `lg`) exists because the shell still draws its
16.5rem sidebar at `md`, where one wide lane would leave a label such as
"Intercept provider web search" about 120px to wrap in.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized settings-row controls with shared responsive widths.
- Updated Web search and Code execution settings to fill the shared control area.
- Preserved right-aligned numeric values and content-sized filter controls.
- Stabilized the backend test button and loading placeholders to prevent layout shifts.
- Added documentation, Storybook examples, and layout tests.
- Updated affected components and tests to use the shared layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->