### PR TITLE
fix(dashboard): open every row Edit in a form dialog

### DIFF
--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -108,14 +108,14 @@ test.describe("standalone provider setup", () => {
     await expect(provider).not.toContainText("Connected.")
 
     await provider.getByRole("button", { name: "Edit" }).click()
-    await page.getByLabel("API base").fill("http://127.0.0.1:9/v2")
-    await page.getByRole("button", { name: "Save changes" }).click()
-    // Wait on Cancel, not on the button that was just pressed: that one reads
-    // "Saving…" while the request is in flight, so asserting "Save changes" is
-    // hidden passes the instant it is pressed, and the reload below then aborts
-    // the PATCH and loses the edit. Cancel is present for as long as the form is,
-    // and the form closes only in the mutation's onSuccess.
-    await expect(page.getByRole("button", { name: "Cancel" })).toBeHidden()
+    const editProvider = page.getByRole("dialog", { name: "Edit provider" })
+    await editProvider.getByLabel("API base").fill("http://127.0.0.1:9/v2")
+    await editProvider.getByRole("button", { name: "Save" }).click()
+    // Wait on the frame, not on the button that was just pressed: the submit
+    // keeps its label through the request, so asserting it is hidden passes the
+    // instant it is pressed and the reload below then aborts the PATCH and loses
+    // the edit. The dialog closes only in the mutation's onSuccess.
+    await expect(editProvider).toBeHidden()
 
     // Reopening is what proves the edit was persisted rather than only echoed
     // back into a form that never closed. Reload first: the form seeds its fields
@@ -126,10 +126,11 @@ test.describe("standalone provider setup", () => {
     await row(page, "Providers", PROVIDER)
       .getByRole("button", { name: "Edit" })
       .click()
-    await expect(page.getByLabel("API base")).toHaveValue(
+    await expect(editProvider.getByLabel("API base")).toHaveValue(
       "http://127.0.0.1:9/v2",
     )
-    await page.getByRole("button", { name: "Cancel" }).click()
+    await editProvider.getByRole("button", { name: "Cancel" }).click()
+    await expect(editProvider).toBeHidden()
 
     // The confirmation is a modal, so it names the provider rather than relying
     // on the row behind the backdrop to say which one this is about.

--- a/web/e2e/parity.tenancy.spec.ts
+++ b/web/e2e/parity.tenancy.spec.ts
@@ -186,8 +186,10 @@ test.describe("standalone tenancy", () => {
     await expect(created).toContainText("Created by the parity suite")
 
     await created.getByRole("button", { name: "Edit" }).click()
-    await page.getByLabel("Name").fill(RENAMED_WORKSPACE)
-    await page.getByRole("button", { name: "Save changes" }).click()
+    const editDialog = page.getByRole("dialog", { name: "Edit workspace" })
+    await editDialog.getByLabel("Name").fill(RENAMED_WORKSPACE)
+    await editDialog.getByRole("button", { name: "Save" }).click()
+    await expect(editDialog).toBeHidden()
 
     const renamed = workspaceRow(page, RENAMED_WORKSPACE)
     await expect(renamed).toBeVisible()

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -1070,7 +1070,7 @@ describe("KeysPage", () => {
     expect(screen.getByText(/starts unrestricted/)).toBeInTheDocument()
   })
 
-  it("opens the edit form from a key row's Edit action", async () => {
+  it("opens the edit form in a dialog, naming the key it is about", async () => {
     mockApi({ keys: [apiKey({ id: "key-1", key_name: "ci-bot" })] })
     const user = userEvent.setup()
     renderPage(<KeysPage />)
@@ -1078,10 +1078,30 @@ describe("KeysPage", () => {
     const row = (await screen.findByText("ci-bot")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Edit" }))
 
-    // The inline edit card appears (its Save button is unique to edit mode).
+    // A dialog rather than a band above the table: the row keeps its place, and
+    // the page under it does not shift by the height of a form (otari-ai#2125).
+    const dialog = await screen.findByRole("dialog", { name: "Edit key" })
+    expect(within(dialog).getByText("ci-bot")).toBeInTheDocument()
     expect(
-      await screen.findByRole("button", { name: "Save changes" }),
+      within(dialog).getByRole("button", { name: "Save" }),
     ).toBeInTheDocument()
+  })
+
+  it("asks before discarding an edited field", async () => {
+    mockApi({ keys: [apiKey({ id: "key-1", key_name: "ci-bot" })] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    const row = (await screen.findByText("ci-bot")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    await user.type(await screen.findByLabelText("Name"), "-2")
+    await user.keyboard("{Escape}")
+
+    // The guard, not the exit: an edit form seeds from the row, so dirty has to
+    // mean "differs from the key" rather than "is not empty".
+    expect(screen.getByRole("button", { name: "Keep editing" })).toBeVisible()
+    await user.click(screen.getByRole("button", { name: "Discard" }))
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
   })
 
   it("toggles exclude_from_budget on an existing key via PATCH", async () => {
@@ -1096,7 +1116,7 @@ describe("KeysPage", () => {
     const row = (await screen.findByText("ci-bot")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Edit" }))
     await user.click(await screen.findByLabelText("Exempt from budget"))
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = fetchMock.mock.calls.find(
       ([u, init]) =>
@@ -1118,7 +1138,7 @@ describe("KeysPage", () => {
     const row = (await screen.findByText("ci-bot")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Edit" }))
     await pickOption(user, "Mismatched user field", "Always accept")
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = fetchMock.mock.calls.find(
       ([u, init]) =>
@@ -1150,7 +1170,7 @@ describe("KeysPage", () => {
       "Mismatched user field",
       "Use the deployment setting (default)",
     )
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = fetchMock.mock.calls.find(
       ([u, init]) =>
@@ -1174,9 +1194,10 @@ describe("KeysPage", () => {
     const alphaRow = (await screen.findByText("alpha")).closest("tr")!
     await user.click(within(alphaRow).getByRole("button", { name: "Edit" }))
     expect(await screen.findByLabelText("Name")).toHaveValue("alpha")
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    // Switching to another key must remount the form; without a keyed remount it
-    // would keep "alpha" and PATCH the wrong key.
+    // The next key must open on its own values; a form that survived the first
+    // row would keep "alpha" and PATCH the wrong key.
     const bravoRow = screen.getByText("bravo").closest("tr")!
     await user.click(within(bravoRow).getByRole("button", { name: "Edit" }))
     expect(await screen.findByLabelText("Name")).toHaveValue("bravo")
@@ -1193,7 +1214,7 @@ describe("KeysPage", () => {
     await user.click(within(row).getByRole("button", { name: "Disable" }))
 
     expect(
-      screen.queryByRole("button", { name: "Save changes" }),
+      screen.queryByRole("button", { name: "Save" }),
     ).not.toBeInTheDocument()
   })
 
@@ -1368,7 +1389,7 @@ describe("KeysPage", () => {
         screen.queryByLabelText("Exempt from budget"),
       ).not.toBeInTheDocument()
 
-      await usr.click(screen.getByRole("button", { name: "Save changes" }))
+      await usr.click(screen.getByRole("button", { name: "Save" }))
 
       const patch = fetchMock.mock.calls.find(
         ([u, init]) =>

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -33,7 +33,6 @@ import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { useConfirmationFocus } from "@/design-system/hooks/useConfirmationFocus"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
-import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
 import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import {
@@ -765,6 +764,14 @@ function EditKeyForm({
     apiKey.reject_user_mismatch,
   )
   const [scopeValid, setScopeValid] = useState(true)
+  const { isDirty } = useDirtySnapshot({
+    keyName,
+    expiresAt,
+    allowedModels,
+    excludeFromBudget,
+    rejectUserMismatch,
+    scopeValid,
+  })
 
   const submit = () => {
     if (update.isPending || !scopeValid) return
@@ -782,30 +789,38 @@ function EditKeyForm({
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // `lg` as on the create form: the same key, the same frame.
+      size="lg"
+      title="Edit key"
+      description={<code>{apiKey.key_name ?? apiKey.id}</code>}
+      submitLabel="Save"
+      onSubmit={submit}
+      isPending={update.isPending}
+      isSubmitDisabled={!scopeValid}
+      isDirty={isDirty}
+      error={update.error}
     >
-      <h2 className="text-title">
-        Edit{" "}
-        <code className="text-mono-title">{apiKey.key_name ?? apiKey.id}</code>
-      </h2>
-      <ErrorBanner error={update.error} />
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Field
-          label="Name"
-          value={keyName}
-          onChange={setKeyName}
-          placeholder="ci-bot"
-        />
-        <Field
-          label="Expires"
-          value={expiresAt}
-          onChange={setExpiresAt}
-          type="datetime-local"
-          description="Blank clears the expiry."
-        />
-      </div>
+      <Field
+        label="Name"
+        value={keyName}
+        onChange={setKeyName}
+        placeholder="ci-bot"
+        autoFocus
+        reserveMessage={false}
+      />
+      <Field
+        label="Expires"
+        value={expiresAt}
+        onChange={setExpiresAt}
+        type="datetime-local"
+        description="Blank clears the expiry."
+        reserveMessage
+      />
       {isDeploymentWide && apiKey.user_id ? (
         <OwnerAccessNote userId={apiKey.user_id} users={users.data ?? []} />
       ) : null}
@@ -837,19 +852,7 @@ function EditKeyForm({
         value={rejectUserMismatch}
         onChange={setRejectUserMismatch}
       />
-      <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-        <Button
-          variant="primary"
-          isDisabled={update.isPending || !scopeValid}
-          onPress={submit}
-        >
-          {update.isPending ? "Saving…" : "Save changes"}
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -1341,9 +1344,9 @@ export function KeysPage() {
         memberLabels={memberLabels}
         returnFocusRef={createButtonRef}
       />
-      {/* Key on the row id so switching which key is edited remounts the form:
-          its fields seed from `apiKey` via useState (mount-only), so without this
-          a second Edit would keep the first key's values and PATCH the wrong row. */}
+      {/* Keyed on the row id: the fields seed from `apiKey` on mount only, so
+          the next Edit has to arrive at a fresh form rather than the last key's
+          values, which would PATCH the wrong row. */}
       {editingKey ? (
         <EditKeyForm
           key={editingKey.id}

--- a/web/src/features/organization/OrganizationMembersPage.test.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.test.tsx
@@ -674,6 +674,23 @@ describe("OrganizationMembersPage", () => {
     expect(patch?.body).toEqual({ blocked: true })
   })
 
+  it("opens the member editor in a dialog, naming the member", async () => {
+    mockApi({ members: [OWNER, ANALYST], workspaces: [workspace()] })
+    const actor = userEvent.setup()
+    renderPage(<OrganizationMembersPage />)
+
+    await screen.findByText("Analyst")
+    await actor.click(
+      within(rowFor("Analyst")).getByRole("button", { name: "Edit" }),
+    )
+
+    // A dialog rather than a band above the roster: the row keeps its place,
+    // and the page under it does not shift by the height of a form
+    // (otari-ai#2125).
+    const dialog = await screen.findByRole("dialog", { name: "Edit member" })
+    expect(within(dialog).getByText("Workspace access")).toBeInTheDocument()
+  })
+
   it("edits model access, workspace membership and the workspace budget in one save", async () => {
     // One control over three tables underneath, so this asserts all three
     // writes land from a single save, and that the ceiling is written against
@@ -722,7 +739,7 @@ describe("OrganizationMembersPage", () => {
     // Bravo. A budget is picked, never an amount: the figure is the budget's.
     await pickOption(actor, "Budget in Default Workspace", "Large")
     await actor.click(screen.getByLabelText("Bravo"))
-    await actor.click(screen.getByRole("button", { name: "Save changes" }))
+    await actor.click(screen.getByRole("button", { name: "Save" }))
 
     // All three writes land from the one save. Model access goes to the spend
     // row the membership is joined to, and it is the third table the editor
@@ -844,7 +861,7 @@ describe("OrganizationMembersPage for a tenant who does not operate the deployme
     expect(
       screen.queryByLabelText("Budget in Default Workspace"),
     ).not.toBeInTheDocument()
-    await actor.click(screen.getByRole("button", { name: "Save changes" }))
+    await actor.click(screen.getByRole("button", { name: "Save" }))
 
     await waitFor(() =>
       expect(

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -36,7 +36,6 @@ import { Select } from "@/design-system/forms/Select"
 import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { Dot } from "@/design-system/indicators/Dot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
-import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
 import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import {
@@ -595,6 +594,14 @@ function MemberEditor({
     })
 
   const canSave = !saving && scopeValid
+  // The workspace rows are a Map, which `JSON.stringify` flattens to `{}`, so
+  // the guard is handed their entries. Both halves seed on mount and neither
+  // changes on its own, so nothing here arms without a keystroke.
+  const { isDirty } = useDirtySnapshot({
+    rows: [...rows],
+    allowedModels,
+    scopeValid,
+  })
 
   const save = async () => {
     if (!canSave || !member.user_id) return
@@ -692,13 +699,22 @@ function MemberEditor({
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-5"
+    <FormDialog
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // `lg`: the workspace access table is three columns wide.
+      size="lg"
+      title="Edit member"
+      description={memberLabel(member)}
+      submitLabel="Save"
+      onSubmit={() => void save()}
+      isPending={saving}
+      isSubmitDisabled={!scopeValid}
+      isDirty={isDirty}
+      error={error}
     >
-      <div className="text-title">Edit {memberLabel(member)}</div>
-      <ErrorBanner error={error} />
-
       {/* Withheld entirely from a caller who does not operate the deployment.
           `spendRow` comes from `useUsers(operates)`, so for them it is always
           undefined and the fallback below would report "no spend row yet" for a
@@ -724,7 +740,7 @@ function MemberEditor({
 
       <div className="flex flex-col gap-2">
         <span className="text-body">Workspace access</span>
-        <div className="max-w-3xl overflow-x-auto">
+        <div className="overflow-x-auto">
           <table className="w-full min-w-lg text-sm">
             <thead>
               <tr className="text-left text-xs text-muted">
@@ -796,7 +812,7 @@ function MemberEditor({
         {/* Gated with the Budget column it explains: "pick a different budget
             here" names a control this caller is not offered. */}
         {operates ? (
-          <span className="max-w-2xl text-xs text-muted">
+          <span className="text-xs text-muted">
             Each workspace holds its own allowance, so someone in two workspaces
             has two. The amount and the reset period belong to the budget, so
             editing one moves everyone held to it; pick a different budget here
@@ -806,16 +822,7 @@ function MemberEditor({
           </span>
         ) : null}
       </div>
-
-      <div className="flex gap-2">
-        <Button variant="primary" isDisabled={!canSave} onPress={save}>
-          {saving ? "Saving…" : "Save changes"}
-        </Button>
-        <Button variant="ghost" isDisabled={saving} onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -1284,8 +1291,8 @@ export function OrganizationMembersPage() {
         onClose={() => setInviting(false)}
       />
 
-      {/* Keyed on the row so switching which member is edited remounts the
-          form: its fields seed from the member on mount only. */}
+      {/* Keyed on the row: its fields seed from the member on mount only, so
+          the next Edit has to arrive at a fresh form. */}
       {editingRow ? (
         <MemberEditor
           key={memberRowKey(editingRow)}

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -529,7 +529,7 @@ describe("ProvidersPage", () => {
       screen.queryByRole("textbox", { name: /AWS region/ }),
     ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = await waitFor(() => {
       const call = fetchMock.mock.calls.find(
@@ -1369,6 +1369,20 @@ describe("ProvidersPage", () => {
     )
   })
 
+  it("opens the edit form in a dialog, naming the instance", async () => {
+    mockApi({ stored: [storedProvider("homelab", "1234", true)] })
+    const user = userEvent.setup()
+    renderPage(<ProvidersPage />)
+
+    await screen.findByText("••••1234")
+    await user.click(screen.getByRole("button", { name: "Edit" }))
+
+    // A dialog rather than a band above the table: the row keeps its place, and
+    // the page under it does not shift by the height of a form (otari-ai#2125).
+    const dialog = await screen.findByRole("dialog", { name: "Edit provider" })
+    expect(within(dialog).getByText("homelab")).toBeInTheDocument()
+  })
+
   it("prefills stored client options on edit and clears them when emptied", async () => {
     const fetchMock = mockApi({
       stored: [storedProvider("homelab", "1234", true, { timeout: 1800 })],
@@ -1384,7 +1398,7 @@ describe("ProvidersPage", () => {
     // Emptying the field clears the stored options: an explicit null, not an
     // omission, which the API would read as "leave them alone".
     await user.clear(clientArgs)
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = await waitFor(() => {
       const call = fetchMock.mock.calls.find(
@@ -1408,7 +1422,7 @@ describe("ProvidersPage", () => {
     await user.type(screen.getByLabelText("Client options (JSON)"), "oops")
 
     expect(await screen.findByText("Not valid JSON.")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled()
     expect(
       fetchMock.mock.calls.some(([, init]) => (init?.method ?? "") === "PATCH"),
     ).toBe(false)
@@ -1442,7 +1456,7 @@ describe("ProvidersPage", () => {
       screen.getByLabelText("API base"),
       "https://api.otari.ai/v1",
     )
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     await waitFor(() =>
       expect(
@@ -1482,7 +1496,7 @@ describe("ProvidersPage", () => {
       screen.getByLabelText("API base"),
       "https://api.otari.ai/v1",
     )
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
     await waitFor(() =>
       expect(screen.queryByText("Testing…")).not.toBeInTheDocument(),
     )
@@ -1642,7 +1656,7 @@ describe("ProvidersPage", () => {
       screen.getByLabelText("API base"),
       "https://api.otari.ai/v1",
     )
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
     await waitFor(() =>
       expect(screen.queryByText("Testing…")).not.toBeInTheDocument(),
     )

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -577,14 +577,21 @@ function EditProviderForm({
     credentials,
     stored.redacted,
   )
+  // `replacingKey` is in the snapshot with the secret it reveals: arming the
+  // replacement and then closing without typing one loses nothing, but a typed
+  // key is work, and the flag is what says the field was ever on screen.
+  const { isDirty } = useDirtySnapshot({
+    providerType,
+    apiBase,
+    replacingKey,
+    apiKey,
+    clientArgsText,
+    credentials,
+  })
+  const blocked = !clientArgs.ok || Object.keys(credentialErrors).length > 0
 
   const submit = () => {
-    if (
-      update.isPending ||
-      !clientArgs.ok ||
-      Object.keys(credentialErrors).length > 0
-    )
-      return
+    if (update.isPending || blocked) return
     const body: UpdateStoredProviderRequest = {
       provider_type: providerType.trim() || null,
       api_base: apiBase.trim() || null,
@@ -612,26 +619,38 @@ function EditProviderForm({
   }
 
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // `lg` as on the add form: the same five fields, plus whatever typed
+      // credentials this provider declares.
+      size="lg"
+      title="Edit provider"
+      description={<code>{provider.instance}</code>}
+      submitLabel="Save"
+      onSubmit={submit}
+      isPending={update.isPending}
+      isSubmitDisabled={blocked}
+      isDirty={isDirty}
+      error={update.error}
     >
-      <div className="text-title">
-        Edit <code>{provider.instance}</code>
-      </div>
-      <ErrorBanner error={update.error} />
       <div className="grid gap-4 sm:grid-cols-2">
         <Field
           label="Provider type"
           value={providerType}
           onChange={setProviderType}
           placeholder="openai"
+          autoFocus
+          reserveMessage={false}
         />
         <Field
           label="API base"
           value={apiBase}
           onChange={setApiBase}
           placeholder="https://api.openai.com/v1"
+          reserveMessage={false}
         />
       </div>
       <div className="flex flex-col gap-2">
@@ -684,23 +703,7 @@ function EditProviderForm({
         onChange={setClientArgsText}
         error={clientArgs.ok ? null : clientArgs.error}
       />
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={
-            update.isPending ||
-            !clientArgs.ok ||
-            Object.keys(credentialErrors).length > 0
-          }
-          onPress={submit}
-        >
-          {update.isPending ? "Saving…" : "Save changes"}
-        </Button>
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -1318,9 +1321,9 @@ export function ProvidersPage() {
       />
       {editingProvider ? (
         <EditProviderForm
-          // Remount when the operator switches rows: the fields are seeded from
-          // the provider once, so without this, editing a second provider would
-          // open with the first one's values (and save them onto it).
+          // The fields are seeded from the provider once, so the next Edit has
+          // to arrive at a fresh form rather than the last provider's values,
+          // which a save would then write onto this one.
           key={editingProvider.instance}
           provider={editingProvider}
           onClose={() => setEditing(null)}

--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -367,6 +367,19 @@ describe("WorkspacesPage", () => {
     expect(screen.getAllByRole("button", { name: "Delete" })[0]).toBeDisabled()
   })
 
+  it("opens the edit form in a dialog, naming the workspace", async () => {
+    mockApi({})
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+
+    // A dialog rather than a band above the table: the row keeps its place, and
+    // the page under it does not shift by the height of a form (otari-ai#2125).
+    const dialog = await screen.findByRole("dialog", { name: "Edit workspace" })
+    expect(within(dialog).getByText("Default Workspace")).toBeInTheDocument()
+  })
+
   it("renames a workspace through the update endpoint", async () => {
     const requests = mockApi({})
     const user = userEvent.setup()
@@ -376,7 +389,7 @@ describe("WorkspacesPage", () => {
     const name = screen.getByLabelText("Name")
     await user.clear(name)
     await user.type(name, "Renamed")
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = requests.find((request) => request.method === "PATCH")
     expect(patch?.url).toContain(
@@ -550,7 +563,7 @@ describe("WorkspacesPage", () => {
     // default: no delete for a "none" the caller never picked.
     await user.clear(name)
     await user.type(name, "Renamed")
-    await user.click(screen.getByRole("button", { name: "Save changes" }))
+    await user.click(screen.getByRole("button", { name: "Save" }))
 
     const patch = requests.find((request) => request.method === "PATCH")
     expect(patch?.body).toEqual({ name: "Renamed", description: null })

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -15,7 +15,6 @@ import { Field } from "@/design-system/forms/Field"
 import { Select } from "@/design-system/forms/Select"
 import { useDirtySnapshot } from "@/design-system/forms/useDirtySnapshot"
 import { PageIntro } from "@/design-system/layout/PageIntro"
-import { Section } from "@/design-system/layout/Section"
 import { TableScrollFrame } from "@/design-system/layout/TableScrollFrame"
 import { FilterSelect } from "@/design-system/navigation/FilterSelect"
 import { canManage, isDeploymentOperator } from "@/features/organization/roles"
@@ -537,6 +536,12 @@ function EditWorkspaceForm({
     createDefault.isPending ||
     updateDefault.isPending ||
     deleteDefault.isPending
+  // `budgetId` rather than `selectedBudget`: null is "the picker was never
+  // touched", so a default that resolves after mount is part of the seed rather
+  // than a change the guard should arm on. The per-provider defaults and the
+  // provider keys below write as they are changed rather than on save, so
+  // nothing they hold is unsaved work.
+  const { isDirty } = useDirtySnapshot({ name, description, budgetId })
 
   // Three outcomes rather than one call: the default is its own row, so moving
   // between "none" and a budget is a create or a delete, not a field write.
@@ -571,27 +576,58 @@ function EditWorkspaceForm({
   }
 
   const trimmed = name.trim()
+  const save = () => {
+    if (update.isPending || savingDefault || trimmed === "") return
+    update.mutate(
+      {
+        id: workspace.id,
+        body: { name: trimmed, description: description.trim() || null },
+      },
+      {
+        onSuccess: async () => {
+          await saveDefault()
+          onClose()
+        },
+      },
+    )
+  }
+
   return (
-    <Section
-      className="border-y border-border py-5"
-      contentClassName="flex flex-col gap-4"
+    <FormDialog
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+      // `lg`: the two fields are joined by the default-budget controls and the
+      // workspace's provider keys, which is well past what `md` holds.
+      size="lg"
+      title="Edit workspace"
+      description={<code>{workspace.name}</code>}
+      submitLabel="Save"
+      onSubmit={save}
+      isPending={update.isPending || savingDefault}
+      isSubmitDisabled={trimmed === ""}
+      isDirty={isDirty}
+      error={
+        update.error ??
+        createDefault.error ??
+        updateDefault.error ??
+        deleteDefault.error
+      }
     >
-      <h2 className="text-title">
-        Edit <code>{workspace.name}</code>
-      </h2>
-      <ErrorBanner
-        error={
-          update.error ??
-          createDefault.error ??
-          updateDefault.error ??
-          deleteDefault.error
-        }
+      <Field
+        label="Name"
+        value={name}
+        onChange={setName}
+        isRequired
+        autoFocus
+        reserveMessage={false}
       />
-      <Field label="Name" value={name} onChange={setName} isRequired />
       <Field
         label="Description"
         value={description}
         onChange={setDescription}
+        reserveMessage={false}
       />
       {/* Withheld from a caller who does not operate the deployment: the
           picker's options come from the operator-gated `/budgets` read, so
@@ -629,36 +665,7 @@ function EditWorkspaceForm({
           to its organization arm because the key names come from the
           organization-gated list. */}
       <WorkspaceProviderKeys workspaceId={workspace.id} />
-      <div className="flex gap-2">
-        <Button
-          variant="primary"
-          isDisabled={trimmed === ""}
-          isPending={update.isPending || savingDefault}
-          onPress={() =>
-            update.mutate(
-              {
-                id: workspace.id,
-                body: {
-                  name: trimmed,
-                  description: description.trim() || null,
-                },
-              },
-              {
-                onSuccess: async () => {
-                  await saveDefault()
-                  onClose()
-                },
-              },
-            )
-          }
-        >
-          Save changes
-        </Button>
-        <Button variant="ghost" onPress={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Section>
+    </FormDialog>
   )
 }
 
@@ -864,8 +871,8 @@ export function WorkspacesPage() {
         returnFocusRef={createButtonRef}
       />
 
-      {/* Keyed on the workspace so switching which one is edited remounts the
-          form: its fields seed from `workspace` on mount only. */}
+      {/* Keyed on the workspace: its fields seed from `workspace` on mount
+          only, so the next Edit has to arrive at a fresh form. */}
       {editingWorkspace ? (
         <EditWorkspaceForm
           key={editingWorkspace.id}


### PR DESCRIPTION
## Description

Four places in the dashboard opened their edit form as a band wedged between the page
heading and the table it belonged to: API keys, Workspaces, Members and roles, and
Providers. Pressing Edit on a row pushed the whole table down by the height of the form,
so the row you just pressed left the spot your pointer was on, and on a long form the row
went off screen entirely. Pressing Edit on a second row while one was open swapped the
band's contents underneath you with nothing to say it had happened.

Every create in the product already opens in a modal, and so does every other edit
(budgets, organization provider keys, routing policies, rate overrides, MCP servers), so
these four were the last of the older shape. They now open in the same modal as everything
else: titled for the thing being edited, with the object's own name under the title, and a
Save button in a footer that stays put. The page behind it does not move.

The shared frame also brings three things these forms did not have: a failed save reported
at the top of the form rather than on the page behind it, a prompt before Escape throws away
an edit you have typed, and a Save button that stays lit while it works instead of dimming
as though it had been refused.

The Models page is deliberately left alone. Its price editor sits inside a row's detail
panel, which is a read surface with an editor in it rather than an Edit action on a row, and
the models table's own price action already opens a dialog.

## How to test it locally

- `pnpm --dir web run build`, then run a gateway and open the dashboard.
- On **API keys**, press Edit on a row. The form opens over the page, the table does not
  move, and the title reads "Edit key" with the key's name under it. Change the name, press
  Escape: it asks before discarding. Press Save: it closes and the row updates.
- Repeat on **Workspaces**, **Organization → Members & roles**, and **Providers**. Each
  opens the same frame, and Save closes it.
- On **Workspaces**, open Edit on a workspace that has a per-provider default and press
  Remove on one. The removal confirm stacks over the edit form and still works.
- Check a phone width (390px): each form fills the screen as a sheet.

Automated checks that already cover it: `pnpm --dir web test` (5692 passing, including a
new test per page asserting the edit form opens as a dialog named for the object, and one
on API keys asserting the unsaved-changes guard), `pnpm --dir web run lint`, and
`pnpm --dir web run typecheck`. The two Playwright parity flows that edit a provider and
rename a workspace are updated to drive the dialog; those run in CI, not locally here,
because another gateway held port 8000 on this machine.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#2125

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on three of those. The change is dashboard-only, so the checks that matter are the
dashboard's (`pnpm --dir web run lint`, `run typecheck`, `test`); `make lint` was run too
and is green. No documentation needed updating: `web/design/feedback.md` and
`web/design/overlays.md` already say that every create and every edit opens in
`FormDialog` and not in a panel under the table, so this makes the code match what was
already written. The API contract did not change, so nothing was regenerated.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The agent read the issue's three screenshots, found the four remaining inline edit forms by
grepping for the pattern rather than only the pages pictured (Providers was not in the
issue and is the fourth), checked each conversion against the existing edit dialogs in the
tree for title, description and submit-label wording, and updated the component tests and
the two Playwright flows that drove the old buttons.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
